### PR TITLE
Non editable list groups

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -39,7 +39,8 @@ const DEFAULT_LAYOUT = {
  *    component: import('preact').Component,
  *    id: String,
  *    items: Array<ListItemDefinition>,
- *    label: String
+ *    label: String,
+ *    shouldSort?: Boolean
  * } } ListGroupDefinition
  *
  * @typedef { {

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -123,11 +123,17 @@ export default function ListGroup(props) {
         { label }
       </div>
       <div class="bio-properties-panel-group-header-buttons">
-        <AddContainer>
-          <div class="bio-properties-panel-add-entry">
-            <CreateIcon />
-          </div>
-        </AddContainer>
+        {
+          AddContainer
+            ? (
+              <AddContainer>
+                <div class="bio-properties-panel-add-entry">
+                  <CreateIcon />
+                </div>
+              </AddContainer>
+            )
+            : null
+        }
         {
           hasItems
             ? (

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -31,7 +31,8 @@ export default function ListGroup(props) {
     id,
     items,
     label,
-    add: AddContainer
+    add: AddContainer,
+    shouldSort = true
   } = props;
 
   const [ open, setOpen ] = useState(false);
@@ -45,14 +46,14 @@ export default function ListGroup(props) {
 
   // (0) set initial ordering from given items
   useEffect(() => {
-    if (!prevItems) {
+    if (!prevItems || !shouldSort) {
       setOrdering(createOrdering(items));
     }
   }, [ items ]);
 
   // (1) items were added
   useEffect(() => {
-    if (prevItems && items.length > prevItems.length) {
+    if (shouldSort && prevItems && items.length > prevItems.length) {
 
       let add = [];
 
@@ -87,14 +88,14 @@ export default function ListGroup(props) {
   useEffect(() => {
 
     // we already sorted as items were added
-    if (open && !newItemAdded) {
+    if (shouldSort && open && !newItemAdded) {
       setOrdering(createOrdering(sortItems(items)));
     }
   }, [ open ]);
 
   // (3) items were deleted
   useEffect(() => {
-    if (prevItems && items.length < prevItems.length) {
+    if (shouldSort && prevItems && items.length < prevItems.length) {
       let keep = [];
 
       ordering.forEach(o => {

--- a/src/components/entries/Collapsible.js
+++ b/src/components/entries/Collapsible.js
@@ -44,9 +44,16 @@ export default function CollapsibleEntry(props) {
         <div class="bio-properties-panel-collapsible-entry-arrow">
           <ListArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
         </div>
-        <RemoveContainer>
-          <ListDeleteIcon class="bio-properties-panel-remove-entry" />
-        </RemoveContainer>
+        {
+          RemoveContainer
+            ?
+            (
+              <RemoveContainer>
+                <ListDeleteIcon class="bio-properties-panel-remove-entry" />
+              </RemoveContainer>
+            )
+            : null
+        }
       </div>
       <div class={ classnames(
         'bio-properties-panel-collapsible-entry-entries',

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -129,6 +129,18 @@ describe('<Collapsible>', function() {
     expect(spy).to.have.been.called;
   });
 
+
+  it('should NOT wrap empty delete container', async function() {
+
+    // when
+    const { container } = createCollapsible({ container: parentContainer });
+
+    const removeEntry = domQuery('.bio-properties-panel-remove-entry', container);
+
+    // then
+    expect(removeEntry).to.not.exist;
+  });
+
 });
 
 

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -211,6 +211,49 @@ describe('<ListGroup>', function() {
     });
 
 
+    it('should NOT sort if configured', async function() {
+
+      // given
+      const items = [
+        {
+          id: 'item-1',
+          label: 'xyz'
+        },
+        {
+          id: 'item-2',
+          label: 'ab'
+        },
+        {
+          id: 'item-3',
+          label: 'def03'
+        },
+        {
+          id: 'item-4',
+          label: 'def04'
+        }
+      ];
+
+      const { container } = createListGroup({ container: parentContainer, items, shouldSort: false });
+
+      const header = domQuery('.bio-properties-panel-group-header', container);
+
+      const list = domQuery('.bio-properties-panel-list', container);
+
+      // when
+      waitFor(async () => {
+        await header.click();
+      });
+
+      // then
+      expect(getListOrdering(list)).to.eql([
+        'item-1',
+        'item-2',
+        'item-3',
+        'item-4'
+      ]);
+    });
+
+
     it('should order alphanumeric on open (label)', async function() {
 
       // given
@@ -580,11 +623,17 @@ function createListGroup(options = {}) {
     label = 'List',
     items = [],
     add,
+    shouldSort,
     container
   } = options;
 
   return render(
-    <ListGroup id={ id } label={ label } items={ items } add={ add } />,
+    <ListGroup
+      id={ id }
+      label={ label }
+      items={ items }
+      add={ add }
+      shouldSort={ shouldSort } />,
     {
       container
     }

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -166,6 +166,18 @@ describe('<ListGroup>', function() {
   });
 
 
+  it('should NOT wrap empty add container', async function() {
+
+    // when
+    const { container } = createListGroup({ container: parentContainer });
+
+    const addEntry = domQuery('.bio-properties-panel-add-entry', container);
+
+    // then
+    expect(addEntry).to.not.exist;
+  });
+
+
   describe('ordering', function() {
 
     it('should create initial ordering from items', function() {


### PR DESCRIPTION
This makes it possible to have lists non-editable, which includes
* no adding of items
* no removal of items
* disable default alphanumeric sorting

Required by https://github.com/bpmn-io/bpmn-properties-panel/issues/25