### PR TITLE
Add dropdown button

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -225,7 +225,6 @@
   justify-content: center;
   align-items: center;
   align-self: center;
-  font-size: var(--text-size-small);
   height: 22px;
   line-height: 22px;
   min-width: 22px;

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -201,7 +201,6 @@
   font-size: var(--text-size-base);
   height: 32px;
   user-select: none;
-  overflow: hidden;
   justify-content: space-between;
 }
 
@@ -777,3 +776,60 @@ textarea.bio-properties-panel-input {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
+
+.bio-properties-panel-dropdown-button {
+  position: relative;
+
+  --dropdown-button-margin: 5px;
+}
+
+.bio-properties-panel-dropdown-button:not(.open) .bio-properties-panel-dropdown-button__menu {
+  display: none;
+}
+
+.bio-properties-panel-dropdown-button__menu {
+  min-width: calc(100% - var(--dropdown-button-margin) * 2);
+  max-width: 240px;
+
+  position: absolute;
+  top: calc(100% - var(--dropdown-button-margin));
+  right: var(--dropdown-button-margin);
+  z-index: 101;
+
+  background-color: var(--color-white);
+
+  padding: 8px 0;
+
+  box-shadow: 0 1px 4px 0 var(--color-grey-225-10-85), 0 2px 16px 0 var(--color-grey-225-10-75)
+}
+
+.bio-properties-panel-dropdown-button__menu-item {
+  display: block;
+  width: 100%;
+  padding: 4px 12px;
+
+  font-size: var(--text-size-small);
+  appearance: revert;
+  border: unset;
+  background: unset;
+  text-align: unset;
+}
+
+.bio-properties-panel-dropdown-button__menu-item--separator {
+  width: 100%;
+  height: 1px;
+
+  padding: 0;
+  margin: 8px 0;
+
+  background-color: var(--color-grey-225-10-75);
+}
+
+.bio-properties-panel-dropdown-button__menu-item--actionable {
+  font-size: var(--text-size-base);
+}
+
+.bio-properties-panel-dropdown-button__menu-item--actionable:hover {
+  background-color: var(--color-grey-225-10-95);
+}
+

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -83,6 +83,10 @@
   --list-entry-add-entry-label-color: var(--color-white);
   --list-entry-add-entry-background-color: var(--color-blue-205-100-50);
   --list-entry-add-entry-fill-color: var(--color-white);
+  
+  --dropdown-item-background-color: var(--color-white);
+  --dropdown-item-hover-background-color: var(--color-grey-225-10-95);
+  --dropdown-separator-background-color: var(--color-grey-225-10-75);
 
   --text-size-base: 14px;
   --text-size-small: 13px;
@@ -796,7 +800,7 @@ textarea.bio-properties-panel-input {
   right: var(--dropdown-button-margin);
   z-index: 101;
 
-  background-color: var(--color-white);
+  background-color: var(--dropdown-item-background-color);
 
   padding: 8px 0;
 
@@ -822,7 +826,7 @@ textarea.bio-properties-panel-input {
   padding: 0;
   margin: 8px 0;
 
-  background-color: var(--color-grey-225-10-75);
+  background-color: var(--dropdown-separator-background-color);
 }
 
 .bio-properties-panel-dropdown-button__menu-item--actionable {
@@ -830,6 +834,5 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-dropdown-button__menu-item--actionable:hover {
-  background-color: var(--color-grey-225-10-95);
+  background-color: var(--dropdown-item-hover-background-color);
 }
-

--- a/src/components/DropdownButton.js
+++ b/src/components/DropdownButton.js
@@ -1,0 +1,108 @@
+import {
+  useEffect,
+  useRef,
+  useState
+} from 'preact/hooks';
+
+import classnames from 'classnames';
+
+/**
+ *
+ * @param {object} props
+ * @param {string} [props.class]
+ * @param {import('preact').Component[]} [props.menuItems]
+ * @returns
+ */
+export function DropdownButton(props) {
+  const {
+    class: className,
+    children,
+    menuItems = []
+  } = props;
+
+  const dropdownRef = useRef(null);
+  const menuRef = useRef(null);
+
+  const [ open, setOpen ] = useState(false);
+  const close = () => setOpen(false);
+
+  function onDropdownToggle(event) {
+    if (menuRef.current && menuRef.current.contains(event.target)) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    setOpen(open => !open);
+  }
+
+  function onActionClick(event, action) {
+    event.stopPropagation();
+
+    close();
+    action();
+  }
+
+  useGlobalClick([ dropdownRef.current ], () => close());
+
+  return (
+    <div
+      class={ classnames('bio-properties-panel-dropdown-button', { open }, className) }
+      onClick={ onDropdownToggle }
+      ref={ dropdownRef }
+    >
+      { children }
+      <div class="bio-properties-panel-dropdown-button__menu" ref={ menuRef }>
+        { menuItems.map((item, index) => (
+          <MenuItem onClick={ onActionClick } item={ item } key={ index } />
+        )) }
+      </div>
+    </div>
+  );
+}
+
+function MenuItem({ item, onClick }) {
+  if (item.separator) {
+    return <div class="bio-properties-panel-dropdown-button__menu-item bio-properties-panel-dropdown-button__menu-item--separator" />;
+  }
+
+  if (item.action) {
+    return (<button
+      class="bio-properties-panel-dropdown-button__menu-item bio-properties-panel-dropdown-button__menu-item--actionable"
+      onClick={ event => onClick(event, item.action) }
+    >
+      {item.entry}
+    </button>);
+  }
+
+  return <div
+    class="bio-properties-panel-dropdown-button__menu-item"
+  >
+    {item.entry}
+  </div>;
+}
+
+/**
+ *
+ * @param {Array<null | Element>} ignoredElements
+ * @param {Function} callback
+ */
+function useGlobalClick(ignoredElements, callback) {
+  useEffect(() => {
+
+    /**
+     * @param {MouseEvent} event
+     */
+    function listener(event) {
+      if (ignoredElements.some(element => element && element.contains(event.target))) {
+        return;
+      }
+
+      callback();
+    }
+
+    document.addEventListener('click', listener, { capture: true });
+
+    return () => document.removeEventListener('click', listener, { capture: true });
+  }, [ ...ignoredElements, callback ]);
+}

--- a/src/components/HeaderButton.js
+++ b/src/components/HeaderButton.js
@@ -1,0 +1,17 @@
+import classnames from 'classnames';
+
+export function HeaderButton(props) {
+  const {
+    children = null,
+    class: classname,
+    onClick = () => {},
+    ...otherProps
+  } = props;
+
+  return <button
+    { ...otherProps }
+    onClick={ onClick }
+    class={ classnames('bio-properties-panel-group-header-button', classname) }>
+    { children }
+  </button>;
+}

--- a/test/spec/components/DropdownButton.spec.js
+++ b/test/spec/components/DropdownButton.spec.js
@@ -1,0 +1,219 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import { DropdownButton } from 'src/components/DropdownButton';
+
+import { clickInput } from 'test/TestHelper';
+
+insertCoreStyles();
+
+
+describe('<DropdownButton>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  describe('rendering', function() {
+
+    it('should render', function() {
+
+      // when
+      const rendered = render(<DropdownButton>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+
+      // then
+      expect(dropdownButtonNode).to.exist;
+    });
+
+
+    it('should render menu items', function() {
+
+      // given
+      const menuItems = [
+        { entry: <span id="my-menu-item">hello</span> }
+      ];
+
+      // when
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const menuItemNode = domQuery('#my-menu-item', rendered.container);
+
+      // then
+      expect(menuItemNode).to.exist;
+    });
+
+
+    it('should render action item', function() {
+
+      // given
+      const menuItems = [
+        { entry: 'Click me', action() {} }
+      ];
+
+      // when
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const actionNode = domQuery(
+        '.bio-properties-panel-dropdown-button__menu-item--actionable', rendered.container);
+
+      // then
+      expect(actionNode).to.exist;
+    });
+
+
+    it('should render separator', function() {
+
+      // given
+      const menuItems = [
+        { separator: true }
+      ];
+
+      // when
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const separatorNode = domQuery(
+        '.bio-properties-panel-dropdown-button__menu-item--separator', rendered.container);
+
+      // then
+      expect(separatorNode).to.exist;
+    });
+  });
+
+
+  describe('open/close', function() {
+
+    it('should open when clicked', function() {
+
+      // given
+      const rendered = render(<DropdownButton>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+
+      // when
+      clickInput(dropdownButtonNode);
+
+      // then
+      expect(dropdownButtonNode.className).to.contain('open');
+    });
+
+
+    it('should close when clicked again', function() {
+
+      // given
+      const rendered = render(<DropdownButton>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+
+      // when
+      clickInput(dropdownButtonNode);
+      clickInput(dropdownButtonNode);
+
+      // then
+      expect(dropdownButtonNode.className).not.to.contain('open');
+    });
+
+
+    it('should close when action item is clicked', function() {
+
+      // given
+      const menuItems = [
+        { entry: 'Click me', action() {} }
+      ];
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+      clickInput(dropdownButtonNode);
+
+      // when
+      const actionNode = domQuery(
+        '.bio-properties-panel-dropdown-button__menu-item--actionable', rendered.container);
+      clickInput(actionNode);
+
+      // then
+      expect(dropdownButtonNode.className).not.to.contain('open');
+    });
+
+
+    it('should close when clicked outside of menu', function() {
+
+      // given
+      const rendered = render(<DropdownButton>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+      clickInput(dropdownButtonNode);
+
+      // when
+      clickInput(container);
+
+      // then
+      expect(dropdownButtonNode.className).not.to.contain('open');
+    });
+
+
+    it('should NOT close when clicked inside of menu', function() {
+
+      // given
+      const menuItems = [
+        { entry: <span id="my-menu-item">hello</span> }
+      ];
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+      clickInput(dropdownButtonNode);
+
+      // when
+      const menuItemNode = domQuery('#my-menu-item', rendered.container);
+      clickInput(menuItemNode);
+
+      // then
+      expect(dropdownButtonNode.className).to.contain('open');
+    });
+  });
+
+
+  describe('action', function() {
+
+    it('should call action item is clicked', function() {
+
+      // given
+      const spy = sinon.spy();
+      const menuItems = [
+        { entry: 'Click me', action: spy }
+      ];
+      const rendered = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      const dropdownButtonNode = domQuery('.bio-properties-panel-dropdown-button', rendered.container);
+      clickInput(dropdownButtonNode);
+
+      // when
+      const actionNode = domQuery(
+        '.bio-properties-panel-dropdown-button__menu-item--actionable', rendered.container);
+      clickInput(actionNode);
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/spec/components/HeaderButton.spec.js
+++ b/test/spec/components/HeaderButton.spec.js
@@ -1,0 +1,39 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import { HeaderButton } from 'src/components/HeaderButton';
+
+insertCoreStyles();
+
+
+describe('<HeaderButton>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  it('should render', function() {
+
+    // when
+    const rendered = render(<HeaderButton />, { container });
+
+    const headerButtonNode = domQuery('.bio-properties-panel-group-header-button', rendered.container);
+
+    // then
+    expect(headerButtonNode).to.exist;
+  });
+});


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/28307541/140102786-6892ab04-c204-49e4-827e-83a3cb122ca4.png)


This PR:

* removes default button font size which is not used anywhere (https://github.com/bpmn-io/properties-panel/commit/01adb3a25e929aca933c0d7462cb8017a4ccc459)
* adds and exposes HeaderButton
* adds and exposes DropdownButton

The components will be used in the Element Templates Group.

Related to https://github.com/bpmn-io/bpmn-properties-panel/issues/149

Test via https://github.com/bpmn-io/bpmn-properties-panel/tree/149-add-dropdown-button and `npm run start:templates`.
