### PR TITLE
fix: use span instead of div inside buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: use valid HTML in add/remove buttons ([#111](https://github.com/bpmn-io/properties-panel/pull/111))
 
 ## 0.5.1
 

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -159,7 +159,7 @@ export default function ListGroup(props) {
                   <CreateIcon />
                   {
                     !hasItems ? (
-                      <div class="bio-properties-panel-add-entry-label">Create</div>
+                      <span class="bio-properties-panel-add-entry-label">Create</span>
                     )
                       : null
                   }

--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -113,7 +113,7 @@ export default function List(props) {
             <CreateIcon />
             {
               !hasItems ? (
-                <div class="bio-properties-panel-add-entry-label">Create</div>
+                <span class="bio-properties-panel-add-entry-label">Create</span>
               )
                 : null
             }


### PR DESCRIPTION
HTML5 allows to pass only inline elements as button children.

Cf. https://stackoverflow.com/questions/12982269/is-it-semantically-incorrect-to-put-a-div-or-span-inside-of-a-button/48383389

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
