### PR TITLE
test(bpmn-provider): add test cases for input + output parameter

### DIFF
--- a/test/spec/bpmn-properties-panel/provider/zeebe/Input.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/Input.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
+          <zeebe:input source="= inputSourceValue2" target="inputTargetValue2" />
+          <zeebe:input source="= inputSourceValue3" target="inputTargetValue3" />
+          <zeebe:input source="= inputSourceValue4" target="inputTargetValue4" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:receiveTask id="ReceiveTask_1" />
+    <bpmn:serviceTask id="ServiceTask_empty" name="empty" />
+    <bpmn:serviceTask id="ServiceTask_2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
+      <bpmn:extensionElements />
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReceiveTask_0mkif7n_di" bpmnElement="ReceiveTask_1">
+        <dc:Bounds x="320" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v1cphs_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="190" y="370" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dticgb_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="420" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08s4ehk_di" bpmnElement="ServiceTask_noIoMapping">
+        <dc:Bounds x="420" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/zeebe/Input.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/Input.spec.js
@@ -1,0 +1,270 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
+
+import ZeebePropertiesProvider from 'src/bpmn-properties-panel/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  getInputParameters,
+  getIoMapping
+} from 'src/bpmn-properties-panel/provider/zeebe/utils/InputOutputUtil';
+
+import diagramXML from './Input.bpmn';
+
+
+describe('provider/zeebe - Input', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:ServiceTask#input', function() {
+
+    it('should NOT display for receive task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+
+      // then
+      expect(inputGroup).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+      const inputListItems = getInputListItems(inputGroup);
+
+      // then
+      expect(inputGroup).to.exist;
+      expect(inputListItems.length).to.equal(getInputParameters(serviceTask).length);
+    }));
+
+
+    it('should add new input', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const inputGroup = getGroup(container, 'inputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+      // when
+      await act(() => {
+        addEntry.parentNode.click();
+      });
+
+      // then
+      expect(getInputParameters(serviceTask)).to.have.length(5);
+    }));
+
+
+    it('should create non existing extension elements',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // assume
+        expect(getBusinessObject(serviceTask).get('extensionElements')).not.to.exist;
+
+        const inputGroup = getGroup(container, 'inputs');
+        const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+        // when
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // then
+        expect(getBusinessObject(serviceTask).get('extensionElements')).to.exist;
+      })
+    );
+
+
+    it('should create non existing ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noIoMapping');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // assume
+        expect(getIoMapping(serviceTask)).not.to.exist;
+
+        const inputGroup = getGroup(container, 'inputs');
+        const addEntry = domQuery('.bio-properties-panel-add-entry', inputGroup);
+
+        // when
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // then
+        expect(getIoMapping(serviceTask)).to.exist;
+      })
+    );
+
+
+    it('should delete input', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const inputListItems = getInputListItems(getGroup(container, 'inputs'));
+      const removeEntry = domQuery('.bio-properties-panel-remove-entry', inputListItems[0]);
+
+      // when
+      await act(() => {
+        removeEntry.parentNode.click();
+      });
+
+      // then
+      expect(getInputParameters(serviceTask)).to.have.length(3);
+    }));
+
+
+    it('should remove ioMapping on last delete', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_2');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // assume
+      expect(getIoMapping(serviceTask)).to.exist;
+
+      const inputListItems = getInputListItems(getGroup(container, 'inputs'));
+      const removeEntry = domQuery('.bio-properties-panel-remove-entry', inputListItems[0]);
+
+      // when
+      await act(() => {
+        removeEntry.parentNode.click();
+      });
+
+      // then
+      expect(getIoMapping(serviceTask)).not.to.exist;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalInputs = getInputParameters(serviceTask);
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        const addEntry = domQuery('.bio-properties-panel-add-entry', container);
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        const inputListItems = getInputListItems(getGroup(container, 'inputs'));
+
+        // then
+        expect(inputListItems.length).to.equal(originalInputs.length);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getListItems(container, type) {
+  return domQueryAll(`div[data-entry-id^="${type}-"].bio-properties-panel-collapsible-entry`, container);
+}
+
+function getInputListItems(container) {
+  return getListItems(container, 'input');
+}

--- a/test/spec/bpmn-properties-panel/provider/zeebe/InputOutputParameter.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/InputOutputParameter.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= inputSourceValue1" target="inputTargetValue1" />
+          <zeebe:input source="= inputSourceValue2" target="inputTargetValue2" />
+          <zeebe:output source="= outputSourceValue1" target="outputTargetValue1" />
+          <zeebe:output source="= outputSourceValue2" target="outputTargetValue2" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_empty" name="empty" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11ypzmy_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="320" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/zeebe/InputOutputParameter.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/InputOutputParameter.spec.js
@@ -1,0 +1,411 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
+
+import BpmnPropertiesProvider from 'src/bpmn-properties-panel/provider/bpmn';
+
+import ZeebePropertiesProvider from 'src/bpmn-properties-panel/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  getInputParameters,
+  getOutputParameters
+} from 'src/bpmn-properties-panel/provider/zeebe/utils/InputOutputUtil';
+
+import diagramXML from './InputOutputParameter.bpmn';
+
+
+describe('provider/bpmn - InputOutputParameter', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:ServiceTask#input.target', function() {
+
+    it('should NOT display for empty ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const inputGroup = getGroup(container, 'inputs');
+        const targetInput = domQuery('input[name=input-0-target]', inputGroup);
+
+        // then
+        expect(targetInput).to.not.exist;
+      })
+    );
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+      const targetInput = domQuery('input[name=input-0-target]', inputGroup);
+
+      // then
+      expect(targetInput.value).to.eql(getInput(serviceTask, 0).get('target'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+      const targetInput = domQuery('input[name=input-0-target]', inputGroup);
+      changeInput(targetInput, 'newValue');
+
+      // then
+      expect(getInput(serviceTask, 0).get('target')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalValue = getInput(serviceTask, 0).get('target');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+        const targetInput = domQuery('input[name=input-0-target]', container);
+        changeInput(targetInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(targetInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:ServiceTask#input.source', function() {
+
+    it('should NOT display for empty ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const inputGroup = getGroup(container, 'inputs');
+        const sourceInput = domQuery('input[name=input-0-source]', inputGroup);
+
+        // then
+        expect(sourceInput).to.not.exist;
+      })
+    );
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+      const sourceInput = domQuery('input[name=input-0-source]', inputGroup);
+
+      // then
+      expect(sourceInput.value).to.eql(getInput(serviceTask, 0).get('source'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const inputGroup = getGroup(container, 'inputs');
+      const sourceInput = domQuery('input[name=input-0-source]', inputGroup);
+      changeInput(sourceInput, 'newValue');
+
+      // then
+      expect(getInput(serviceTask, 0).get('source')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalValue = getInput(serviceTask, 0).get('source');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+        const sourceInput = domQuery('input[name=input-0-source]', container);
+        changeInput(sourceInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(sourceInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:ServiceTask#output.target', function() {
+
+    it('should NOT display for empty ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const outputGroup = getGroup(container, 'outputs');
+        const targetInput = domQuery('input[name=output-0-target]', outputGroup);
+
+        // then
+        expect(targetInput).to.not.exist;
+      })
+    );
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+      const targetInput = domQuery('input[name=output-0-target]', outputGroup);
+
+      // then
+      expect(targetInput.value).to.eql(getOutput(serviceTask, 0).get('target'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+      const targetInput = domQuery('input[name=output-0-target]', outputGroup);
+      changeInput(targetInput, 'newValue');
+
+      // then
+      expect(getOutput(serviceTask, 0).get('target')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalValue = getOutput(serviceTask, 0).get('target');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+        const targetInput = domQuery('input[name=output-0-target]', container);
+        changeInput(targetInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(targetInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:ServiceTask#output.source', function() {
+
+    it('should NOT display for empty ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // when
+        const outputGroup = getGroup(container, 'outputs');
+        const sourceInput = domQuery('input[name=output-0-source]', outputGroup);
+
+        // then
+        expect(sourceInput).to.not.exist;
+      })
+    );
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+      const sourceInput = domQuery('input[name=output-0-source]', outputGroup);
+
+      // then
+      expect(sourceInput.value).to.eql(getOutput(serviceTask, 0).get('source'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+      const sourceInput = domQuery('input[name=output-0-source]', outputGroup);
+      changeInput(sourceInput, 'newValue');
+
+      // then
+      expect(getOutput(serviceTask, 0).get('source')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalValue = getOutput(serviceTask, 0).get('source');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+        const sourceInput = domQuery('input[name=output-0-source]', container);
+        changeInput(sourceInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(sourceInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getInput(element, idx) {
+  return (getInputParameters(element) || [])[idx];
+}
+
+function getOutput(element, idx) {
+  return (getOutputParameters(element) || [])[idx];
+}
+

--- a/test/spec/bpmn-properties-panel/provider/zeebe/Output.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/Output.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1md541i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= outputSourceValue1" target="outputTargetValue1" />
+          <zeebe:output source="= outputSourceValue2" target="outputTargetValue2" />
+          <zeebe:output source="= outputSourceValue3" target="outputTargetValue3" />
+          <zeebe:output source="= outputSourceValue4" target="outputTargetValue4" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="Task_1" />
+    <bpmn:serviceTask id="ServiceTask_empty" name="empty" />
+    <bpmn:serviceTask id="ServiceTask_2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= outputSourceValue1" target="outputTargetValue1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_noIoMapping" name="no IoMapping">
+      <bpmn:extensionElements />
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_0rud1s3_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tyoei0_di" bpmnElement="Task_1">
+        <dc:Bounds x="340" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ckisu_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="200" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jxbsb5_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="440" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18i7pky_di" bpmnElement="ServiceTask_noIoMapping">
+        <dc:Bounds x="370" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/zeebe/Output.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/zeebe/Output.spec.js
@@ -1,0 +1,270 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
+
+import ZeebePropertiesProvider from 'src/bpmn-properties-panel/provider/zeebe';
+
+import zeebeModdleExtensions from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  getOutputParameters,
+  getIoMapping
+} from 'src/bpmn-properties-panel/provider/zeebe/utils/InputOutputUtil';
+
+import diagramXML from './Output.bpmn';
+
+
+describe('provider/zeebe - Output', function() {
+
+  const testModules = [
+    CoreModule, SelectionModule, ModelingModule,
+    BpmnPropertiesPanel,
+    ZeebePropertiesProvider
+  ];
+
+  const moddleExtensions = {
+    zeebe: zeebeModdleExtensions
+  };
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    moddleExtensions,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:ServiceTask#output', function() {
+
+    it('should NOT display for simple task', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      await act(() => {
+        selection.select(task);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+
+      // then
+      expect(outputGroup).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const outputGroup = getGroup(container, 'outputs');
+      const outputListItems = getOutputListItems(outputGroup);
+
+      // then
+      expect(outputGroup).to.exist;
+      expect(outputListItems.length).to.equal(getOutputParameters(serviceTask).length);
+    }));
+
+
+    it('should add new output', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const outputGroup = getGroup(container, 'outputs');
+      const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+      // when
+      await act(() => {
+        addEntry.parentNode.click();
+      });
+
+      // then
+      expect(getOutputParameters(serviceTask)).to.have.length(5);
+    }));
+
+
+    it('should create non existing extension elements',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_empty');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // assume
+        expect(getBusinessObject(serviceTask).get('extensionElements')).not.to.exist;
+
+        const outputGroup = getGroup(container, 'outputs');
+        const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+        // when
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // then
+        expect(getBusinessObject(serviceTask).get('extensionElements')).to.exist;
+      })
+    );
+
+
+    it('should create non existing ioMapping',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_noIoMapping');
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        // assume
+        expect(getIoMapping(serviceTask)).not.to.exist;
+
+        const outputGroup = getGroup(container, 'outputs');
+        const addEntry = domQuery('.bio-properties-panel-add-entry', outputGroup);
+
+        // when
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // then
+        expect(getIoMapping(serviceTask)).to.exist;
+      })
+    );
+
+
+    it('should delete output', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      const outputListItems = getOutputListItems(getGroup(container, 'outputs'));
+      const removeEntry = domQuery('.bio-properties-panel-remove-entry', outputListItems[0]);
+
+      // when
+      await act(() => {
+        removeEntry.parentNode.click();
+      });
+
+      // then
+      expect(getOutputParameters(serviceTask)).to.have.length(3);
+    }));
+
+
+    it('should remove ioMapping on last delete', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_2');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // assume
+      expect(getIoMapping(serviceTask)).to.exist;
+
+      const outputListItems = getOutputListItems(getGroup(container, 'outputs'));
+      const removeEntry = domQuery('.bio-properties-panel-remove-entry', outputListItems[0]);
+
+      // when
+      await act(() => {
+        removeEntry.parentNode.click();
+      });
+
+      // then
+      expect(getIoMapping(serviceTask)).not.to.exist;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+        const originalOutputs = getOutputParameters(serviceTask);
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        const addEntry = domQuery('.bio-properties-panel-add-entry', container);
+        await act(() => {
+          addEntry.parentNode.click();
+        });
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        const outputListItems = getOutputListItems(getGroup(container, 'outputs'));
+
+        // then
+        expect(outputListItems.length).to.equal(originalOutputs.length);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getGroup(container, id) {
+  return domQuery(`[data-group-id="group-${id}"`, container);
+}
+
+function getListItems(container, type) {
+  return domQueryAll(`div[data-entry-id^="${type}-"].bio-properties-panel-collapsible-entry`, container);
+}
+
+function getOutputListItems(container) {
+  return getListItems(container, 'output');
+}


### PR DESCRIPTION
Related to #9

Adds missing test coverage for the input + output parameters, that were introduced with basic lists support (cf. #19).
