### PR TITLE
style: add disabled input styles

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -385,6 +385,12 @@ textarea.bio-properties-panel-input,
   border: 1px solid var(--input-focus-border-color);
 }
 
+.bio-properties-panel-input:disabled {
+  border-color: var(--color-grey-225-10-90);
+  background-color: var(--color-grey-225-10-97);
+  color: var(--color-grey-225-10-55);
+}
+
 select.bio-properties-panel-input {
   padding: 4px 6px;
 }


### PR DESCRIPTION
Styles disabled inputs according to https://fluffy-fiesta-212e1c7c.pages.github.io/prototypes/visual-ide/v15/.

Example:

![image](https://user-images.githubusercontent.com/7633572/140046109-e589af2e-d879-41df-b84b-e1f83e403117.png)

_Throw expression_ input is disabled.