### PR TITLE
fix(bpmn-properties-panel): show labels for processes

### DIFF
--- a/src/bpmn-properties-panel/PanelHeaderProvider.js
+++ b/src/bpmn-properties-panel/PanelHeaderProvider.js
@@ -61,6 +61,10 @@ export function getConcreteType(element) {
 export const PanelHeaderProvider = {
 
   getElementLabel: (element) => {
+    if (is(element, 'bpmn:Process')) {
+      return getBusinessObject(element).name;
+    }
+
     return getLabel(element);
   },
 

--- a/test/spec/bpmn-properties-panel/PanelHeaderProvider.spec.js
+++ b/test/spec/bpmn-properties-panel/PanelHeaderProvider.spec.js
@@ -160,6 +160,21 @@ describe('<PanelHeaderProvider>', function() {
       expect(elementLabel).to.equal('foo');
     });
 
+
+    it('should get label - processes', function() {
+
+      // given
+      const element = createElement('bpmn:Process', {
+        name: 'foo'
+      });
+
+      // when
+      const elementLabel = PanelHeaderProvider.getElementLabel(element);
+
+      // then
+      expect(elementLabel).to.equal('foo');
+    });
+
   });
 
 


### PR DESCRIPTION
This ensures we also display the header label for processes. We can't only rely on the `LabelUtil` for this.

![image](https://user-images.githubusercontent.com/9433996/118783875-c6330a80-b88f-11eb-9bfd-8c9d9c3d7650.png)

