### PR TITLE
Show Entry and Error Adjustments

### DIFF
--- a/src/components/entries/Checkbox.js
+++ b/src/components/entries/Checkbox.js
@@ -64,7 +64,7 @@ export default function CheckboxEntry(props) {
 
   const value = getValue(element);
 
-  const error = useShowErrorEvent(show, [ element, value ]);
+  const error = useShowErrorEvent(show);
 
   return (
     <div class="bio-properties-panel-entry bio-properties-panel-checkbox-entry" data-entry-id={ id }>

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -98,7 +98,7 @@ export default function SelectEntry(props) {
   const value = getValue(element);
   const options = getOptions(element);
 
-  const error = useShowErrorEvent(show, [ element, value ]);
+  const error = useShowErrorEvent(show);
 
   return (
     <div

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -123,7 +123,7 @@ export default function TextfieldEntry(props) {
     value = cachedInvalidValue;
   }
 
-  const temporaryError = useShowErrorEvent(show, [ element, value ]);
+  const temporaryError = useShowErrorEvent(show);
 
   const error = temporaryError || validationError;
 

--- a/src/context/EventContext.js
+++ b/src/context/EventContext.js
@@ -18,12 +18,12 @@
  *
  * @example
  *
- * useEvent('propertiesPanel.showError', ({ error, focus = false, ...rest }) => {
+ * useEvent('propertiesPanel.showError', ({ focus = false, message, ...rest }) => {
  *   // ...
  * });
  *
  * @param {Object} context
- * @param {string} context.error
+ * @param {string} context.message
  * @param {boolean} [context.focus]
  *
  * @returns void

--- a/src/hooks/useShowEntryEvent.js
+++ b/src/hooks/useShowEntryEvent.js
@@ -32,7 +32,7 @@ export function useShowEntryEvent(show) {
         onShow();
       }
 
-      if (event.focus) {
+      if (event.focus && !focus) {
         setFocus(true);
       }
     }

--- a/src/hooks/useShowErrorEvent.js
+++ b/src/hooks/useShowErrorEvent.js
@@ -32,7 +32,7 @@ export function useShowErrorEvent(show, inputs = []) {
     if (show(event)) {
       eventBus.fire('propertiesPanel.showEntry', event);
 
-      setTemporaryError(event.error);
+      setTemporaryError(event.message);
     }
   }, [ show ]);
 

--- a/src/hooks/useShowErrorEvent.js
+++ b/src/hooks/useShowErrorEvent.js
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useContext,
-  useEffect,
   useState
 } from 'preact/hooks';
 
@@ -11,20 +10,21 @@ import { useEvent } from './useEvent';
 
 /**
  * Subscribe to `propertiesPanel.showError`. On `propertiesPanel.showError` set
- * temporary error. Unset error on inputs change. Fire
- * `propertiesPanel.showEntry` for temporary error to be visible.
+ * temporary error. Fire `propertiesPanel.showEntry` for temporary error to be
+ * visible. Unset error on `propertiesPanel.updated`.
  *
  * @param {Function} show
- * @param {any[]} [inputs]
  *
  * @returns {import('preact').Ref}
  */
-export function useShowErrorEvent(show, inputs = []) {
+export function useShowErrorEvent(show) {
   const { eventBus } = useContext(EventContext);
 
   const [ temporaryError, setTemporaryError ] = useState(null);
 
-  useEffect(() => setTemporaryError(null), inputs);
+  const onPropertiesPanelUpdated = useCallback(() => setTemporaryError(null), []);
+
+  useEvent('propertiesPanel.updated', onPropertiesPanelUpdated);
 
   const onShowError = useCallback((event) => {
     setTemporaryError(null);

--- a/test/spec/components/Checkbox.spec.js
+++ b/test/spec/components/Checkbox.spec.js
@@ -164,7 +164,7 @@ describe('<Checkbox>', function() {
       const result = createCheckbox({ container, eventBus, onShow: onShowSpy, show });
 
       // when
-      act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+      act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
       // then
       expect(onShowSpy).to.have.been.called;

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -244,7 +244,7 @@ describe('<Select>', function() {
       const result = createSelect({ container, eventBus, onShow: onShowSpy, show });
 
       // when
-      act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+      act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
       // then
       expect(onShowSpy).to.have.been.called;

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -153,7 +153,7 @@ describe('<TextField>', function() {
       const result = createTextField({ container, eventBus, onShow: onShowSpy, show });
 
       // when
-      act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+      act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
       // then
       expect(onShowSpy).to.have.been.called;

--- a/test/spec/hooks/useShowErrorEvent.spec.js
+++ b/test/spec/hooks/useShowErrorEvent.spec.js
@@ -30,7 +30,7 @@ describe('hooks/useShowErrorEvent', function() {
     let temporaryError;
 
     renderHook(() => {
-      temporaryError = useShowErrorEvent(show, []);
+      temporaryError = useShowErrorEvent(show);
     }, { wrapper: WithEventContext(eventBus, onShowSpy) });
 
     // when
@@ -51,7 +51,7 @@ describe('hooks/useShowErrorEvent', function() {
     eventBus.on('propertiesPanel.showEntry', showEntrySpy);
 
     renderHook(() => {
-      useShowErrorEvent(show, []);
+      useShowErrorEvent(show);
     }, { wrapper: WithEventContext(eventBus, noop) });
 
     // when
@@ -63,7 +63,7 @@ describe('hooks/useShowErrorEvent', function() {
   });
 
 
-  it('should unset temporary error on inputs changed', function() {
+  it('should unset temporary error on propertiesPanel.updated', function() {
 
     // given
     const show = () => true;
@@ -72,21 +72,16 @@ describe('hooks/useShowErrorEvent', function() {
 
     let temporaryError;
 
-    const { rerender } = renderHook(({ inputs }) => {
-      temporaryError = useShowErrorEvent(show, inputs);
-    }, {
-      initialProps: {
-        inputs: [ 'foo' ]
-      },
-      wrapper: WithEventContext(eventBus, onShowSpy)
-    });
+    renderHook(() => {
+      temporaryError = useShowErrorEvent(show);
+    }, { wrapper: WithEventContext(eventBus, onShowSpy) });
 
     act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
     expect(temporaryError).to.have.equal('foo');
 
     // when
-    act(() => rerender({ inputs: [ 'bar' ] }));
+    act(() => eventBus.fire('propertiesPanel.updated'));
 
     // then
     expect(temporaryError).to.be.null;

--- a/test/spec/hooks/useShowErrorEvent.spec.js
+++ b/test/spec/hooks/useShowErrorEvent.spec.js
@@ -34,7 +34,7 @@ describe('hooks/useShowErrorEvent', function() {
     }, { wrapper: WithEventContext(eventBus, onShowSpy) });
 
     // when
-    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+    act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
     // then
     expect(temporaryError).to.have.equal('foo');
@@ -55,11 +55,11 @@ describe('hooks/useShowErrorEvent', function() {
     }, { wrapper: WithEventContext(eventBus, noop) });
 
     // when
-    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+    act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
     // then
     expect(showEntrySpy).to.have.been.calledOnce;
-    expect(showEntrySpy).to.have.been.calledWithMatch({ error: 'foo' });
+    expect(showEntrySpy).to.have.been.calledWithMatch({ message: 'foo' });
   });
 
 
@@ -81,7 +81,7 @@ describe('hooks/useShowErrorEvent', function() {
       wrapper: WithEventContext(eventBus, onShowSpy)
     });
 
-    act(() => eventBus.fire('propertiesPanel.showError', { error: 'foo' }));
+    act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
     expect(temporaryError).to.have.equal('foo');
 


### PR DESCRIPTION
This PR contains a couple of small adjustments to the recently added feature of showing entries and errors:

* rename `error` property of `propertiesPanel.showError` event to `message`
* unset temporary error on `propertiesPanel.updated`
* do not set focus if already set

---

Required by https://github.com/bpmn-io/bpmn-js-properties-panel/pull/601
