### PR TITLE
test: remove unnecessary test helper

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -1,11 +1,8 @@
 import {
-  attr as domAttr
-} from 'min-dom';
-
-import {
   act,
   fireEvent
 } from '@testing-library/preact';
+
 import TestContainer from 'mocha-test-container-support';
 
 import {
@@ -44,6 +41,10 @@ export function changeInput(input, value) {
   fireEvent.input(input, { target: { value } });
 }
 
+export function clickInput(input) {
+  fireEvent.click(input);
+}
+
 export function insertCoreStyles() {
   insertCSS(
     'properties-panel.css',
@@ -70,94 +71,4 @@ export function insertBpmnStyles() {
 
 export function bootstrapModeler(diagram, options, locals) {
   return bootstrapBpmnJS(Modeler, diagram, options, locals);
-}
-
-/**
- * Triggers a change event
- *
- * @param element on which the change should be triggered
- * @param eventType type of the event (e.g. click, change, ...)
- */
-export function triggerEvent(element, eventType) {
-
-  let evt;
-
-  eventType = eventType || 'change';
-
-  if (document.createEvent) {
-    try {
-
-      // Chrome, Safari, Firefox
-      evt = new MouseEvent((eventType), {
-        view: window,
-        bubbles: true,
-        cancelable: true
-      });
-    } catch (e) {
-
-      // IE 11, PhantomJS (wat!)
-      evt = document.createEvent('MouseEvent');
-
-      evt.initEvent((eventType), true, true);
-    }
-    return element.dispatchEvent(evt);
-  } else {
-
-    // Welcome IE
-    evt = document.createEventObject();
-
-    return element.fireEvent('on' + eventType, evt);
-  }
-}
-
-/**
- * Set the new value to the given element.
- *
- * @param element on which the change should be triggered
- * @param value new value for the element
- * @param eventType (optional) type of the event (e.g. click, change, ...)
- * @param cursorPosition (optional) position ot the cursor after changing
- *                                  the value
- */
-export function triggerValue(element, value, eventType, cursorPosition) {
-  if (typeof eventType == 'number') {
-    cursorPosition = eventType;
-    eventType = null;
-  }
-
-  element.focus();
-
-  if (domAttr(element, 'contenteditable')) {
-    element.innerText = value;
-  } else {
-    element.value = value;
-  }
-
-  if (cursorPosition) {
-    element.selectionStart = cursorPosition;
-    element.selectionEnd = cursorPosition;
-  }
-
-  triggerEvent(element, eventType);
-}
-
-export function triggerInput(element, value) {
-  element.value = value;
-
-  triggerEvent(element, 'input');
-
-  element.focus();
-}
-
-export function triggerKeyEvent(element, event, code) {
-  let e = document.createEvent('Events');
-
-  if (e.initEvent) {
-    e.initEvent(event, true, true);
-  }
-
-  e.keyCode = code;
-  e.which = code;
-
-  element.dispatchEvent(e);
 }

--- a/test/spec/bpmn-properties-panel/provider/bpmn/Executable.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/Executable.spec.js
@@ -5,7 +5,7 @@ import {
   inject,
   insertCoreStyles,
   insertBpmnStyles,
-  triggerEvent
+  clickInput
 } from 'test/TestHelper';
 
 import {
@@ -73,7 +73,7 @@ describe('provider/bpmn - Executable', function() {
     const isExecutableNode = domQuery('input[name=isExecutable]', container);
 
     // when
-    triggerEvent(isExecutableNode, 'click');
+    clickInput(isExecutableNode);
 
     // then
     expect(getBusinessObject(shape).get('isExecutable')).to.equal(true);
@@ -89,7 +89,7 @@ describe('provider/bpmn - Executable', function() {
 
     const isExecutableNode = domQuery('input[name=isExecutable]', container);
 
-    triggerEvent(isExecutableNode, 'click');
+    clickInput(isExecutableNode);
 
     // when
     commandStack.undo();
@@ -108,7 +108,7 @@ describe('provider/bpmn - Executable', function() {
 
     const isExecutableNode = domQuery('input[name=isExecutable]', container);
 
-    triggerEvent(isExecutableNode, 'click');
+    clickInput(isExecutableNode);
 
     // when
     commandStack.undo();

--- a/test/spec/properties-panel/components/Checkbox.spec.js
+++ b/test/spec/properties-panel/components/Checkbox.spec.js
@@ -10,7 +10,7 @@ import {
 
 import {
   insertCoreStyles,
-  triggerEvent
+  clickInput
 } from 'test/TestHelper';
 
 import Checkbox from 'src/properties-panel/components/entries/Checkbox';
@@ -49,7 +49,7 @@ describe('<Checkbox>', function() {
     const input = domQuery('.bio-properties-panel-input', result.container);
 
     // when
-    triggerEvent(input, 'click');
+    clickInput(input);
 
     // then
     expect(updateSpy).to.have.been.calledWith(true);

--- a/test/spec/properties-panel/components/TextField.spec.js
+++ b/test/spec/properties-panel/components/TextField.spec.js
@@ -10,7 +10,7 @@ import {
 
 import {
   insertCoreStyles,
-  triggerInput
+  changeInput
 } from 'test/TestHelper';
 
 import TextField from 'src/properties-panel/components/entries/TextField';
@@ -49,7 +49,7 @@ describe('<TextField>', function() {
     const input = domQuery('.bio-properties-panel-input', result.container);
 
     // when
-    triggerInput(input, 'foo');
+    changeInput(input, 'foo');
 
     // then
     expect(updateSpy).to.have.been.calledWith('foo');


### PR DESCRIPTION
I believe we don't need the old test helpers now as we use preact-specific `fireEvent` for it.
