### PR TITLE
feat(hooks): add `useLayoutState`

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -3,6 +3,11 @@ import {
   useEffect
 } from 'preact/hooks';
 
+import {
+  get,
+  set
+} from 'min-dash';
+
 import classnames from 'classnames';
 
 import Header from './components/Header';
@@ -82,16 +87,18 @@ export default function PropertiesPanel(props) {
     }
   }, [ layout, layoutChanged ]);
 
+  const getLayoutForKey = (key, defaultValue) => {
+    return get(layout, key, defaultValue);
+  };
+
   const setLayoutForKey = (key, config) => {
-    setLayout({
-      ...layout,
-      [key]: config
-    });
+    setLayout(set(layout, key, config));
   };
 
   const layoutContext = {
     layout,
     setLayout,
+    getLayoutForKey,
     setLayoutForKey
   };
 

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -13,6 +13,10 @@ import {
   isFunction
 } from 'min-dash';
 
+import {
+  useLayoutState
+} from '../hooks';
+
 import { GroupArrowIcon } from './icons';
 
 /**
@@ -25,8 +29,10 @@ export default function Group(props) {
     label
   } = props;
 
-  const [ open, setOpen ] = useState(false);
-
+  const [ open, setOpen ] = useLayoutState(
+    [ 'groups', id, 'open' ],
+    false
+  );
   const toggleOpen = () => setOpen(!open);
 
   const [ edited, setEdited ] = useState(false);

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -1,6 +1,6 @@
 import {
-  useState,
-  useEffect
+  useEffect,
+  useState
 } from 'preact/hooks';
 
 import classnames from 'classnames';
@@ -11,6 +11,7 @@ import {
 } from 'min-dash';
 
 import {
+  useLayoutState,
   usePrevious
 } from '../hooks';
 
@@ -36,7 +37,12 @@ export default function ListGroup(props) {
     shouldSort = true
   } = props;
 
-  const [ open, setOpen ] = useState(false);
+
+  const [ open, setOpen ] = useLayoutState(
+    [ 'groups', id, 'open' ],
+    false
+  );
+
   const [ ordering, setOrdering ] = useState([]);
   const [ newItemAdded, setNewItemAdded ] = useState(false);
 
@@ -77,7 +83,7 @@ export default function ListGroup(props) {
       // sort + open if closed
       if (!open) {
         newOrdering = createOrdering(sortItems(items));
-        setOpen(true);
+        toggleOpen();
       }
 
       // add new items on top

--- a/src/context/LayoutContext.js
+++ b/src/context/LayoutContext.js
@@ -5,6 +5,7 @@ import {
 const LayoutContext = createContext({
   layout: {},
   setLayout: () => {},
+  getLayoutForKey: () => {},
   setLayoutForKey: () => {}
 });
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as usePrevious } from './usePrevious';
 export { useKeyFactory } from './useKeyFactory';
+export { useLayoutState } from './useLayoutState';

--- a/src/hooks/useLayoutState.js
+++ b/src/hooks/useLayoutState.js
@@ -1,0 +1,44 @@
+import {
+  useContext,
+  useState
+} from 'preact/hooks';
+
+import {
+  LayoutContext
+} from '../context';
+
+/**
+ * Creates a state that persists in the global LayoutContext.
+ *
+ * @example
+ * ```jsx
+ * function Group(props) {
+ *   const [ open, setOpen ] = useLayoutState([ 'groups', 'foo', 'open' ], false);
+ * }
+ * ```
+ *
+ * @param {(string|number)[]} path
+ * @param {any} [defaultValue]
+ *
+ * @returns {[ any, Function ]}
+ */
+export function useLayoutState(path, defaultValue) {
+  const {
+    getLayoutForKey,
+    setLayoutForKey
+  } = useContext(LayoutContext);
+
+  const layoutForKey = getLayoutForKey(path, defaultValue);
+  const [ value, set ] = useState(layoutForKey);
+
+  const setState = (newValue) => {
+
+    // (1) set component state
+    set(newValue);
+
+    // (2) set context
+    setLayoutForKey(path, newValue);
+  };
+
+  return [ value, setState ];
+}

--- a/test/spec/hooks/useLayoutState.spec.js
+++ b/test/spec/hooks/useLayoutState.spec.js
@@ -1,0 +1,134 @@
+import {
+  act,
+  renderHook
+} from '@testing-library/preact-hooks';
+
+import {
+  get,
+  set
+} from 'min-dash';
+
+import {
+  useLayoutState
+} from 'src/hooks';
+
+import {
+  LayoutContext
+} from 'src/context';
+
+const noop = () => {};
+
+
+describe('hooks/useLayoutState', function() {
+
+  it('should get from layout context', function() {
+
+    // given
+    const layout = {
+      a: {
+        b: 'foo'
+      }
+    };
+
+    const getLayoutForKey = (path) => get(layout, path);
+
+    const path = [ 'a', 'b' ];
+
+    const wrapper = createLayout({
+      getLayoutForKey,
+      layout
+    });
+
+    // when
+    const { result } = renderHook(() => useLayoutState(path), { wrapper });
+
+    const value = result.current[0];
+
+    // then
+    expect(value).to.eql('foo');
+  });
+
+
+  it('should get default value', function() {
+
+    // given
+    const layout = {};
+
+    const getLayoutForKey = (path, defaultValue) => get(layout, path, defaultValue);
+
+    const path = [ 'a', 'b' ];
+
+    const wrapper = createLayout({
+      getLayoutForKey
+    });
+
+    // when
+    const { result } = renderHook(() => useLayoutState(path, 'default'), { wrapper });
+
+    const [ value ] = result.current;
+
+    // then
+    expect(value).to.equal('default');
+  });
+
+
+  it('should set to layout context', function() {
+
+    // given
+    const layout = {
+      a: {
+        b: 'foo'
+      }
+    };
+
+    const setLayoutForKey = (path, value) => set(layout, path, value);
+
+    const path = [ 'a', 'b' ];
+
+    const wrapper = createLayout({
+      setLayoutForKey,
+      layout
+    });
+
+    const { result } = renderHook(() => useLayoutState(path), { wrapper });
+
+    const [ , setState ] = result.current;
+
+    const newValue = 'newValue';
+
+    // when
+    act(() => {
+      setState(newValue);
+    });
+
+    const [ value ] = result.current;
+
+    // then
+    expect(value).to.eql(newValue);
+    expect(layout).to.eql({
+      a: {
+        b: newValue
+      }
+    });
+  });
+
+});
+
+
+// helper ////////////////////
+
+function createLayout(props = {}) {
+  const {
+    layout = {},
+    getLayoutForKey = noop,
+    setLayoutForKey = noop
+  } = props;
+
+  const context = {
+    layout,
+    getLayoutForKey,
+    setLayoutForKey
+  };
+
+  return ({ children }) => <LayoutContext.Provider value={ context }>{children}</LayoutContext.Provider>;
+}


### PR DESCRIPTION
Proposal: This adds a `useLayoutState` hook to persist state inside the global `LayoutContext`. The `LayoutContext` can be used to persist state for components that might not be rendered sometimes (example groups), but we want to keep.

```js
const groupId = 'general';

const [ open, setOpen ] = useLayoutState(
  [ 'groups', id, 'open' ],
  false
);

setOpen(true);
```

Potentially it would also be possible to persist this layout state outside of the application (e.g. the Camunda Modeler), via [`propertiesPanel.layoutChanged`](https://github.com/bpmn-io/bpmn-properties-panel/blob/main/src/render/BpmnPropertiesPanel.js#L142) + the [`layoutConfig`](https://github.com/bpmn-io/bpmn-properties-panel/blob/main/src/render/BpmnPropertiesPanel.js#L25) parameter.



Closes #98

![Kapture 2021-09-24 at 10 46 30](https://user-images.githubusercontent.com/9433996/134646164-115c3f58-74ee-45da-8c48-e411e7054b92.gif)
