### PR TITLE
fix: prevent debounced input from losing value when focused

### DIFF
--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 import { isFunction } from 'min-dash';
 
 import {
+  useLocalValue,
   usePrevious,
   useShowEntryEvent,
   useShowErrorEvent
@@ -34,9 +35,16 @@ function Textfield(props) {
 
   const ref = useShowEntryEvent(show);
 
-  const handleInput = useMemo(() => {
-    return debounce(({ target }) => onInput(target.value.length ? target.value : undefined));
-  }, [ onInput, debounce ]);
+  const debouncedOnInput = useMemo(() => {
+    return debounce((value) => onInput(value.length ? value : undefined));
+  }, [ debounce, onInput ]);
+
+  const [
+    localValue,
+    localOnInput,
+    onFocus,
+    onBlur
+  ] = useLocalValue(value, debouncedOnInput);
 
   return (
     <div class="bio-properties-panel-textfield">
@@ -53,10 +61,10 @@ function Textfield(props) {
         autoComplete="off"
         disabled={ disabled }
         class="bio-properties-panel-input"
-        onInput={ handleInput }
-        onFocus={ props.onFocus }
-        onBlur={ props.onBlur }
-        value={ value || '' } />
+        onInput={ localOnInput }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
+        value={ localValue || '' } />
     </div>
   );
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { useLocalValue } from './useLocalValue';
 export { useDescriptionContext } from './useDescriptionContext';
 export { useEvent } from './useEvent';
 export { useEventBuffer } from './useEventBuffer';

--- a/src/hooks/useLocalValue.js
+++ b/src/hooks/useLocalValue.js
@@ -1,0 +1,28 @@
+import {
+  useRef,
+  useState
+} from 'preact/hooks';
+
+export function useLocalValue(value, onInput) {
+  const [ localValue, setLocalValue ] = useState(value);
+
+  const localOnInput = ({ target }) => {
+    const { value } = target;
+
+    setLocalValue(value);
+
+    onInput(value);
+  };
+
+  const focused = useRef(false);
+
+  const onFocus = () => focused.current = true;
+
+  const onBlur = () => {
+    focused.current = false;
+
+    setLocalValue(value);
+  };
+
+  return [ focused.current ? localValue : value, localOnInput, onFocus, onBlur ];
+}

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -36,6 +36,8 @@ export function insertCSS(name, css) {
 }
 
 export function changeInput(input, value) {
+  input.focus();
+
   fireEvent.input(input, { target: { value } });
 }
 

--- a/test/spec/hooks/useLocalValue.spec.js
+++ b/test/spec/hooks/useLocalValue.spec.js
@@ -1,0 +1,179 @@
+/* eslint-disable no-unused-vars */
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { useLocalValue } from 'src/hooks';
+
+
+describe('hooks/useLocalValue', function() {
+
+  it('should not return local value if not focused', function() {
+
+    // given
+    let localValue,
+        localOnInput,
+        onFocus,
+        onBlur;
+
+    const onInput = () => {};
+
+    const { rerender } = renderHook(({ value }) => {
+      ([
+        localValue,
+        localOnInput,
+        onFocus,
+        onBlur
+      ] = useLocalValue(value, onInput));
+
+      return null;
+    }, {
+      initialProps: { value: 'foo' }
+    });
+
+    // when
+    rerender({ value: 'bar' });
+
+    // then
+    expect(localValue).to.equal('bar');
+  });
+
+
+  it('should return local value if focused', async function() {
+
+    // given
+    let localValue,
+        localOnInput,
+        onFocus,
+        onBlur;
+
+    const onInput = () => {};
+
+    const { rerender } = renderHook(({ value }) => {
+      ([
+        localValue,
+        localOnInput,
+        onFocus,
+        onBlur
+      ] = useLocalValue(value, onInput));
+
+      return null;
+    }, {
+      initialProps: { value: 'foo' }
+    });
+
+    // when
+    onFocus();
+
+    rerender({ value: 'bar' });
+
+    // then
+    expect(localValue).to.equal('foo');
+  });
+
+
+  it('should not return local value if blurred', async function() {
+
+    // given
+    let localValue,
+        localOnInput,
+        onFocus,
+        onBlur;
+
+    const onInput = () => {};
+
+    const { rerender } = renderHook(({ value }) => {
+      ([
+        localValue,
+        localOnInput,
+        onFocus,
+        onBlur
+      ] = useLocalValue(value, onInput));
+
+      return null;
+    }, {
+      initialProps: { value: 'foo' }
+    });
+
+    // assume
+    onFocus();
+
+    rerender({ value: 'bar' });
+
+    expect(localValue).to.equal('foo');
+
+    // when
+    onBlur();
+
+    rerender({ value: 'bar' });
+
+    // then
+    expect(localValue).to.equal('bar');
+  });
+
+
+  it('should set local value', function() {
+
+    // given
+    let localValue,
+        localOnInput,
+        onFocus,
+        onBlur;
+
+    const onInput = () => {};
+
+    const { rerender } = renderHook(({ value }) => {
+      ([
+        localValue,
+        localOnInput,
+        onFocus,
+        onBlur
+      ] = useLocalValue(value, onInput));
+
+      return null;
+    }, {
+      initialProps: { value: 'foo' }
+    });
+
+    onFocus();
+
+    // when
+    localOnInput({ target: { value: 'bar' } });
+
+    rerender({ value: 'baz' });
+
+    // then
+    expect(localValue).to.equal('bar');
+  });
+
+
+  it('should propagate local value', function() {
+
+    // given
+    let localValue,
+        localOnInput,
+        onFocus,
+        onBlur;
+
+    const onInput = sinon.spy();
+
+    renderHook(({ value }) => {
+      ([
+        localValue,
+        localOnInput,
+        onFocus,
+        onBlur
+      ] = useLocalValue(value, onInput));
+
+      return null;
+    }, {
+      initialProps: { value: 'foo' }
+    });
+
+    // when
+    localOnInput({ target: { value: 'bar' } });
+
+    // then
+    expect(onInput).to.have.been.calledOnceWith('bar');
+  });
+
+});

--- a/test/spec/hooks/useShowEntryEvent.spec.js
+++ b/test/spec/hooks/useShowEntryEvent.spec.js
@@ -35,7 +35,6 @@ describe('hooks/useShowEntryEvent', function() {
     }, { wrapper: WithContext(eventBus, onShowSpy) });
 
     // when
-
     eventBus.fire('propertiesPanel.showEntry');
 
     // then
@@ -57,7 +56,6 @@ describe('hooks/useShowEntryEvent', function() {
     });
 
     // when
-
     eventBus.fire('propertiesPanel.showEntry');
 
     // then


### PR DESCRIPTION
Prevents text input from losing value due to prop changes while focused.

Closes #146

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
