### PR TITLE
style: unbuild custom checkbox component

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -292,63 +292,13 @@ textarea.bio-properties-panel-input,
 
 .bio-properties-panel-input[type="checkbox"], .bio-properties-panel-input[type="radio"] {
   margin: 0;
+  vertical-align: middle;
 }
 
-.bio-properties-panel-input[type="checkbox"] + label::after,
-.bio-properties-panel-input[type="radio"] + label::after {
-  -webkit-transform: scale(0);
-  -ms-transform: scale(0);
-  -o-transform: scale(0);
-  transform: scale(0);
-}
-
-.bio-properties-panel-input[type="checkbox"]:checked + label::after,
-.bio-properties-panel-input[type="radio"]:checked + label::after {
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-}
-
-.bio-properties-panel-checkbox {
-  margin-top: 12px;
-  margin-bottom: 6px;
-}
-
-.bio-properties-panel-checkbox .bio-properties-panel-input {
-  position: absolute;
-  opacity: 0;
-  z-index: -1;
-}
-
-.bio-properties-panel-checkbox .bio-properties-panel-label {
-  position: relative;
+.bio-properties-panel-checkbox > .bio-properties-panel-label {
   display: inline-block;
-  padding: 0 0 0 24px;
-}
-
-.bio-properties-panel-checkbox .bio-properties-panel-label::before,
-.bio-properties-panel-checkbox .bio-properties-panel-label::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
-  width: 16px;
-  height: 16px;
-}
-
-.bio-properties-panel-checkbox .bio-properties-panel-label::before {
-  content: " ";
-  border: 1px solid var(--color-input-border);
-  border-radius: 3px;
-  background-color:var(--color-000000-opacity-5);
-}
-
-.bio-properties-panel-checkbox .bio-properties-panel-label::after {
-  content: "\2714";
-  color: var(--color-text-base);
-  line-height: 1.5;
-  text-align: center;
+  margin-left: 4px;
+  vertical-align: middle;
 }
 
 textarea.bio-properties-panel-input {


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-properties-panel/issues/21
Related to https://github.com/bpmn-io/bpmn-properties-panel/issues/115

----

This unbuilds the custom Checkbox component which was in a WIP state and not meant to be included in the final design (cf. https://github.com/bpmn-io/bpmn-properties-panel/issues/90). We should keep the form components as default as possible and let the using components (Camunda Modeler, ...) decide how they look like.

This also fixes known issues for the Checkbox as https://github.com/bpmn-io/bpmn-properties-panel/issues/21 + https://github.com/bpmn-io/bpmn-properties-panel/issues/115.
 
![Kapture 2021-09-23 at 10 15 28](https://user-images.githubusercontent.com/9433996/134474852-f9a3e26c-e11d-4337-b9ff-497c87aaa720.gif)

