### PR TITLE
fix: make event bus prop optional

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -96,6 +96,7 @@ const bufferedEvents = [
  * @param {Function} [props.layoutChanged]
  * @param {DescriptionConfig} [props.descriptionConfig]
  * @param {Function} [props.descriptionLoaded]
+ * @param {Object} [props.eventBus]
  */
 export default function PropertiesPanel(props) {
   const {

--- a/src/context/EventContext.js
+++ b/src/context/EventContext.js
@@ -31,10 +31,6 @@
 
 import { createContext } from 'preact';
 
-import EventBus from 'diagram-js/lib/core/EventBus';
-
-const eventBus = new EventBus();
-
-const EventContext = createContext({ eventBus });
+const EventContext = createContext({ eventBus: null });
 
 export default EventContext;

--- a/src/hooks/useEvent.js
+++ b/src/hooks/useEvent.js
@@ -18,8 +18,12 @@ export function useEvent(event, callback, priority = DEFAULT_PRIORITY) {
   const { eventBus } = useContext(EventContext);
 
   useEffect(() => {
+    if (!eventBus) {
+      return;
+    }
+
     eventBus.on(event, priority, callback);
 
     return () => eventBus.off(event, callback);
-  }, [ event, eventBus, callback, priority ]);
+  }, [ callback, event, eventBus, priority ]);
 }

--- a/src/hooks/useShowErrorEvent.js
+++ b/src/hooks/useShowErrorEvent.js
@@ -30,7 +30,9 @@ export function useShowErrorEvent(show) {
     setTemporaryError(null);
 
     if (show(event)) {
-      eventBus.fire('propertiesPanel.showEntry', event);
+      if (eventBus) {
+        eventBus.fire('propertiesPanel.showEntry', event);
+      }
 
       setTemporaryError(event.message);
     }

--- a/test/spec/hooks/useEvent.spec.js
+++ b/test/spec/hooks/useEvent.spec.js
@@ -33,6 +33,19 @@ describe('hooks/useEvent', function() {
   });
 
 
+  it('should not subscribe (no event bus)', function() {
+
+    // given
+    const onSpy = sinon.spy(eventBus, 'on');
+
+    // when
+    renderHook(() => useEvent('foo', noop));
+
+    // then
+    expect(onSpy).not.to.have.been.called;
+  });
+
+
   it('should call callback', function() {
 
     // given

--- a/test/spec/hooks/useShowEntryEvent.spec.js
+++ b/test/spec/hooks/useShowEntryEvent.spec.js
@@ -43,6 +43,28 @@ describe('hooks/useShowEntryEvent', function() {
   });
 
 
+  it('should not call onShow (no event bus)', function() {
+
+    // given
+    const show = () => true;
+
+    const onShowSpy = sinon.spy();
+
+    renderHook(() => {
+      const ref = useShowEntryEvent(show);
+
+      return <input id="foo" ref={ ref } />;
+    });
+
+    // when
+
+    eventBus.fire('propertiesPanel.showEntry');
+
+    // then
+    expect(onShowSpy).not.to.have.been.called;
+  });
+
+
   it('should call focus', function() {
 
     // given

--- a/test/spec/hooks/useShowErrorEvent.spec.js
+++ b/test/spec/hooks/useShowErrorEvent.spec.js
@@ -8,8 +8,6 @@ import { EventContext } from 'src/context';
 
 import { useShowErrorEvent } from 'src/hooks';
 
-const noop = () => {};
-
 
 describe('hooks/useShowErrorEvent', function() {
 
@@ -25,19 +23,36 @@ describe('hooks/useShowErrorEvent', function() {
     // given
     const show = () => true;
 
-    const onShowSpy = sinon.spy();
-
     let temporaryError;
 
     renderHook(() => {
       temporaryError = useShowErrorEvent(show);
-    }, { wrapper: WithEventContext(eventBus, onShowSpy) });
+    }, { wrapper: WithEventContext(eventBus) });
 
     // when
     act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 
     // then
-    expect(temporaryError).to.have.equal('foo');
+    expect(temporaryError).to.equal('foo');
+  });
+
+
+  it('should not set temporary error (no event bus)', function() {
+
+    // given
+    const show = () => true;
+
+    let temporaryError;
+
+    renderHook(() => {
+      temporaryError = useShowErrorEvent(show);
+    });
+
+    // when
+    act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
+
+    // then
+    expect(temporaryError).to.be.null;
   });
 
 
@@ -52,7 +67,7 @@ describe('hooks/useShowErrorEvent', function() {
 
     renderHook(() => {
       useShowErrorEvent(show);
-    }, { wrapper: WithEventContext(eventBus, noop) });
+    }, { wrapper: WithEventContext(eventBus) });
 
     // when
     act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
@@ -68,13 +83,11 @@ describe('hooks/useShowErrorEvent', function() {
     // given
     const show = () => true;
 
-    const onShowSpy = sinon.spy();
-
     let temporaryError;
 
     renderHook(() => {
       temporaryError = useShowErrorEvent(show);
-    }, { wrapper: WithEventContext(eventBus, onShowSpy) });
+    }, { wrapper: WithEventContext(eventBus) });
 
     act(() => eventBus.fire('propertiesPanel.showError', { message: 'foo' }));
 


### PR DESCRIPTION
Make the properties panel fly without an event bus. 🛫