### PR TITLE
fix: remove unnecessary properties panel padding

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -197,7 +197,6 @@
   overflow-y: auto;
   overflow-x: hidden;
   flex: 1;
-  padding-bottom: 70px;
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/2831.

The negative margin is there to 'hide' the last group's separator when a scrollbar is visible.

This avoids that:

![image](https://user-images.githubusercontent.com/17801113/161953032-c2c9df5b-0619-47d8-b5c1-4f19e791c50e.png)

This has the side effect of moving the scrollbar itself down a little. Not really visible, and definitely a little weird but I've tried multiple other css tricks without success.

How it will look:

![image](https://user-images.githubusercontent.com/17801113/161953434-8415d569-4558-43f3-8b0a-5fc7c482e430.png)

Worth testing on non windows platforms if the scrollbars look different.
