### PR TITLE
fix(css): default cursor when hovering collapsible entry header

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -471,6 +471,7 @@ textarea.bio-properties-panel-input {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: none;
 }
 
 .bio-properties-panel-collapsible-entry-arrow {


### PR DESCRIPTION
Makes sure collapsible entry headers have default cursor and can't be selected. Before:

![qJqsg5lgMG](https://user-images.githubusercontent.com/7633572/132855936-518ee026-d0ae-41a7-a848-ab9aeaa277a1.gif)



