### PR TITLE
Sticky headers

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -218,6 +218,7 @@
   height: 32px;
   user-select: none;
   justify-content: space-between;
+  margin-bottom: -1px; /* avoid double borders */
   position: relative;  /* browsers not supporting sticky */
   position: -webkit-sticky;  /* for safari */
   position: sticky;
@@ -239,7 +240,6 @@
 .bio-properties-panel-group-header.sticky {
   background-color: var(--sticky-group-background-color);
   border-bottom: 1px solid var(--sticky-group-bottom-border-color);
-  margin-bottom: -1px;
 }
 
 .bio-properties-panel-group-header-buttons {

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -45,6 +45,9 @@
   --group-background-color: var(--color-white);
   --group-bottom-border-color: var(--color-grey-225-10-75);
 
+  --sticky-group-background-color: var(--color-grey-225-10-95);
+  --sticky-group-bottom-border-color: var(--color-grey-225-10-75);
+
   --add-entry-fill-color: var(--color-grey-225-10-35);
   --add-entry-hover-fill-color: var(--color-white);
   --add-entry-hover-background-color: var(--color-blue-205-100-50);
@@ -144,7 +147,6 @@
   align-items: center;
   font-size: var(--text-size-base);
   padding: 16px 10px;
-  margin-bottom: 2px;
   background-color: var(--header-background-color);
   border-bottom: 1px solid var(--header-bottom-border-color);
   width: 100%;
@@ -205,10 +207,10 @@
 .bio-properties-panel-group {
   background-color: var(--group-background-color);
   border-bottom: 1px solid var(--group-bottom-border-color);
+  position: relative;
 }
 
 .bio-properties-panel-group-header {
-  position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -216,6 +218,10 @@
   height: 32px;
   user-select: none;
   justify-content: space-between;
+  position: -webkit-sticky;  /* for safari */
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .bio-properties-panel-group-header .bio-properties-panel-group-header-title {
@@ -227,6 +233,12 @@
 
 .bio-properties-panel-group-header.open .bio-properties-panel-group-header-title {
   font-weight: 500;
+}
+
+.bio-properties-panel-group-header.sticky {
+  background-color: var(--sticky-group-background-color);
+  border-bottom: 1px solid var(--sticky-group-bottom-border-color);
+  margin-bottom: -1px;
 }
 
 .bio-properties-panel-group-header-buttons {

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -218,6 +218,7 @@
   height: 32px;
   user-select: none;
   justify-content: space-between;
+  position: relative;  /* browsers not supporting sticky */
   position: -webkit-sticky;  /* for safari */
   position: sticky;
   top: 0;

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -2,6 +2,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState
 } from 'preact/hooks';
 
@@ -21,6 +22,8 @@ import {
 
 import { PropertiesPanelContext } from '../context';
 
+import { useStickyIntersectionObserver } from '../hooks';
+
 import { ArrowIcon } from './icons';
 
 /**
@@ -35,6 +38,8 @@ export default function Group(props) {
     shouldOpen = false,
   } = props;
 
+  const groupRef = useRef(null);
+
   const [ open, setOpen ] = useLayoutState(
     [ 'groups', id, 'open' ],
     shouldOpen
@@ -45,6 +50,8 @@ export default function Group(props) {
   const toggleOpen = () => setOpen(!open);
 
   const [ edited, setEdited ] = useState(false);
+
+  const [ sticky, setSticky ] = useState(false);
 
   // set edited state depending on all entries
   useEffect(() => {
@@ -68,16 +75,20 @@ export default function Group(props) {
     setEdited(hasOneEditedEntry);
   }, [ entries ]);
 
+  // set css class when group is sticky to top
+  useStickyIntersectionObserver(groupRef, 'div.bio-properties-panel-scroll-container', setSticky);
+
   const propertiesPanelContext = {
     ...useContext(PropertiesPanelContext),
     onShow
   };
 
-  return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id }>
+  return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id } ref={ groupRef }>
     <div class={ classnames(
       'bio-properties-panel-group-header',
       edited ? '' : 'empty',
-      open? 'open' : ''
+      open ? 'open' : '',
+      (sticky && open) ? 'sticky' : ''
     ) } onClick={ toggleOpen }>
       <div title={ label } class="bio-properties-panel-group-header-title">
         { label }

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -2,6 +2,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState
 } from 'preact/hooks';
 
@@ -26,6 +27,8 @@ import {
 
 import { PropertiesPanelContext } from '../context';
 
+import { useStickyIntersectionObserver } from '../hooks';
+
 const noop = () => {};
 
 /**
@@ -43,10 +46,14 @@ export default function ListGroup(props) {
   } = props;
 
 
+  const groupRef = useRef(null);
+
   const [ open, setOpen ] = useLayoutState(
     [ 'groups', id, 'open' ],
     false
   );
+
+  const [ sticky, setSticky ] = useState(false);
 
   const onShow = useCallback(() => setOpen(true), [ setOpen ]);
 
@@ -135,6 +142,9 @@ export default function ListGroup(props) {
     }
   }, [ items, shouldHandleEffects ]);
 
+  // set css class when group is sticky to top
+  useStickyIntersectionObserver(groupRef, 'div.bio-properties-panel-scroll-container', setSticky);
+
   const toggleOpen = () => setOpen(!open);
 
   const hasItems = !!items.length;
@@ -144,12 +154,13 @@ export default function ListGroup(props) {
     onShow
   };
 
-  return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id }>
+  return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id } ref={ groupRef }>
     <div
       class={ classnames(
         'bio-properties-panel-group-header',
         hasItems ? '' : 'empty',
-        (hasItems && open) ? 'open' : ''
+        (hasItems && open) ? 'open' : '',
+        (sticky && open) ? 'sticky' : ''
       ) }
       onClick={ hasItems ? toggleOpen : noop }>
       <div

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,3 +6,4 @@ export { useLayoutState } from './useLayoutState';
 export { usePrevious } from './usePrevious';
 export { useShowEntryEvent } from './useShowEntryEvent';
 export { useShowErrorEvent } from './useShowErrorEvent';
+export { useStickyIntersectionObserver } from './useStickyIntersectionObserver';

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -24,6 +24,12 @@ import {
  */
 export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
   useEffect(() => {
+
+    // return early if IntersectionObserver is not available
+    if (!IntersectionObserver) {
+      return;
+    }
+
     let observer;
 
     if (ref.current) {

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -1,0 +1,56 @@
+import {
+  useEffect
+} from 'preact/hooks';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+
+/**
+ * @callback setSticky
+ * @param {boolean} value
+ */
+
+/**
+ * Use IntersectionObserver to identify when DOM element is in sticky mode.
+ * If sticky is observered setSticky(true) will be called.
+ * If sticky mode is left, setSticky(false) will be called.
+ *
+ *
+ * @param {Object} ref
+ * @param {string} scrollContainerSelector
+ * @param {setSticky} setSticky
+ */
+export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
+  useEffect(() => {
+    let observer;
+
+    if (ref.current) {
+      const scrollContainer = domQuery(scrollContainerSelector);
+
+      observer = new IntersectionObserver((entries) => {
+        if (entries[0].intersectionRatio < 1) {
+          setSticky(true);
+        }
+        else if (entries[0].intersectionRatio === 1) {
+          setSticky(false);
+        }
+      },
+      {
+        root: scrollContainer,
+        rootMargin: '0px 0px 999999% 0px', // Use bottom margin to avoid stickyness when scrolling out to bottom
+        threshold: [ 1 ]
+      });
+      observer.observe(ref.current);
+    }
+
+    // Unobserve if unmounted
+    return () => {
+      if (ref.current && observer) {
+        observer.unobserve(ref.current);
+      }
+    };
+
+  }, [ ref ]);
+}

--- a/test/spec/hooks/useStickyIntersectionObserver.spec.js
+++ b/test/spec/hooks/useStickyIntersectionObserver.spec.js
@@ -1,0 +1,108 @@
+import { useStickyIntersectionObserver } from 'src/hooks';
+
+import { renderHook } from '@testing-library/preact-hooks';
+
+
+describe('hooks/userStickyIntersectionObserver', function() {
+
+  const OriginalIntersectionObserver = global.IntersectionObserver;
+
+  afterEach(function() {
+    global.IntersectionObserver = OriginalIntersectionObserver;
+  });
+
+
+  it('should observe', async function() {
+
+    // given
+    const observeSpy = sinon.spy();
+
+    mockIntersectionObserver({ observe: observeSpy });
+
+    const domObject = <div></div>;
+
+    // when
+    const ref = { current: domObject };
+
+    await renderHook(() => {
+      useStickyIntersectionObserver(ref, 'div', () => {});
+
+      return domObject;
+    });
+
+    // then
+    expect(observeSpy).to.have.been.calledOnce;
+  });
+
+
+  it('should not observe if DOM not ready', async function() {
+
+    // given
+    const observeSpy = sinon.spy();
+
+    mockIntersectionObserver({ observe: observeSpy });
+
+    // when
+    const ref = { current: undefined };
+
+    await renderHook(() => {
+      useStickyIntersectionObserver(ref, 'div', () => {});
+
+      return undefined;
+    });
+
+    // then
+    expect(observeSpy).to.not.have.been.called;
+  });
+
+
+  it('should unobserve after unmount', async function() {
+
+    // given
+    const unobserveSpy = sinon.spy();
+
+    mockIntersectionObserver({ unobserve: unobserveSpy });
+
+    const domObject = <div></div>;
+
+    const ref = { current: domObject };
+
+    const { unmount } = await renderHook(() => {
+      useStickyIntersectionObserver(ref, 'div', () => {});
+
+      return domObject;
+    });
+
+    // when
+    unmount();
+
+    // then
+    expect(unobserveSpy).to.have.been.calledOnce;
+  });
+
+});
+
+
+// helpers ////////////////////
+
+function noop() {}
+
+function mockIntersectionObserver(props) {
+  const {
+    observe = noop,
+    unobserve = noop
+  } = props;
+
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+
+    observe() {
+      return observe();
+    }
+
+    unobserve() {
+      return unobserve();
+    }
+
+  };
+}

--- a/test/spec/hooks/useStickyIntersectionObserver.spec.js
+++ b/test/spec/hooks/useStickyIntersectionObserver.spec.js
@@ -80,6 +80,29 @@ describe('hooks/userStickyIntersectionObserver', function() {
     expect(unobserveSpy).to.have.been.calledOnce;
   });
 
+
+  it('should NOT crash when IntersectionObserver is not available', async function() {
+
+    // given
+    global.IntersectionObserver = null;
+
+    const domObject = <div></div>;
+
+    const ref = { current: domObject };
+
+    // when
+    try {
+      await renderHook(() => {
+        useStickyIntersectionObserver(ref, 'div', () => {});
+
+        return domObject;
+      });
+    } catch (error) {
+
+      // then
+      expect(error).not.to.exist;
+    }
+  });
 });
 
 


### PR DESCRIPTION
closes camunda/camunda-modeler-design#118

:warning: Please notice this does not yet include the `Scroll to focus on new added list item` => I will tackle this seperately as a follow-up.

Try this out yourself with:
```
npx @bpmn-io/sr "bpmn-io/bpmn-js-properties-panel" -l "bpmn-io/properties-panel#sticky-headers"  
```

![StickyHeader](https://user-images.githubusercontent.com/42800119/169138140-562e4b51-d945-4940-9658-061b4d92ca40.gif)

