### PR TITLE
feat: render components instead of elements

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -29,7 +29,7 @@ const DEFAULT_DESCRIPTION = {};
 
 /**
  * @typedef { {
- *    component: import('preact').ComponentChild,
+ *    component: import('preact').Component,
  *    id: String,
  *    isEdited?: Function
  * } } EntryDefinition
@@ -157,16 +157,17 @@ export default function PropertiesPanel(props) {
         <div class="bio-properties-panel-scroll-container">
           {
             groups.map(group => {
-
               const {
-                component: GroupComponent = Group,
+                component: Component = Group,
                 id
               } = group;
 
-              return <GroupComponent
-                key={ id }
-                element={ element }
-                { ...group } />;
+              return (
+                <Component
+                  { ...group }
+                  key={ id }
+                  element={ element } />
+              );
             })
           }
         </div>

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -24,8 +24,9 @@ import { ArrowIcon } from './icons';
  */
 export default function Group(props) {
   const {
-    id,
+    element,
     entries = [],
+    id,
     label
   } = props;
 
@@ -85,7 +86,19 @@ export default function Group(props) {
       open ? 'open' : ''
     ) }>
       {
-        entries.map(e => e.component)
+        entries.map(entry => {
+          const {
+            component: Component,
+            id
+          } = entry;
+
+          return (
+            <Component
+              { ...entry }
+              key={ id }
+              element={ element } />
+          );
+        })
       }
     </div>
   </div>;

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -29,13 +29,13 @@ const noop = () => {};
  */
 export default function ListGroup(props) {
   const {
+    add,
     element,
     id,
     items,
     label,
-    add,
-    shouldSort = true,
-    shouldOpen = true
+    shouldOpen = true,
+    shouldSort = true
   } = props;
 
 
@@ -205,13 +205,17 @@ export default function ListGroup(props) {
             return;
           }
 
+          const { id } = item;
+
           return (
             <ListItem
-              key={ item.id }
+              { ...item }
+              element={ element }
+              index={ index }
+              key={ id }
 
               // if item was added, open first or last item based on ordering
-              autoOpen={ newItemAdded && (shouldSort ? index === 0 : index === ordering.length - 1) }
-              { ...item } />
+              autoOpen={ newItemAdded && (shouldSort ? index === 0 : index === ordering.length - 1) } />
           );
         })
       }

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -15,8 +15,8 @@ import CollapsibleEntry from './entries/Collapsible';
  */
 export default function ListItem(props) {
   const {
-    autoOpen,
-    autoFocusEntry
+    autoFocusEntry,
+    autoOpen
   } = props;
 
   // focus specified entry on auto open
@@ -41,7 +41,9 @@ export default function ListItem(props) {
 
   return (
     <div class="bio-properties-panel-list-item">
-      <CollapsibleEntry { ...props } open={ autoOpen } />
+      <CollapsibleEntry
+        { ...props }
+        open={ autoOpen } />
     </div>
   );
 

--- a/src/components/entries/Collapsible.js
+++ b/src/components/entries/Collapsible.js
@@ -12,11 +12,12 @@ import {
 
 export default function CollapsibleEntry(props) {
   const {
-    id,
+    element,
     entries = [],
+    id,
     label,
-    remove,
-    open: shouldOpen
+    open: shouldOpen,
+    remove
   } = props;
 
   const [ open, setOpen ] = useState(shouldOpen);
@@ -64,7 +65,17 @@ export default function CollapsibleEntry(props) {
         open ? 'open' : ''
       ) }>
         {
-          entries.map(e => e.component)
+          entries.map(entry => {
+            const {
+              component: Component,
+              id
+            } = entry;
+
+            return <Component
+              { ...entry }
+              key={ id }
+              element={ element } />;
+          })
         }
       </div>
     </div>

--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -31,7 +31,7 @@ import {
  * @param {string} props.id
  * @param {*} props.element
  * @param {Function} props.onAdd
- * @param {(item: Item, index: number, isNew: boolean) => JSX.Element} props.renderItem
+ * @param {import('preact').Component} props.component
  * @param {string} [props.label='<empty>']
  * @param {Function} [props.onRemove]
  * @param {Item[]} [props.items]
@@ -45,7 +45,7 @@ export default function List(props) {
     id,
     element,
     items = [],
-    renderItem,
+    component,
     label = '<empty>',
     open: shouldOpen,
     onAdd,
@@ -144,12 +144,13 @@ export default function List(props) {
         hasItems && (
           <ItemsList
             autoFocusEntry={ autoFocusEntry }
+            component={ component }
+            element={ element }
             id={ id }
-            open={ open }
             items={ sortedItems }
             newItems={ newItems }
             onRemove={ onRemove }
-            renderItem={ renderItem }
+            open={ open }
           />
         )
       }
@@ -160,12 +161,13 @@ export default function List(props) {
 function ItemsList(props) {
   const {
     autoFocusEntry,
+    component: Component,
+    element,
     id,
     items,
     newItems,
-    open,
     onRemove,
-    renderItem
+    open
   } = props;
 
   const getKey = useKeyFactory();
@@ -207,7 +209,12 @@ function ItemsList(props) {
           const key = getKey(item);
 
           return (<li class="bio-properties-panel-list-entry-item" key={ key }>
-            { renderItem(item, index, item === newItem) }
+            <Component
+              element={ element }
+              id={ id }
+              index={ index }
+              item={ item }
+              open={ item === newItem } />
             {
               onRemove && (
                 <button

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -113,15 +113,15 @@ describe('<PropertiesPanel>', function() {
           entries: [
             {
               id: 'entry-1',
-              component: <TestEntryComponent value="one" />
+              component: TestEntry
             },
             {
               id: 'entry-2',
-              component: <TestEntryComponent value="two" />
+              component: TestEntry
             },
             {
               id: 'entry-3',
-              component: <TestEntryComponent value="three" />
+              component: TestEntry
             }
           ]
         }
@@ -154,15 +154,15 @@ describe('<PropertiesPanel>', function() {
               entries: [
                 {
                   id: 'entry-1',
-                  component: <TestEntryComponent value="one" />
+                  component: TestEntry
                 },
                 {
                   id: 'entry-2',
-                  component: <TestEntryComponent value="two" />
+                  component: TestEntry
                 },
                 {
                   id: 'entry-3',
-                  component: <TestEntryComponent value="three" />
+                  component: TestEntry
                 }
               ]
             },
@@ -197,7 +197,7 @@ describe('<PropertiesPanel>', function() {
           id: 'group-1',
           label: 'Group 1',
           entries: [],
-          component: TestGroupComponent
+          component: TestGroup
         }
       ];
 
@@ -321,7 +321,7 @@ describe('<PropertiesPanel>', function() {
 });
 
 
-// helpers /////////////////////////
+// helpers //////////
 
 function createPropertiesPanel(options = {}) {
 
@@ -352,16 +352,17 @@ function createPropertiesPanel(options = {}) {
   );
 }
 
-function TestEntryComponent(props) {
+function TestEntry(props) {
   const {
-    value
+    id = 'entry-1',
+    value = 'foo'
   } = props;
 
-  return <div class="bio-properties-panel-entry">
-    { value }
+  return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <input class="bio-properties-panel-input" value={ value } />
   </div>;
 }
 
-function TestGroupComponent() {
+function TestGroup() {
   return <div class="foo-group">foo</div>;
 }

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -34,8 +34,8 @@ describe('<Collapsible>', function() {
     // given
     const entries = [
       {
-        id: 'foo',
-        component: <div class="some-entry">bar</div>
+        id: 'entry-1',
+        component: TestEntry
       }
     ];
 
@@ -46,7 +46,7 @@ describe('<Collapsible>', function() {
 
     // then
     expect(domQuery('.bio-properties-panel-collapsible-entry', container)).to.exist;
-    expect(domQuery('.some-entry', entriesNode)).to.exist;
+    expect(domQuery('.bio-properties-panel-entry', entriesNode)).to.exist;
   });
 
 
@@ -163,7 +163,7 @@ describe('<Collapsible>', function() {
 });
 
 
-// helpers ////////////////////
+// helpers //////////
 
 function createCollapsible(options = {}) {
   const {
@@ -186,4 +186,15 @@ function createCollapsible(options = {}) {
       container
     }
   );
+}
+
+function TestEntry(props) {
+  const {
+    id = 'entry-1',
+    value = 'foo'
+  } = props;
+
+  return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <input class="bio-properties-panel-input" value={ value } />
+  </div>;
 }

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -84,8 +84,7 @@ describe('<Group>', function() {
 
       // given
       const entries = createEntries({
-        isEdited: (node) => !!node.value,
-        entryComponent: <TestEntry id="entry1" />,
+        isEdited: (node) => !!node.value
       });
 
       // when
@@ -104,8 +103,7 @@ describe('<Group>', function() {
 
       // given
       const entries = createEntries({
-        isEdited: () => false,
-        entryComponent: <TestEntry id="entry1" value="foo" />,
+        isEdited: () => false
       });
 
       // when
@@ -125,7 +123,7 @@ describe('<Group>', function() {
       // given
       const entries = createEntries({
         isEdited: (node) => !!node.value,
-        entryComponent: <TestEntry id="entry1" value="foo" />,
+        value: 'foo'
       });
 
       // when
@@ -162,8 +160,7 @@ describe('<Group>', function() {
 
       // given
       const entries = createEntries({
-        isEdited: () => true,
-        entryComponent: <TestEntry id="entry1" value="foo" />,
+        isEdited: () => true
       });
 
       const result = createGroup({ container, label: 'Group', entries });
@@ -198,14 +195,37 @@ describe('<Group>', function() {
 });
 
 
-// helpers ////////////////////
+// helpers ///////////
+
+function createEntries(options = {}) {
+  const {
+    component = TestEntry,
+    isEdited = noop,
+    value
+  } = options;
+
+  return [
+    {
+      id: 'entry-1',
+      component,
+      isEdited,
+      value
+    },
+    {
+      id: 'entry-2'
+    },
+    {
+      id: 'entry-3'
+    }
+  ];
+}
 
 function createGroup(options = {}) {
   const {
+    container,
+    entries = [],
     id,
     label,
-    entries = [],
-    container
   } = options;
 
   return render(
@@ -216,38 +236,13 @@ function createGroup(options = {}) {
   );
 }
 
-function createEntries(overrides = {}) {
-  const {
-    entries = [],
-    isEdited = noop,
-    entryComponent
-  } = overrides;
-
-  const newEntries = [
-    {
-      id: 'entry1',
-      component: entryComponent,
-      isEdited
-    },
-    {
-      id: 'entry2'
-    },
-    {
-      id: 'entry2'
-    },
-    ...entries
-  ];
-
-  return newEntries;
-}
-
-function TestEntry(props) {
+function TestEntry(props = {}) {
   const {
     id,
     value
   } = props;
 
-  return <div data-entry-id={ id }>
-    <input className="bio-properties-panel-input" value={ value }></input>
+  return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <input class="bio-properties-panel-input" value={ value } />
   </div>;
 }

--- a/test/spec/components/List.spec.js
+++ b/test/spec/components/List.spec.js
@@ -162,7 +162,9 @@ describe('<List>', function() {
     it('should auto-focus first input entry added', async function() {
 
       // given
-      const renderItem = item => {
+      const Component = (props) => {
+        const { item } = props;
+
         return <input class="bio-properties-panel-input" data-id={ item.id } />;
       };
 
@@ -184,7 +186,7 @@ describe('<List>', function() {
         items,
         onAdd,
         open: true,
-        renderItem,
+        component: Component,
         compareFn: defaultCompareFn
       };
 
@@ -210,7 +212,9 @@ describe('<List>', function() {
     it('should auto-focus first select on entry added', async function() {
 
       // given
-      const renderItem = item => {
+      const Component = (props) => {
+        const { item } = props;
+
         return <select class="bio-properties-panel-input" data-id={ item.id }>
           <option value="foo">Foo</option>
           <option value="bar">Bar</option>
@@ -235,7 +239,7 @@ describe('<List>', function() {
         items,
         onAdd,
         open: true,
-        renderItem,
+        component: Component,
         compareFn: defaultCompareFn
       };
 
@@ -261,7 +265,9 @@ describe('<List>', function() {
     it('should focus custom input once new input was added given selector', async function() {
 
       // given
-      const renderItem = item => {
+      const Component = (props) => {
+        const { item } = props;
+
         return <input class="bio-properties-panel-input" data-id={ item.id } />;
       };
 
@@ -283,7 +289,7 @@ describe('<List>', function() {
         items,
         onAdd,
         open: true,
-        renderItem,
+        component: Component,
         compareFn: defaultCompareFn
       };
 
@@ -989,7 +995,7 @@ function createListEntry(options = {}, renderFn = render) {
     onRemove,
     open,
     container,
-    renderItem = defaultRenderItem,
+    component = DefaultComponent,
     compareFn,
     autoFocusEntry = false
   } = options;
@@ -1003,7 +1009,7 @@ function createListEntry(options = {}, renderFn = render) {
       onAdd={ onAdd }
       onRemove={ onRemove }
       open={ open }
-      renderItem={ renderItem }
+      component={ component }
       compareFn={ compareFn }
       autoFocusEntry={ autoFocusEntry } />,
     {
@@ -1012,7 +1018,9 @@ function createListEntry(options = {}, renderFn = render) {
   );
 }
 
-function defaultRenderItem(item = {}) {
+function DefaultComponent(props) {
+  const { item = {} } = props;
+
   return <span data-entry-id={ item.id }>Item {item.id}</span>;
 }
 

--- a/test/spec/components/ListItem.spec.js
+++ b/test/spec/components/ListItem.spec.js
@@ -16,9 +16,6 @@ import {
 
 import ListItem from 'src/components/ListItem';
 
-import TextFieldEntry from 'src/components/entries/TextField';
-import SelectEntry from 'src/components/entries/Select';
-
 insertCoreStyles();
 
 
@@ -74,21 +71,33 @@ describe('<ListItem>', function() {
     it('should auto-focus input on list item created', function() {
 
       // given
+      const Component = (props) => {
+        const { id } = props;
+
+        return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+          <input id={ `bio-properties-panel-${ id }` } class="bio-properties-panel-input" />
+        </div>;
+      };
+
       const entries = [
         {
-          id: 'foo',
-          component: <TextFieldEntry debounce={ () => {} } id="foo" getValue={ () => {} } />
+          id: 'entry-1',
+          component: Component
+        },
+        {
+          id: 'entry-2',
+          component: Component
         }
       ];
 
       const result = createListItem({
-        autoFocusEntry: 'foo',
+        autoFocusEntry: 'entry-1',
         autoOpen: true,
         container: parentContainer,
         entries
       });
 
-      const input = domQuery('#bio-properties-panel-foo', result.container);
+      const input = domQuery('#bio-properties-panel-entry-1', result.container);
 
       // then
       expect(document.activeElement).to.equal(input);
@@ -98,21 +107,35 @@ describe('<ListItem>', function() {
     it('should auto-focus select on list item created', function() {
 
       // given
+      const Component = (props) => {
+        const { id } = props;
+
+        return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+          <select id={ `bio-properties-panel-${ id }` } class="bio-properties-panel-input">
+            <option value="option-1">Option 1</option>
+          </select>
+        </div>;
+      };
+
       const entries = [
         {
-          id: 'foo',
-          component: <SelectEntry id="foo" getOptions={ () => [] } getValue={ () => {} } />
+          id: 'entry-1',
+          component: Component
+        },
+        {
+          id: 'entry-2',
+          component: Component
         }
       ];
 
       const result = createListItem({
-        autoFocusEntry: 'foo',
+        autoFocusEntry: 'entry-1',
         autoOpen: true,
         container: parentContainer,
         entries
       });
 
-      const select = domQuery('#bio-properties-panel-foo', result.container);
+      const select = domQuery('#bio-properties-panel-entry-1', result.container);
 
       // then
       expect(document.activeElement).to.equal(select);
@@ -143,21 +166,22 @@ describe('<ListItem>', function() {
 
 function createListItem(options = {}) {
   const {
-    id,
-    label = 'item',
-    entries = [],
-    autoOpen = false,
     autoFocusEntry,
-    container
+    autoOpen = false,
+    container,
+    entries = [],
+    id,
+    label = 'List item'
   } = options;
 
   return render(
     <ListItem
-      id={ id }
-      autoOpen={ autoOpen }
+      { ...options }
       autoFocusEntry={ autoFocusEntry }
-      label={ label }
-      entries={ entries } />,
+      autoOpen={ autoOpen }
+      entries={ entries }
+      id={ id }
+      label={ label } />,
     {
       container
     }


### PR DESCRIPTION
* all group and entry components specified as `component` are actual components, not elements
* props can be passed from parent to child components
* props specified when creating group or entry will be passed to component

---

Required by https://github.com/bpmn-io/bpmn-js-properties-panel/pull/590