### PR TITLE
fix: rollup now sets up correct paths for preact on windows builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
         node-version: [ 14 ]
 
     runs-on: ${{ matrix.os }}
@@ -29,8 +29,16 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Build
+      if: matrix.os == 'ubuntu-latest'
       env:
         COVERAGE: 1
+        TEST_BROWSERS: ChromeHeadless
+      run: npm run all
+    - name: Build
+      if: matrix.os != 'ubuntu-latest'
+      env:
+        TEST_BROWSERS: ChromeHeadless
       run: npm run all
     - name: Upload coverage
+      if: matrix.os == 'ubuntu-latest'
       run: npx codecov

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import { parse as parsePath, relative as relativePath } from 'path';
+import path, { parse as parsePath, relative as relativePath } from 'path';
 import { replaceInFile } from 'replace-in-file';
 
 import babel from '@rollup/plugin-babel';
@@ -64,9 +64,8 @@ function rewirePreactSubpackages() {
                 filePath = args.pop();
 
           const { dir } = parsePath(filePath);
-          const pathToPreact = relativePath(dir, './preact');
-
-          return `${importGroup}${pathToPreact}${afterImport}`;
+          const posixPathToPreact = relativePath(dir, './preact').split(path.sep).join(path.posix.sep);
+          return `${importGroup}${posixPathToPreact}${afterImport}`;
         }
       });
     }


### PR DESCRIPTION
Closes #127.

This also includes changes to the CI config, now triggering builds on windows, mac and linux platforms. 