### PR TITLE
Switch from containers to callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: accept callbacks instead of containers for `add` and `remove` props ([#108](https://github.com/bpmn-io/properties-panel/issues/108))
 * `FIX`: use valid HTML in add/remove buttons ([#111](https://github.com/bpmn-io/properties-panel/pull/111))
+
+### BREAKING CHANGES
+
+* `ListGroup#add` changed to function instead of Preact component
+* `Collapsible#remove` changed to function instead of Preact component
 
 ## 0.5.1
 

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -60,7 +60,7 @@
 
   --input-background-color: var(--color-grey-225-10-97);
   --input-border-color: var(--color-grey-225-10-75);
-  
+
   --input-focus-background-color: var(--color-blue-205-100-95);
   --input-focus-border-color: var(--color-blue-205-100-50);
 
@@ -237,10 +237,6 @@
 
 .bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-buttons:last-child {
   margin-right: 0;
-}
-
-.bio-properties-panel-add-container {
-  pointer-events: none;
 }
 
 .bio-properties-panel-add-entry {
@@ -445,7 +441,7 @@ textarea.bio-properties-panel-input {
 
 .bio-properties-panel-simple + .bio-properties-panel-remove-entry {
   margin: auto;
-} 
+}
 
 /**
  * Toggle Switch
@@ -574,10 +570,6 @@ textarea.bio-properties-panel-input {
   align-self: center;
 }
 
-.bio-properties-panel-remove-container {
-  pointer-events: none;
-}
-
 .bio-properties-panel-remove-entry {
   pointer-events: all;
   display: flex;
@@ -637,8 +629,8 @@ textarea.bio-properties-panel-input {
   left: -18px;
 }
 
-/* 
- * List entry 
+/*
+ * List entry
  */
 .bio-properties-panel-list-entry {
   position: relative;
@@ -777,14 +769,14 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-list-entry-item .bio-properties-panel-simple .bio-properties-panel-input {
   border-radius: 0;
   margin-bottom: -2px;
-} 
+}
 
-.bio-properties-panel-list-entry-item:first-child .bio-properties-panel-simple .bio-properties-panel-input {  
+.bio-properties-panel-list-entry-item:first-child .bio-properties-panel-simple .bio-properties-panel-input {
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-} 
+}
 
-.bio-properties-panel-list-entry-item:last-child .bio-properties-panel-simple .bio-properties-panel-input {  
+.bio-properties-panel-list-entry-item:last-child .bio-properties-panel-simple .bio-properties-panel-input {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -36,11 +36,11 @@ const DEFAULT_LAYOUT = {
  *    entries: Array<EntryDefinition>,
  *    id: String,
  *    label: String,
- *    remove: import('preact').Component
+ *    remove: (event: MouseEvent) => void
  * } } ListItemDefinition
  *
  * @typedef { {
- *    add: import('preact').Component,
+ *    add: (event: MouseEvent) => void,
  *    component: import('preact').Component,
  *    element: Object,
  *    id: String,

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -33,7 +33,7 @@ export default function ListGroup(props) {
     id,
     items,
     label,
-    add: AddContainer,
+    add,
     shouldSort = true,
     shouldOpen = true
   } = props;
@@ -149,22 +149,21 @@ export default function ListGroup(props) {
       </div>
       <div class="bio-properties-panel-group-header-buttons">
         {
-          AddContainer
+          add
             ? (
-              <AddContainer>
-                <button
-                  title="Create new list item"
-                  class="bio-properties-panel-group-header-button bio-properties-panel-add-entry"
-                >
-                  <CreateIcon />
-                  {
-                    !hasItems ? (
-                      <span class="bio-properties-panel-add-entry-label">Create</span>
-                    )
-                      : null
-                  }
-                </button>
-              </AddContainer>
+              <button
+                title="Create new list item"
+                class="bio-properties-panel-group-header-button bio-properties-panel-add-entry"
+                onClick={ add }
+              >
+                <CreateIcon />
+                {
+                  !hasItems ? (
+                    <span class="bio-properties-panel-add-entry-label">Create</span>
+                  )
+                    : null
+                }
+              </button>
             )
             : null
         }

--- a/src/components/entries/Collapsible.js
+++ b/src/components/entries/Collapsible.js
@@ -15,7 +15,7 @@ export default function CollapsibleEntry(props) {
     id,
     entries = [],
     label,
-    remove: RemoveContainer,
+    remove,
     open: shouldOpen
   } = props;
 
@@ -49,14 +49,12 @@ export default function CollapsibleEntry(props) {
           <ArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
         </button>
         {
-          RemoveContainer
+          remove
             ?
             (
-              <RemoveContainer>
-                <button title="Delete item" class="bio-properties-panel-remove-entry">
-                  <DeleteIcon />
-                </button>
-              </RemoveContainer>
+              <button title="Delete item" class="bio-properties-panel-remove-entry" onClick={ remove }>
+                <DeleteIcon />
+              </button>
             )
             : null
         }

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -1,4 +1,5 @@
 import {
+  act,
   render
 } from '@testing-library/preact/pure';
 
@@ -111,26 +112,26 @@ describe('<Collapsible>', function() {
   });
 
 
-  it('should wrap delete container', async function() {
+  it('should bind remove callback', async function() {
 
     // given
-    const spy = sinon.spy();
-
-    const remove = ({ children }) => <span class="delete" onClick={ spy }>{ children }</span>;
+    const remove = sinon.spy();
 
     const { container } = createCollapsible({ container: parentContainer, remove });
 
     const removeEntry = domQuery('.bio-properties-panel-remove-entry', container);
 
     // when
-    await removeEntry.parentNode.click();
+    await act(() => {
+      removeEntry.click();
+    });
 
     // then
-    expect(spy).to.have.been.called;
+    expect(remove).to.have.been.called;
   });
 
 
-  it('should NOT wrap empty delete container', async function() {
+  it('should NOT display remove button when no callback was passed', async function() {
 
     // when
     const { container } = createCollapsible({ container: parentContainer });

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -121,12 +121,10 @@ describe('<ListGroup>', function() {
   });
 
 
-  it('should wrap add container', async function() {
+  it('should bind add callback', async function() {
 
     // given
-    const spy = sinon.spy();
-
-    const add = ({ children }) => <span class="add" onClick={ spy }>{ children }</span>;
+    const add = sinon.spy();
 
     const { container } = createListGroup({ container: parentContainer, add });
 
@@ -134,15 +132,15 @@ describe('<ListGroup>', function() {
 
     // when
     await act(() => {
-      addEntry.parentNode.click();
+      addEntry.click();
     });
 
     // then
-    expect(spy).to.have.been.called;
+    expect(add).to.have.been.called;
   });
 
 
-  it('should NOT wrap empty add container', async function() {
+  it('should NOT display add button if no callback was passed', async function() {
 
     // when
     const { container } = createListGroup({ container: parentContainer });


### PR DESCRIPTION
BREAKING CHANGES:

* `ListGroup#add` changed to function instead of Preact component
* `Collapsible#remove` changed to function instead of Preact component

Closes #108 

Can be tested with https://github.com/bpmn-io/bpmn-properties-panel/pull/144