### PR TITLE
Be Able to Show Entry and Error through Event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2950,6 +2950,11 @@
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
       "dev": true
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3168,6 +3173,27 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
+    },
+    "diagram-js": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.1.2.tgz",
+      "integrity": "sha512-l0UWjWA9zcO3bwGg2C3sybNEWiICdXdkFy4JRjWdPyOcO00v3T0whuNhLwz9kaS5ht67awnPyKr+RWgsx3H0Rw==",
+      "requires": {
+        "css.escape": "^1.5.1",
+        "didi": "^5.2.1",
+        "hammerjs": "^2.0.1",
+        "inherits": "^2.0.4",
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3",
+        "object-refs": "^0.3.0",
+        "path-intersection": "^2.2.1",
+        "tiny-svg": "^2.2.2"
+      }
+    },
+    "didi": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-5.2.1.tgz",
+      "integrity": "sha512-IKNnajUlD4lWMy/Q9Emkk7H1qnzREgY4UyE3IhmOi/9IKua0JYtYldk928bOdt1yNxN8EiOy1sqtSozEYsmjCg=="
     },
     "diff": {
       "version": "5.0.0",
@@ -4499,6 +4525,11 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
+    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -4733,8 +4764,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -6362,6 +6392,11 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
+    "object-refs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.3.0.tgz",
+      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ=="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -6564,6 +6599,11 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
+    },
+    "path-intersection": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -8213,6 +8253,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tiny-svg": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
+      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
     },
     "tinydate": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "^2.3.1",
+    "diagram-js": "^8.1.2",
     "min-dash": "^3.7.0",
     "min-dom": "^3.1.3"
   },

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -16,15 +16,24 @@ import Header from './components/Header';
 import Group from './components/Group';
 
 import {
+  DescriptionContext,
+  EventContext,
   LayoutContext,
-  DescriptionContext
+  PropertiesPanelContext
 } from './context';
+
+import { useEventBuffer } from './hooks';
 
 const DEFAULT_LAYOUT = {
   open: true
 };
 
 const DEFAULT_DESCRIPTION = {};
+
+const bufferedEvents = [
+  'propertiesPanel.showEntry',
+  'propertiesPanel.showError'
+];
 
 
 /**
@@ -95,7 +104,8 @@ export default function PropertiesPanel(props) {
     layoutConfig = {},
     layoutChanged,
     descriptionConfig = {},
-    descriptionLoaded
+    descriptionLoaded,
+    eventBus
   } = props;
 
   // set-up layout context
@@ -140,40 +150,57 @@ export default function PropertiesPanel(props) {
     getDescriptionForId
   };
 
+  useEventBuffer(bufferedEvents, eventBus);
+
+  const eventContext = {
+    eventBus
+  };
+
+  const propertiesPanelContext = {
+    element
+  };
+
   if (!element) {
     return <div class="bio-properties-panel-placeholder">Select an element to edit its properties.</div>;
   }
 
-  return <DescriptionContext.Provider value={ descriptionContext }>
-    <LayoutContext.Provider value={ layoutContext }>
-      <div
-        class={ classnames(
-          'bio-properties-panel',
-          layout.open ? 'open' : '')
-        }>
-        <Header
-          element={ element }
-          headerProvider={ headerProvider } />
-        <div class="bio-properties-panel-scroll-container">
-          {
-            groups.map(group => {
-              const {
-                component: Component = Group,
-                id
-              } = group;
+  return (
+    <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
 
-              return (
-                <Component
-                  { ...group }
-                  key={ id }
-                  element={ element } />
-              );
-            })
-          }
-        </div>
-      </div>
-    </LayoutContext.Provider>
-  </DescriptionContext.Provider>;
+      <DescriptionContext.Provider value={ descriptionContext }>
+        <LayoutContext.Provider value={ layoutContext }>
+          <EventContext.Provider value={ eventContext }>
+            <div
+              class={ classnames(
+                'bio-properties-panel',
+                layout.open ? 'open' : '')
+              }>
+              <Header
+                element={ element }
+                headerProvider={ headerProvider } />
+              <div class="bio-properties-panel-scroll-container">
+                {
+                  groups.map(group => {
+                    const {
+                      component: Component = Group,
+                      id
+                    } = group;
+
+                    return (
+                      <Component
+                        { ...group }
+                        key={ id }
+                        element={ element } />
+                    );
+                  })
+                }
+              </div>
+            </div>
+          </EventContext.Provider>
+        </LayoutContext.Provider>
+      </DescriptionContext.Provider>
+    </PropertiesPanelContext.Provider>
+  );
 }
 
 

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -1,4 +1,6 @@
 import {
+  useCallback,
+  useContext,
   useEffect,
   useState
 } from 'preact/hooks';
@@ -17,6 +19,8 @@ import {
   useLayoutState
 } from '../hooks';
 
+import { PropertiesPanelContext } from '../context';
+
 import { ArrowIcon } from './icons';
 
 /**
@@ -34,6 +38,9 @@ export default function Group(props) {
     [ 'groups', id, 'open' ],
     false
   );
+
+  const onShow = useCallback(() => setOpen(true), [ setOpen ]);
+
   const toggleOpen = () => setOpen(!open);
 
   const [ edited, setEdited ] = useState(false);
@@ -60,6 +67,11 @@ export default function Group(props) {
     setEdited(hasOneEditedEntry);
   }, [ entries ]);
 
+  const propertiesPanelContext = {
+    ...useContext(PropertiesPanelContext),
+    onShow
+  };
+
   return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id }>
     <div class={ classnames(
       'bio-properties-panel-group-header',
@@ -85,21 +97,23 @@ export default function Group(props) {
       'bio-properties-panel-group-entries',
       open ? 'open' : ''
     ) }>
-      {
-        entries.map(entry => {
-          const {
-            component: Component,
-            id
-          } = entry;
+      <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
+        {
+          entries.map(entry => {
+            const {
+              component: Component,
+              id
+            } = entry;
 
-          return (
-            <Component
-              { ...entry }
-              key={ id }
-              element={ element } />
-          );
-        })
-      }
+            return (
+              <Component
+                { ...entry }
+                element={ element }
+                key={ id } />
+            );
+          })
+        }
+      </PropertiesPanelContext.Provider>
     </div>
   </div>;
 }

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -1,4 +1,6 @@
 import {
+  useCallback,
+  useContext,
   useEffect,
   useState
 } from 'preact/hooks';
@@ -22,6 +24,8 @@ import {
   CreateIcon
 } from './icons';
 
+import { PropertiesPanelContext } from '../context';
+
 const noop = () => {};
 
 /**
@@ -43,6 +47,8 @@ export default function ListGroup(props) {
     [ 'groups', id, 'open' ],
     false
   );
+
+  const onShow = useCallback(() => setOpen(true), [ setOpen ]);
 
   const [ ordering, setOrdering ] = useState([]);
   const [ newItemAdded, setNewItemAdded ] = useState(false);
@@ -133,6 +139,11 @@ export default function ListGroup(props) {
 
   const hasItems = !!items.length;
 
+  const propertiesPanelContext = {
+    ...useContext(PropertiesPanelContext),
+    onShow
+  };
+
   return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id }>
     <div
       class={ classnames(
@@ -197,28 +208,32 @@ export default function ListGroup(props) {
       'bio-properties-panel-list',
       open && hasItems ? 'open' : ''
     ) }>
-      {
-        ordering.map((o, index) => {
-          const item = getItem(items, o);
+      <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
 
-          if (!item) {
-            return;
-          }
+        {
+          ordering.map((o, index) => {
+            const item = getItem(items, o);
 
-          const { id } = item;
+            if (!item) {
+              return;
+            }
 
-          return (
-            <ListItem
-              { ...item }
-              element={ element }
-              index={ index }
-              key={ id }
+            const { id } = item;
 
-              // if item was added, open first or last item based on ordering
-              autoOpen={ newItemAdded && (shouldSort ? index === 0 : index === ordering.length - 1) } />
-          );
-        })
-      }
+            // if item was added, open first or last item based on ordering
+            const autoOpen = newItemAdded && (shouldSort ? index === 0 : index === ordering.length - 1);
+
+            return (
+              <ListItem
+                { ...item }
+                autoOpen={ autoOpen }
+                element={ element }
+                index={ index }
+                key={ id } />
+            );
+          })
+        }
+      </PropertiesPanelContext.Provider>
     </div>
   </div>;
 }

--- a/src/components/entries/Checkbox.js
+++ b/src/components/entries/Checkbox.js
@@ -1,4 +1,11 @@
+import {
+  useShowEntryEvent,
+  useShowErrorEvent
+} from '../../hooks';
+
 import Description from './Description';
+
+const noop = () => {};
 
 function Checkbox(props) {
   const {
@@ -6,16 +13,20 @@ function Checkbox(props) {
     label,
     onChange,
     disabled,
-    value = false
+    value = false,
+    show = noop
   } = props;
 
   const handleChange = ({ target }) => {
     onChange(target.checked);
   };
 
+  const ref = useShowEntryEvent(show);
+
   return (
     <div class="bio-properties-panel-checkbox">
       <input
+        ref={ ref }
         id={ prefixId(id) }
         name={ id }
         type="checkbox"
@@ -47,14 +58,24 @@ export default function CheckboxEntry(props) {
     label,
     getValue,
     setValue,
-    disabled
+    disabled,
+    show = noop
   } = props;
 
   const value = getValue(element);
 
+  const error = useShowErrorEvent(show, [ element, value ]);
+
   return (
     <div class="bio-properties-panel-entry bio-properties-panel-checkbox-entry" data-entry-id={ id }>
-      <Checkbox id={ id } label={ label } onChange={ setValue } value={ value } disabled={ disabled } />
+      <Checkbox
+        disabled={ disabled }
+        id={ id }
+        label={ label }
+        onChange={ setValue }
+        show={ show }
+        value={ value } />
+      { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );

--- a/src/components/entries/Collapsible.js
+++ b/src/components/entries/Collapsible.js
@@ -1,13 +1,19 @@
 import {
+  useCallback,
+  useContext,
   useState
 } from 'preact/hooks';
 
 import classnames from 'classnames';
 
+import { isFunction } from 'min-dash';
+
 import {
   ArrowIcon,
   DeleteIcon,
 } from '../icons';
+
+import { PropertiesPanelContext } from '../../context';
 
 
 export default function CollapsibleEntry(props) {
@@ -23,6 +29,19 @@ export default function CollapsibleEntry(props) {
   const [ open, setOpen ] = useState(shouldOpen);
 
   const toggleOpen = () => setOpen(!open);
+
+  const { onShow } = useContext(PropertiesPanelContext);
+
+  const propertiesPanelContext = {
+    ...useContext(PropertiesPanelContext),
+    onShow: useCallback(() => {
+      setOpen(true);
+
+      if (isFunction(onShow)) {
+        onShow();
+      }
+    }, [ onShow, setOpen ])
+  };
 
   // todo(pinussilvestrus): translate once we have a translate mechanism for the core
   const placeholderLabel = '<empty>';
@@ -64,19 +83,21 @@ export default function CollapsibleEntry(props) {
         'bio-properties-panel-collapsible-entry-entries',
         open ? 'open' : ''
       ) }>
-        {
-          entries.map(entry => {
-            const {
-              component: Component,
-              id
-            } = entry;
+        <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
+          {
+            entries.map(entry => {
+              const {
+                component: Component,
+                id
+              } = entry;
 
-            return <Component
-              { ...entry }
-              key={ id }
-              element={ element } />;
-          })
-        }
+              return <Component
+                { ...entry }
+                element={ element }
+                key={ id } />;
+            })
+          }
+        </PropertiesPanelContext.Provider>
       </div>
     </div>
   );

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -1,4 +1,13 @@
+import classNames from 'classnames';
+
+import {
+  useShowEntryEvent,
+  useShowErrorEvent
+} from '../../hooks';
+
 import Description from './Description';
+
+const noop = () => {};
 
 /**
  * @typedef { { value: string, label: string, disabled: boolean } } Option
@@ -9,6 +18,7 @@ import Description from './Description';
  *
  * @param {object} props
  * @param {string} props.id
+ * @param {string[]} props.path
  * @param {string} props.label
  * @param {Function} props.onChange
  * @param {Array<Option>} [props.options]
@@ -22,8 +32,11 @@ function Select(props) {
     onChange,
     options = [],
     value,
-    disabled
+    disabled,
+    show = noop
   } = props;
+
+  const ref = useShowEntryEvent(show);
 
   const handleChange = ({ target }) => {
     onChange(target.value);
@@ -33,6 +46,7 @@ function Select(props) {
     <div class="bio-properties-panel-select">
       <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label>
       <select
+        ref={ ref }
         id={ prefixId(id) }
         name={ id }
         class="bio-properties-panel-input"
@@ -77,21 +91,31 @@ export default function SelectEntry(props) {
     getValue,
     setValue,
     getOptions,
-    disabled
+    disabled,
+    show = noop
   } = props;
 
   const value = getValue(element);
   const options = getOptions(element);
 
+  const error = useShowErrorEvent(show, [ element, value ]);
+
   return (
-    <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <div
+      class={ classNames(
+        'bio-properties-panel-entry',
+        error ? 'has-error' : '')
+      }
+      data-entry-id={ id }>
       <Select
         id={ id }
         label={ label }
         value={ value }
         onChange={ setValue }
         options={ options }
-        disabled={ disabled } />
+        disabled={ disabled }
+        show={ show } />
+      { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );

--- a/src/context/EventContext.js
+++ b/src/context/EventContext.js
@@ -18,7 +18,7 @@
  *
  * @example
  *
- * useEvent('propertiesPanel.showEntry', ({ error, focus = false, ...rest }) => {
+ * useEvent('propertiesPanel.showError', ({ error, focus = false, ...rest }) => {
  *   // ...
  * });
  *

--- a/src/context/EventContext.js
+++ b/src/context/EventContext.js
@@ -1,0 +1,40 @@
+/**
+ * @typedef {Function} <propertiesPanel.showEntry> callback
+ *
+ * @example
+ *
+ * useEvent('propertiesPanel.showEntry', ({ focus = false, ...rest }) => {
+ *   // ...
+ * });
+ *
+ * @param {Object} context
+ * @param {boolean} [context.focus]
+ *
+ * @returns void
+ */
+
+/**
+ * @typedef {Function} <propertiesPanel.showError> callback
+ *
+ * @example
+ *
+ * useEvent('propertiesPanel.showEntry', ({ error, focus = false, ...rest }) => {
+ *   // ...
+ * });
+ *
+ * @param {Object} context
+ * @param {string} context.error
+ * @param {boolean} [context.focus]
+ *
+ * @returns void
+ */
+
+import { createContext } from 'preact';
+
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+const eventBus = new EventBus();
+
+const EventContext = createContext({ eventBus });
+
+export default EventContext;

--- a/src/context/PropertiesPanelContext.js
+++ b/src/context/PropertiesPanelContext.js
@@ -1,0 +1,10 @@
+import { createContext } from 'preact';
+
+const PropertiesPanelContext = createContext({
+
+  // TODO: get element through context instead of props
+  element: null,
+  onShow: () => {}
+});
+
+export default PropertiesPanelContext;

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,2 +1,4 @@
 export { default as DescriptionContext } from './DescriptionContext';
+export { default as EventContext } from './EventContext';
 export { default as LayoutContext } from './LayoutContext';
+export { default as PropertiesPanelContext } from './LayoutContext';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,4 +1,8 @@
-export { default as usePrevious } from './usePrevious';
+export { useDescriptionContext } from './useDescriptionContext';
+export { useEvent } from './useEvent';
+export { useEventBuffer } from './useEventBuffer';
 export { useKeyFactory } from './useKeyFactory';
 export { useLayoutState } from './useLayoutState';
-export { useDescriptionContext } from './useDescriptionContext';
+export { usePrevious } from './usePrevious';
+export { useShowEntryEvent } from './useShowEntryEvent';
+export { useShowErrorEvent } from './useShowErrorEvent';

--- a/src/hooks/useEvent.js
+++ b/src/hooks/useEvent.js
@@ -1,0 +1,25 @@
+import { useContext, useEffect } from 'preact/hooks';
+
+import { EventContext } from '../context';
+
+const DEFAULT_PRIORITY = 1000;
+
+
+/**
+ * Subscribe to an event.
+ *
+ * @param {string} event
+ * @param {Function} callback
+ * @param {number} [priority]
+ *
+ * @returns {import('preact').Ref}
+ */
+export function useEvent(event, callback, priority = DEFAULT_PRIORITY) {
+  const { eventBus } = useContext(EventContext);
+
+  useEffect(() => {
+    eventBus.on(event, priority, callback);
+
+    return () => eventBus.off(event, callback);
+  }, [ event, eventBus, callback, priority ]);
+}

--- a/src/hooks/useEventBuffer.js
+++ b/src/hooks/useEventBuffer.js
@@ -1,0 +1,62 @@
+import {
+  useEffect,
+  useRef
+} from 'preact/hooks';
+
+const HIGH_PRIORITY = 10000;
+
+
+/**
+ * Buffer events and re-fire during passive effect phase.
+ *
+ * @param {string[]} bufferedEvents
+ * @param {Object} [eventBus]
+ */
+export function useEventBuffer(bufferedEvents, eventBus) {
+  const buffer = useRef([]),
+        buffering = useRef(true);
+
+  const createCallback = (event) => (data) => {
+    if (buffering.current === true) {
+      buffer.current.unshift([ event, data ]);
+    }
+  };
+
+  // (1) buffer events
+  useEffect(() => {
+    if (!eventBus) {
+      return;
+    }
+
+    const listeners = bufferedEvents.map((event) => {
+      return [ event, createCallback(event) ];
+    });
+
+    listeners.forEach(([ event, callback ]) => {
+      eventBus.on(event, HIGH_PRIORITY, callback);
+    });
+
+    return () => {
+      listeners.forEach(([ event, callback ]) => {
+        eventBus.off(event, callback);
+      });
+    };
+  }, [ bufferedEvents, eventBus ]);
+
+  // (2) re-fire events
+  useEffect(() => {
+    if (!eventBus) {
+      return;
+    }
+
+    buffering.current = false;
+
+    while (buffer.current.length) {
+      const [ event, data ] = buffer.current.pop();
+
+      eventBus.fire(event, data);
+    }
+
+    buffering.current = true;
+  });
+}

--- a/src/hooks/usePrevious.js
+++ b/src/hooks/usePrevious.js
@@ -10,7 +10,7 @@ import {
  * cf. https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
  */
 
-export default function usePrevious(value) {
+export function usePrevious(value) {
   const ref = useRef();
   useEffect(() => {
     ref.current = value;

--- a/src/hooks/useShowEntryEvent.js
+++ b/src/hooks/useShowEntryEvent.js
@@ -1,0 +1,58 @@
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState
+} from 'preact/hooks';
+
+import { isFunction } from 'min-dash';
+
+import { PropertiesPanelContext } from '../context';
+
+import { useEvent } from './useEvent';
+
+/**
+ * Subscribe to `propertiesPanel.showEntry`.
+ *
+ * @param {Function} show
+ *
+ * @returns {import('preact').Ref}
+ */
+export function useShowEntryEvent(show) {
+  const { onShow } = useContext(PropertiesPanelContext);
+
+  const ref = useRef();
+
+  const [ focus, setFocus ] = useState(false);
+
+  const onShowEntry = useCallback((event) => {
+    if (show(event)) {
+      if (isFunction(onShow)) {
+        onShow();
+      }
+
+      if (event.focus) {
+        setFocus(true);
+      }
+    }
+  }, [ show ]);
+
+  useEffect(() => {
+    if (focus && ref.current) {
+      if (isFunction(ref.current.focus)) {
+        ref.current.focus();
+      }
+
+      if (isFunction(ref.current.select)) {
+        ref.current.select();
+      }
+
+      setFocus(false);
+    }
+  }, [ focus ]);
+
+  useEvent('propertiesPanel.showEntry', onShowEntry);
+
+  return ref;
+}

--- a/src/hooks/useShowErrorEvent.js
+++ b/src/hooks/useShowErrorEvent.js
@@ -1,0 +1,42 @@
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useState
+} from 'preact/hooks';
+
+import { EventContext } from '../context';
+
+import { useEvent } from './useEvent';
+
+/**
+ * Subscribe to `propertiesPanel.showError`. On `propertiesPanel.showError` set
+ * temporary error. Unset error on inputs change. Fire
+ * `propertiesPanel.showEntry` for temporary error to be visible.
+ *
+ * @param {Function} show
+ * @param {any[]} [inputs]
+ *
+ * @returns {import('preact').Ref}
+ */
+export function useShowErrorEvent(show, inputs = []) {
+  const { eventBus } = useContext(EventContext);
+
+  const [ temporaryError, setTemporaryError ] = useState(null);
+
+  useEffect(() => setTemporaryError(null), inputs);
+
+  const onShowError = useCallback((event) => {
+    setTemporaryError(null);
+
+    if (show(event)) {
+      eventBus.fire('propertiesPanel.showEntry', event);
+
+      setTemporaryError(event.error);
+    }
+  }, [ show ]);
+
+  useEvent('propertiesPanel.showError', onShowError);
+
+  return temporaryError;
+}

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -1,3 +1,5 @@
+import { useContext } from 'preact/hooks';
+
 import {
   act,
   render
@@ -14,6 +16,8 @@ import {
   expectNoViolations,
   insertCoreStyles
 } from 'test/TestHelper';
+
+import { PropertiesPanelContext } from 'src/context';
 
 import Collapsible from 'src/components/entries/Collapsible';
 
@@ -107,6 +111,34 @@ describe('<Collapsible>', function() {
 
     // when
     await header.click();
+
+    // then
+    expect(domClasses(entries).has('open')).to.be.true;
+  });
+
+
+  it('should provide onShow through context', async function() {
+
+    // given
+    const Entry = () => {
+      const { onShow } = useContext(PropertiesPanelContext);
+
+      onShow();
+    };
+
+    const { container } = createCollapsible({
+      container: parentContainer,
+      entries: [
+        {
+          id: 'foo',
+          component: Entry
+        }
+      ]
+    });
+
+    const entry = domQuery('.bio-properties-panel-collapsible-entry', container);
+
+    const entries = domQuery('.bio-properties-panel-collapsible-entry-entries', entry);
 
     // then
     expect(domClasses(entries).has('open')).to.be.true;

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -1,3 +1,5 @@
+import { useContext } from 'preact/hooks';
+
 import {
   render
 } from '@testing-library/preact/pure';
@@ -16,6 +18,8 @@ import {
 } from 'test/TestHelper';
 
 import Group from 'src/components/Group';
+
+import { PropertiesPanelContext } from 'src/context';
 
 insertCoreStyles();
 
@@ -55,6 +59,30 @@ describe('<Group>', function() {
 
     // when
     await header.click();
+
+    // then
+    expect(domClasses(entries).has('open')).to.be.true;
+  });
+
+
+  it('should provide onShow through context', async function() {
+
+    // given
+    const Entry = () => {
+      const { onShow } = useContext(PropertiesPanelContext);
+
+      onShow();
+    };
+
+    const result = createGroup({
+      container,
+      entries: createEntries({
+        component: Entry
+      }),
+      label: 'Group'
+    });
+
+    const entries = domQuery('.bio-properties-panel-group-entries', result.container);
 
     // then
     expect(domClasses(entries).has('open')).to.be.true;

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -1,3 +1,5 @@
+import { useContext } from 'preact/hooks';
+
 import {
   act,
   render,
@@ -19,6 +21,8 @@ import {
 } from 'test/TestHelper';
 
 import ListGroup from 'src/components/ListGroup';
+
+import { PropertiesPanelContext } from 'src/context';
 
 insertCoreStyles();
 
@@ -54,11 +58,11 @@ describe('<ListGroup>', function() {
     // given
     const items = [
       {
-        id: 'foo',
+        id: 'item-1',
         label: 'Item 1'
       },
       {
-        id: 'bar',
+        id: 'item-2',
         label: 'Item 2'
       }
     ];
@@ -100,7 +104,7 @@ describe('<ListGroup>', function() {
     // given
     const items = [
       {
-        id: 'foo',
+        id: 'item-1',
         label: 'Item 1'
       }
     ];
@@ -118,6 +122,37 @@ describe('<ListGroup>', function() {
     await act(() => {
       header.click();
     });
+
+    // then
+    expect(domClasses(list).has('open')).to.be.true;
+  });
+
+
+  it('should provide onShow through context', async function() {
+
+    // given
+    const Entry = () => {
+      const { onShow } = useContext(PropertiesPanelContext);
+
+      onShow();
+    };
+
+    const items = [
+      {
+        id: 'item-1',
+        label: 'Item 1',
+        entries: [
+          {
+            id: 'entry-1',
+            component: Entry
+          }
+        ]
+      }
+    ];
+
+    const { container } = createListGroup({ container: parentContainer, items });
+
+    const list = domQuery('.bio-properties-panel-list', container);
 
     // then
     expect(domClasses(list).has('open')).to.be.true;
@@ -165,19 +200,19 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item D'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item A'
           },
           {
             id: 'item-3',
-            label: 'def03'
+            label: 'Item B'
           },
           {
             id: 'item-4',
-            label: 'def04'
+            label: 'Item C'
           }
         ];
 
@@ -208,15 +243,15 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'Item 1'
+            label: 'Item A'
           },
           {
             id: 'item-2',
-            label: 'Item 2'
+            label: 'Item B'
           },
           {
             id: 'item-3',
-            label: 'Item 2'
+            label: 'Item C'
           }
         ];
 
@@ -239,15 +274,15 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item 1'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item 2'
           },
           {
             id: 'item-3',
-            label: 'def03'
+            label: 'Item 3'
           }
         ];
 
@@ -282,15 +317,15 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item C'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item A'
           },
           {
             id: 'item-3',
-            label: 'def03'
+            label: 'Item B'
           }
         ];
 
@@ -325,19 +360,19 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item 1'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item 2'
           },
           {
             id: 'item-3',
-            label: 'def03'
+            label: 'Item 3'
           },
           {
             id: 'item-4',
-            label: 'def04'
+            label: 'Item 4'
           }
         ];
 
@@ -368,19 +403,19 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item D'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item A'
           },
           {
             id: 'item-3',
-            label: 'def03'
+            label: 'Item B'
           },
           {
             id: 'item-4',
-            label: 'def04'
+            label: 'Item C'
           }
         ];
 
@@ -462,11 +497,11 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item C'
           },
           {
             id: 'item-2',
-            label: 'ab'
+            label: 'Item A'
           }
         ];
 
@@ -479,7 +514,7 @@ describe('<ListGroup>', function() {
           ...items,
           {
             id: 'item-3',
-            label: 'foo'
+            label: 'Item B'
           }
         ];
 
@@ -509,15 +544,15 @@ describe('<ListGroup>', function() {
         const items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item C'
           },
           {
             id: 'item-2',
-            label: 'abc'
+            label: 'Item A'
           },
           {
             id: 'item-3',
-            label: 'foo'
+            label: 'Item B'
           }
         ];
 
@@ -561,11 +596,11 @@ describe('<ListGroup>', function() {
         let items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item D'
           },
           {
             id: 'item-2',
-            label: 'abc'
+            label: 'Item A'
           }
         ];
 
@@ -595,7 +630,7 @@ describe('<ListGroup>', function() {
           ...items,
           {
             id: 'item-3',
-            label: 'foo'
+            label: 'Item B'
           }
         ];
 
@@ -614,7 +649,7 @@ describe('<ListGroup>', function() {
           ...items,
           {
             id: 'item-4',
-            label: 'goo'
+            label: 'Item C'
           }
         ];
 
@@ -655,11 +690,11 @@ describe('<ListGroup>', function() {
         let items = [
           {
             id: 'item-1',
-            label: 'xyz'
+            label: 'Item C'
           },
           {
             id: 'item-2',
-            label: 'abc'
+            label: 'Item A'
           }
         ];
 
@@ -689,7 +724,7 @@ describe('<ListGroup>', function() {
           ...items,
           {
             id: 'item-3',
-            label: 'foo'
+            label: 'Item B'
           }
         ];
 
@@ -1018,11 +1053,11 @@ describe('<ListGroup>', function() {
       // given
       const items = [
         {
-          id: 'foo',
+          id: 'item-1',
           label: 'Item 1'
         },
         {
-          id: 'bar',
+          id: 'item-2',
           label: 'Item 2'
         }
       ];

--- a/test/spec/hooks/useEvent.spec.js
+++ b/test/spec/hooks/useEvent.spec.js
@@ -1,0 +1,101 @@
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { EventContext } from 'src/context';
+
+import { useEvent } from 'src/hooks';
+
+const noop = () => {};
+
+const DEFAULT_PRIORITY = 1000;
+
+
+describe('hooks/useEvent', function() {
+
+  let eventBus;
+
+  beforeEach(function() {
+    eventBus = new EventBus();
+  });
+
+
+  it('should subscribe', function() {
+
+    // given
+    const onSpy = sinon.spy(eventBus, 'on');
+
+    // when
+    renderHook(() => useEvent('foo', noop), { wrapper: WithEventContext(eventBus) });
+
+    // then
+    expect(onSpy).to.have.been.calledOnceWith('foo', DEFAULT_PRIORITY, noop);
+  });
+
+
+  it('should call callback', function() {
+
+    // given
+    const onSpy = sinon.spy(eventBus, 'on');
+
+    const callbackSpy = sinon.spy();
+
+    // when
+    renderHook(() => useEvent('foo', callbackSpy), { wrapper: WithEventContext(eventBus) });
+
+    const event = { foo: 'bar' };
+
+    eventBus.fire('foo', event);
+
+    // then
+    expect(onSpy).to.have.been.calledOnceWith('foo', DEFAULT_PRIORITY, callbackSpy);
+
+    expect(callbackSpy).to.have.been.calledOnce;
+    expect(callbackSpy).to.have.been.always.calledWithMatch(event);
+  });
+
+
+  it('should unsubscribe', function() {
+
+    // given
+    const onSpy = sinon.spy(eventBus, 'on');
+    const offSpy = sinon.spy(eventBus, 'off');
+
+    const callbackSpy = sinon.spy();
+
+    // when
+    const { unmount } = renderHook(() => useEvent('foo', callbackSpy), { wrapper: WithEventContext(eventBus) });
+
+    unmount();
+
+    const event = { foo: 'bar' };
+
+    eventBus.fire('foo', event);
+
+    // then
+    expect(onSpy).to.have.been.calledOnceWith('foo', DEFAULT_PRIORITY, callbackSpy);
+    expect(offSpy).to.have.been.calledOnceWith('foo', callbackSpy);
+
+    expect(callbackSpy).not.to.have.been.called;
+  });
+
+});
+
+
+// helpers //////////
+
+function WithEventContext(eventBus) {
+  return function Wrapper(props) {
+    const { children } = props;
+
+    const eventContext = {
+      eventBus
+    };
+
+    return (
+      <EventContext.Provider value={ eventContext }>
+        { children }
+      </EventContext.Provider>
+    );
+  };
+}

--- a/test/spec/hooks/useEventBuffer.spec.js
+++ b/test/spec/hooks/useEventBuffer.spec.js
@@ -1,0 +1,87 @@
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { EventContext } from 'src/context';
+
+import { useEventBuffer } from 'src/hooks';
+
+
+describe('hooks/useEventBuffer', function() {
+
+  let eventBus;
+
+  beforeEach(function() {
+    eventBus = new EventBus();
+  });
+
+
+  it('should buffer event', function() {
+
+    // given
+    const fooSpy = sinon.spy();
+
+    // when
+    const { rerender } = renderHook(() => useEventBuffer([ 'foo' ], eventBus), { wrapper: WithEventContext(eventBus) });
+
+    eventBus.fire('foo', { value: 'foo' });
+
+    expect(fooSpy).not.to.have.been.called;
+
+    eventBus.on('foo', fooSpy);
+
+    rerender();
+
+    // then
+    expect(fooSpy).to.have.been.calledOnce;
+
+    expect(fooSpy.getCall(0).args[ 0 ]).to.include({ value: 'foo' });
+  });
+
+
+  it('should buffer events', function() {
+
+    // given
+    const fooSpy = sinon.spy();
+
+    // when
+    const { rerender } = renderHook(() => useEventBuffer([ 'foo' ], eventBus), { wrapper: WithEventContext(eventBus) });
+
+    eventBus.fire('foo', { value: 'foo' });
+    eventBus.fire('foo', { value: 'bar' });
+    eventBus.fire('foo', { value: 'baz' });
+
+    expect(fooSpy).not.to.have.been.called;
+
+    eventBus.on('foo', fooSpy);
+
+    rerender();
+
+    // then
+    expect(fooSpy).to.have.been.calledThrice;
+
+    expect(fooSpy.getCall(0).args[ 0 ]).to.include({ value: 'foo' });
+    expect(fooSpy.getCall(1).args[ 0 ]).to.include({ value: 'bar' });
+    expect(fooSpy.getCall(2).args[ 0 ]).to.include({ value: 'baz' });
+  });
+
+});
+
+
+// helpers //////////
+
+function WithEventContext(eventBus) {
+  return function Wrapper(props) {
+    const { children } = props;
+
+    const eventContext = {
+      eventBus
+    };
+
+    return (
+      <EventContext.Provider value={ eventContext }>
+        { children }
+      </EventContext.Provider>
+    );
+  };
+}

--- a/test/spec/hooks/useShowEntryEvent.spec.js
+++ b/test/spec/hooks/useShowEntryEvent.spec.js
@@ -1,0 +1,116 @@
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import {
+  EventContext,
+  PropertiesPanelContext
+} from 'src/context';
+
+import { useShowEntryEvent } from 'src/hooks';
+
+const noop = () => {};
+
+
+describe('hooks/useShowEntryEvent', function() {
+
+  let eventBus;
+
+  beforeEach(function() {
+    eventBus = new EventBus();
+  });
+
+
+  it('should call onShow', function() {
+
+    // given
+    const show = () => true;
+
+    const onShowSpy = sinon.spy();
+
+    renderHook(() => {
+      const ref = useShowEntryEvent(show);
+
+      return <input id="foo" ref={ ref } />;
+    }, { wrapper: WithContext(eventBus, onShowSpy) });
+
+    // when
+
+    eventBus.fire('propertiesPanel.showEntry');
+
+    // then
+    expect(onShowSpy).to.have.been.called;
+  });
+
+
+  it('should call focus', function() {
+
+    // given
+    const show = () => true;
+
+    const focusSpy = sinon.spy();
+
+    const { rerender } = renderHook(() => {
+      const ref = useShowEntryEvent(show);
+
+      ref.current = { focus: focusSpy };
+    }, { wrapper: WithContext(eventBus, noop) });
+
+    // when
+    eventBus.fire('propertiesPanel.showEntry', { focus: true });
+
+    rerender();
+
+    // then
+    expect(focusSpy).to.have.been.called;
+  });
+
+
+  it('should call select', function() {
+
+    // given
+    const show = () => true;
+
+    const selectSpy = sinon.spy();
+
+    const { rerender } = renderHook(() => {
+      const ref = useShowEntryEvent(show);
+
+      ref.current = { select: selectSpy };
+    }, { wrapper: WithContext(eventBus, noop) });
+
+    // when
+    eventBus.fire('propertiesPanel.showEntry', { focus: true });
+
+    rerender();
+
+    // then
+    expect(selectSpy).to.have.been.called;
+  });
+
+});
+
+
+// helpers //////////
+
+function WithContext(eventBus, onShow = noop) {
+  return function Wrapper(props) {
+    const { children } = props;
+
+    const propertiesPanelContext = {
+      onShow
+    };
+
+    const eventContext = {
+      eventBus
+    };
+
+    return (
+      <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
+        <EventContext.Provider value={ eventContext }>
+          { children }
+        </EventContext.Provider>
+      </PropertiesPanelContext.Provider>
+    );
+  };
+}

--- a/test/spec/hooks/useShowErrorEvent.spec.js
+++ b/test/spec/hooks/useShowErrorEvent.spec.js
@@ -1,0 +1,114 @@
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import { act } from 'preact/test-utils';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { EventContext } from 'src/context';
+
+import { useShowErrorEvent } from 'src/hooks';
+
+const noop = () => {};
+
+
+describe('hooks/useShowErrorEvent', function() {
+
+  let eventBus;
+
+  beforeEach(function() {
+    eventBus = new EventBus();
+  });
+
+
+  it('should set temporary error', function() {
+
+    // given
+    const show = () => true;
+
+    const onShowSpy = sinon.spy();
+
+    let temporaryError;
+
+    renderHook(() => {
+      temporaryError = useShowErrorEvent(show, []);
+    }, { wrapper: WithEventContext(eventBus, onShowSpy) });
+
+    // when
+    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+
+    // then
+    expect(temporaryError).to.have.equal('foo');
+  });
+
+
+  it('should fire propertiesPanel.showEntry', function() {
+
+    // given
+    const show = () => true;
+
+    const showEntrySpy = sinon.spy();
+
+    eventBus.on('propertiesPanel.showEntry', showEntrySpy);
+
+    renderHook(() => {
+      useShowErrorEvent(show, []);
+    }, { wrapper: WithEventContext(eventBus, noop) });
+
+    // when
+    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+
+    // then
+    expect(showEntrySpy).to.have.been.calledOnce;
+    expect(showEntrySpy).to.have.been.calledWithMatch({ error: 'foo' });
+  });
+
+
+  it('should unset temporary error on inputs changed', function() {
+
+    // given
+    const show = () => true;
+
+    const onShowSpy = sinon.spy();
+
+    let temporaryError;
+
+    const { rerender } = renderHook(({ inputs }) => {
+      temporaryError = useShowErrorEvent(show, inputs);
+    }, {
+      initialProps: {
+        inputs: [ 'foo' ]
+      },
+      wrapper: WithEventContext(eventBus, onShowSpy)
+    });
+
+    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+
+    expect(temporaryError).to.have.equal('foo');
+
+    // when
+    act(() => rerender({ inputs: [ 'bar' ] }));
+
+    // then
+    expect(temporaryError).to.be.null;
+  });
+
+});
+
+
+// helpers //////////
+
+function WithEventContext(eventBus) {
+  return function Wrapper(props) {
+    const { children } = props;
+
+    const eventContext = {
+      eventBus
+    };
+
+    return (
+      <EventContext.Provider value={ eventContext }>
+        { children }
+      </EventContext.Provider>
+    );
+  };
+}


### PR DESCRIPTION
## Events

`EventContext` is introduced. Through this context, one can subscribe to events using the `useEvent` hook.

```js
function Foo() {
  useEvent('foo', (event) => console.log(event));

  // ...
}
```

## Event Buffering

The `useEventBuffer` hook is introduced to buffer events that will be re-fired during the passive effect phase. If a component is rendered after an event was fired it will still catch the event.

```js
function Foo() {
  useEvent('foo', (event) => console.log(event));

  // ...
}

function Bar() {
  useEventBuffer([ 'foo' ], eventBus);

  return <Foo />;
}
```

It allows the user to do

```js
selection.select(element);

eventBus.fire('propertiesPanel.showEntry', { ... });
```

without using `setTimeout` or similar workarounds.

## Showing Entries

The `useShowEntryEvent` hook is introduced to make subscribing to `propertiesPanel.showEntry` events easy. It expects a `show` callback that will be called whenever a `propertiesPanel.showEntry` event is caught. If it returns true the entry is shown. The `ref` returned by the hook can be used to focus an input whenever an entry is shown.

```js
function Foo() {
  const show = useCallback(({ foo }) => foo === 'foo', []);

  const ref = useShowEntryEvent(show);

  return <input type="text" ref={ ref } />;
}
```

## Showing Errors

The `useShowEntryEvent` hook is introduced to make subscribing to `propertiesPanel.showError` events easy. It also expects a `show` callback and an optional second argument `inputs`. Whenever any of the values in `inputs` changes the temporary error will be reset.

```js
function Foo() {
  const [ value, setValue ] = useState('foo');

  const show = useCallback(({ foo }) => foo === 'foo', [ 'foo', 'bar' ]);

  const temporaryError = useShowErrorEvent(show, [ value ]);

  // ...
}
```

## Showing Parent Groups When Showing Entries

For an entry to be shown all of its parent groups must be shown as well. An `onShow` callback is introduced that can be called by a child component whenever it's shown. The parent component will then be shown as well. The `onShow` callback is provided through the closest context provider of the newly introduced `PropertiesPanelContext`. Providing the callback through a context instead of a prop means that it doesn't have to be passed explicitly when creating a custom entry.

```js
import { Group, TextFieldEntry } from '@bpmn-io/properties-panel';

function FooEntry() {

  // TextFieldEntry component will get onShow through context provider of its parent Group component
  return <TextFieldEntry />;
}

const group = {
  component: Group,
  entries: [
    {
      component: FooEntry
    }
  ]
};
```

---

Required by https://github.com/bpmn-io/bpmn-js-properties-panel/pull/601