### PR TITLE
Add basic accessibility tests

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -107,7 +107,10 @@ module.exports = function(karma) {
         modules: [
           'node_modules',
           absoluteBasePath
-        ]
+        ],
+        fallback: {
+          'crypto': false
+        }
       },
       devtool: 'eval-source-map'
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1766,6 +1766,12 @@
       "dev": true,
       "optional": true
     },
+    "axe-core": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+      "dev": true
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@testing-library/preact": "^2.0.1",
     "@testing-library/preact-hooks": "^1.1.0",
+    "axe-core": "^4.3.5",
     "babel-loader": "^8.2.2",
     "babel-plugin-inline-react-svg": "^2.0.1",
     "babel-plugin-module-resolver": "^4.1.0",

--- a/src/components/entries/Simple.js
+++ b/src/components/entries/Simple.js
@@ -42,6 +42,7 @@ export default function Simple(props) {
         disabled={ disabled }
         class="bio-properties-panel-input"
         onInput={ handleInput }
+        aria-label={ value || '<empty>' }
         onFocus={ onFocus }
         onBlur={ onBlur }
         value={ value || '' } />

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -2,6 +2,18 @@ import {
   fireEvent
 } from '@testing-library/preact';
 
+import axe from 'axe-core';
+
+/**
+ * https://www.deque.com/axe/core-documentation/api-documentation/#axe-core-tags
+ */
+const DEFAULT_AXE_RULES = [
+  'best-practice',
+  'wcag2a',
+  'wcag2aa',
+  'cat.semantics'
+];
+
 
 export function insertCSS(name, css) {
   if (document.querySelector('[data-css-file="' + name + '"]')) {
@@ -41,4 +53,19 @@ export function insertCoreStyles() {
     'test.css',
     require('./test.css').default
   );
+}
+
+export async function expectNoViolations(node, options = {}) {
+  const {
+    rules,
+    ...rest
+  } = options;
+
+  const results = await axe.run(node, {
+    runOnly: rules || DEFAULT_AXE_RULES,
+    ...rest
+  });
+
+  expect(results.passes).to.be.not.empty;
+  expect(results.violations).to.be.empty;
 }

--- a/test/spec/components/Checkbox.spec.js
+++ b/test/spec/components/Checkbox.spec.js
@@ -9,8 +9,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  clickInput
+  clickInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import {
@@ -202,6 +203,23 @@ describe('<Checkbox>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createCheckbox({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -11,7 +11,8 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import Collapsible from 'src/components/entries/Collapsible';
@@ -140,6 +141,23 @@ describe('<Collapsible>', function() {
 
     // then
     expect(removeEntry).to.not.exist;
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createCollapsible({
+        container: parentContainer,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
+    });
+
   });
 
 });

--- a/test/spec/components/DropdownButton.spec.js
+++ b/test/spec/components/DropdownButton.spec.js
@@ -2,6 +2,8 @@ import {
   render
 } from '@testing-library/preact/pure';
 
+import axe from 'axe-core';
+
 import TestContainer from 'mocha-test-container-support';
 
 import {
@@ -215,5 +217,30 @@ describe('<DropdownButton>', function() {
       // then
       expect(spy).to.have.been.calledOnce;
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const menuItems = [
+        { entry: 'Click me' }
+      ];
+
+      const { container: node } = render(
+        <DropdownButton menuItems={ menuItems }>Click</DropdownButton>, { container });
+
+      // when
+      const results = await axe.run(node, {
+        runOnly: [ 'best-practice', 'wcag2a', 'wcag2aa' ]
+      });
+
+      // then
+      expect(results.passes).to.be.not.empty;
+      expect(results.violations).to.be.empty;
+    });
+
   });
 });

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -11,6 +11,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
 
@@ -173,6 +174,23 @@ describe('<Group>', function() {
 
       // then
       expect(domAttr(dataMarker, 'title')).to.eql('Section contains data');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createGroup({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/Header.spec.js
+++ b/test/spec/components/Header.spec.js
@@ -9,6 +9,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
 
@@ -139,6 +140,26 @@ describe('<Header>', function() {
 
     // then
     expect(iconNode).to.exist;
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const provider = {
+        getElementLabel: () => 'name',
+        getTypeLabel: () => 'type',
+        getElementIcon: () => 'icon'
+      };
+
+      const { container: node } = render(<Header headerProvider={ provider } />, { container });
+
+      // then
+      await expectNoViolations(node);
+    });
+
   });
 
 });

--- a/test/spec/components/HeaderButton.spec.js
+++ b/test/spec/components/HeaderButton.spec.js
@@ -9,6 +9,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
 
@@ -36,4 +37,19 @@ describe('<HeaderButton>', function() {
     // then
     expect(headerButtonNode).to.exist;
   });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = render(<HeaderButton>foo</HeaderButton>, { container });
+
+      // then
+      await expectNoViolations(node);
+    });
+
+  });
+
 });

--- a/test/spec/components/List.spec.js
+++ b/test/spec/components/List.spec.js
@@ -14,6 +14,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
 
@@ -25,6 +26,8 @@ const noopElement = {
   id: 'foo',
   type: 'foo'
 };
+
+const noop = () => {};
 
 
 describe('<List>', function() {
@@ -933,6 +936,40 @@ describe('<List>', function() {
 
       // then
       expect(domAttr(badge, 'title')).to.eql('List contains 2 items');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const items = [
+        {
+          id: 'item-1',
+          label: 'Item 1'
+        },
+        {
+          id: 'item-2',
+          label: 'Item 2'
+        },
+        {
+          id: 'item-3',
+          label: 'Item 3'
+        }
+      ];
+
+      const { container: node } = createListEntry({
+        container: parentContainer,
+        items,
+        onAdd: noop,
+        onRemove: noop
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -14,6 +14,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
 
@@ -25,6 +26,8 @@ const noopElement = {
   id: 'foo',
   type: 'foo'
 };
+
+const noop = () => {};
 
 
 describe('<ListGroup>', function() {
@@ -1032,6 +1035,44 @@ describe('<ListGroup>', function() {
 
       // then
       expect(domAttr(badge, 'title')).to.eql('List contains 2 items');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const items = [
+        {
+          id: 'item-1',
+          label: 'Item 1',
+          remove: noop
+        },
+        {
+          id: 'item-2',
+          label: 'Item 2',
+          remove: noop
+        },
+        {
+          id: 'item-3',
+          label: 'Item 3',
+          remove: noop
+        }
+      ];
+
+      const add = noop;
+
+      const { container: node } = createListGroup({
+        container: parentContainer,
+        items,
+        add
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/ListItem.spec.js
+++ b/test/spec/components/ListItem.spec.js
@@ -10,6 +10,7 @@ import {
 } from 'min-dom';
 
 import {
+  expectNoViolations,
   insertCoreStyles,
 } from 'test/TestHelper';
 
@@ -115,6 +116,22 @@ describe('<ListItem>', function() {
 
       // then
       expect(document.activeElement).to.equal(select);
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createListItem({
+        container: parentContainer
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/NumberField.spec.js
+++ b/test/spec/components/NumberField.spec.js
@@ -9,8 +9,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  changeInput
+  changeInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import NumberField, { isEdited } from 'src/components/entries/NumberField';
@@ -286,6 +287,23 @@ describe('<NumberField>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createNumberField({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -10,8 +10,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  changeInput
+  expectNoViolations,
+  changeInput,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import Select, { isEdited } from 'src/components/entries/Select';
@@ -282,6 +283,23 @@ describe('<Select>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createSelect({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/Simple.spec.js
+++ b/test/spec/components/Simple.spec.js
@@ -9,8 +9,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  changeInput
+  changeInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import Simple, { isEdited } from 'src/components/entries/Simple';
@@ -120,6 +121,59 @@ describe('<Simple>', function() {
 
       // then
       expect(isEdited(input)).to.be.true;
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const getValue = () => '';
+
+      const { container: node } = createSimple({
+        container,
+        getValue
+      });
+
+      // then
+      await expectNoViolations(node);
+    });
+
+
+    it('should set aria label', async function() {
+
+      // given
+      const getValue = () => 'foo';
+
+      const { container: node } = createSimple({
+        container,
+        getValue
+      });
+
+      // then
+      await expectNoViolations(node, {
+        rules: [ 'label' ]
+      });
+    });
+
+
+    it('should set aria label (empty value)', async function() {
+
+      // given
+      const getValue = () => null;
+
+      const { container: node } = createSimple({
+        container,
+        getValue
+      });
+
+      // then
+      await expectNoViolations(node, {
+        rules: [ 'label' ]
+      });
     });
 
   });

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -10,8 +10,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  changeInput
+  changeInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import TextArea, { isEdited } from 'src/components/entries/TextArea';
@@ -215,6 +216,23 @@ describe('<TextArea>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createTextArea({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -10,8 +10,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  changeInput
+  changeInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import {
@@ -330,6 +331,23 @@ describe('<TextField>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createTextField({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });

--- a/test/spec/components/ToggleSwitch.spec.js
+++ b/test/spec/components/ToggleSwitch.spec.js
@@ -9,8 +9,9 @@ import {
 } from 'min-dom';
 
 import {
-  insertCoreStyles,
-  clickInput
+  clickInput,
+  expectNoViolations,
+  insertCoreStyles
 } from 'test/TestHelper';
 
 import ToggleSwitch, { isEdited } from 'src/components/entries/ToggleSwitch';
@@ -248,6 +249,23 @@ describe('<ToggleSwitch>', function() {
 
       expect(description).to.exist;
       expect(description.innerText).to.equal('myExplicitDescription');
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createToggleSwitch({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
     });
 
   });


### PR DESCRIPTION
This
* adds basic a11y testing infrastructure via `axe-core`
* defines basic rules set we testing against 
  * `best-practice`
  * `wcag2a`
  * `wcag2aa`,
  * `cat.semantics` (some additional rules to ensure we use semantic HTML, something we focus on in the past)
* adds unit tests for all components 
* fixes a minor a11y issue with the `Simple` component (no label)