### PR TITLE
Enable generic multiple and empty state

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -36,7 +36,8 @@
   --description-code-border-color: var(--color-grey-225-10-85);
   --description-list-item-color: var(--color-grey-225-10-35);
 
-  --placeholder-color: var(--color-grey-225-10-75);
+  --placeholder-color: var(--color-grey-225-10-35);
+  --placeholder-background-color: var(--color-grey-225-10-95);
 
   --header-background-color: var(--color-grey-225-10-95);
   --header-icon-fill-color: var(--color-grey-225-10-15);
@@ -128,11 +129,27 @@
   flex: 1;
 }
 
+/**
+ * Placeholder (empty, multi select, ...)
+ */
 .bio-properties-panel-placeholder {
-  padding: 10px;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: var(--placeholder-background-color);
+}
+
+.bio-properties-panel-placeholder-text {
   color: var(--placeholder-color);
   font-size: var(--text-size-base);
   text-align: center;
+  margin: 12px 48px;
 }
 
 /**

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -77,7 +77,7 @@ const bufferedEvents = [
  *
  * @callback { {
  * @param {string} id
- * @param {djs.model.base} element
+ * @param {Object} element
  * @returns {string}
  * } } GetDescriptionFunction
  *

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -6,6 +6,7 @@ import {
 import {
   assign,
   get,
+  isArray,
   set
 } from 'min-dash';
 
@@ -14,6 +15,8 @@ import classnames from 'classnames';
 import Header from './components/Header';
 
 import Group from './components/Group';
+
+import Placeholder from './components/Placeholder';
 
 import {
   DescriptionContext,
@@ -81,6 +84,11 @@ const bufferedEvents = [
  * @returns {string}
  * } } GetDescriptionFunction
  *
+ * @typedef { {
+ *  getEmpty: (element: object) => import('./components/Placeholder').PlaceholderDefinition,
+ *  getMultiple: (element: Object) => import('./components/Placeholder').PlaceholderDefinition
+ * } } PlaceholderProvider
+ *
  */
 
 
@@ -89,8 +97,9 @@ const bufferedEvents = [
  * data from implementor to describe *what* will be rendered.
  *
  * @param {Object} props
- * @param {Object} props.element
+ * @param {Object|Array} props.element
  * @param {import('./components/Header').HeaderProvider} props.headerProvider
+ * @param {PlaceholderProvider} [props.placeholderProvider]
  * @param {Array<GroupDefinition|ListGroupDefinition>} props.groups
  * @param {Object} [props.layoutConfig]
  * @param {Function} [props.layoutChanged]
@@ -102,6 +111,7 @@ export default function PropertiesPanel(props) {
   const {
     element,
     headerProvider,
+    placeholderProvider,
     groups,
     layoutConfig = {},
     layoutChanged,
@@ -162,8 +172,14 @@ export default function PropertiesPanel(props) {
     element
   };
 
-  if (!element) {
-    return <div class="bio-properties-panel-placeholder">Select an element to edit its properties.</div>;
+  // empty state
+  if (placeholderProvider && !element) {
+    return <Placeholder { ...placeholderProvider.getEmpty() } />;
+  }
+
+  // multiple state
+  if (placeholderProvider && isArray(element)) {
+    return <Placeholder { ...placeholderProvider.getMultiple() } />;
   }
 
   return (

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,10 +2,10 @@ import { ExternalLinkIcon } from './icons';
 
 /**
  * @typedef { {
- *  getElementLabel: (element: djs.model.base) => string,
- *  getTypeLabel: (element: djs.model.base) => string,
- *  getElementIcon: (element: djs.model.base) => import('preact').Component,
- *  getDocumentationRef: (element: djs.model.base) => string
+ *  getElementLabel: (element: object) => string,
+ *  getTypeLabel: (element: object) => string,
+ *  getElementIcon: (element: object) => import('preact').Component,
+ *  getDocumentationRef: (element: object) => string
  * } } HeaderProvider
  */
 

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef { {
+ *  text: (element: object) => string,
+ *  icon?: (element: Object) => import('preact').Component
+ * } } PlaceholderDefinition
+ *
+ * @param { PlaceholderDefinition } props
+ */
+export default function Placeholder(props) {
+  const {
+    text,
+    icon: Icon
+  } = props;
+
+  return (
+    <div class="bio-properties-panel open">
+      <section class="bio-properties-panel-placeholder">
+        { Icon && <Icon class="bio-properties-panel-placeholder-icon" /> }
+        <p class="bio-properties-panel-placeholder-text">{ text }</p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,5 +4,6 @@ export { default as Header } from './Header';
 export { HeaderButton } from './HeaderButton';
 export { default as ListGroup } from './ListGroup';
 export { default as ListItem } from './ListItem';
+export { default as Placeholder } from './Placeholder';
 export * from './icons';
 export * from './entries';

--- a/src/hooks/useDescriptionContext.js
+++ b/src/hooks/useDescriptionContext.js
@@ -17,7 +17,7 @@ import {
  * ```
  *
  * @param {string} id
- * @param {djs.model.Base} element
+ * @param {object} element
  *
  * @returns {string}
  */

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -19,7 +19,8 @@ import PropertiesPanel from 'src/PropertiesPanel';
 import ListGroup from 'src/components/ListGroup';
 
 import {
-  HeaderProvider
+  HeaderProvider,
+  PlaceholderProvider
 } from './mocks';
 
 insertCoreStyles();
@@ -57,7 +58,47 @@ describe('<PropertiesPanel>', function() {
     const result = createPropertiesPanel({ container });
 
     // then
-    expect(domQuery('.bio-properties-panel-placeholder', result.container)).to.exist;
+    const placeholder = domQuery('.bio-properties-panel-placeholder', result.container);
+    const placeholderIcon = domQuery('.bio-properties-panel-placeholder', result.container);
+    const placeholderText = domQuery('.bio-properties-panel-placeholder-text', placeholder);
+
+    expect(placeholder).to.exist;
+    expect(placeholderIcon).to.exist;
+    expect(placeholderText.innerText).to.eql('empty');
+  });
+
+
+  it('should render (multiple elements)', function() {
+
+    // given
+    const result = createPropertiesPanel({
+      container,
+      element: [ noopElement, noopElement ]
+    });
+
+    // then
+    const placeholder = domQuery('.bio-properties-panel-placeholder', result.container);
+    const placeholderIcon = domQuery('.bio-properties-panel-placeholder', result.container);
+    const placeholderText = domQuery('.bio-properties-panel-placeholder-text', placeholder);
+
+    expect(placeholder).to.exist;
+    expect(placeholderIcon).to.exist;
+    expect(placeholderText.innerText).to.eql('multiple');
+  });
+
+
+  it('should not throw - no placeholder provider', function() {
+
+    // when
+    const result = createPropertiesPanel({
+      container,
+      placeholderProvider: null
+    });
+
+    // then
+    const placeholder = domQuery('.bio-properties-panel-placeholder', result.container);
+
+    expect(placeholder).to.not.exist;
   });
 
 
@@ -329,6 +370,7 @@ function createPropertiesPanel(options = {}) {
     container,
     element,
     headerProvider = HeaderProvider,
+    placeholderProvider = PlaceholderProvider,
     groups = [],
     layoutConfig,
     layoutChanged = noop,
@@ -340,6 +382,7 @@ function createPropertiesPanel(options = {}) {
     <PropertiesPanel
       element={ element }
       headerProvider={ headerProvider }
+      placeholderProvider={ placeholderProvider }
       groups={ groups }
       layoutConfig={ layoutConfig }
       layoutChanged={ layoutChanged }

--- a/test/spec/components/Placeholder.spec.js
+++ b/test/spec/components/Placeholder.spec.js
@@ -1,0 +1,86 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  expectNoViolations,
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import Placeholder from 'src/components/Placeholder';
+
+insertCoreStyles();
+
+
+describe('<Placeholder>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  it('should render', function() {
+
+    // when
+    const result = render(<Placeholder />, { container });
+
+    const placeholderNode = domQuery('.bio-properties-panel-placeholder', result.container);
+
+    // then
+    expect(placeholderNode).to.exist;
+  });
+
+
+  it('should render text', function() {
+
+    // given
+    const text = 'foo';
+
+    // when
+    const result = render(<Placeholder text={ text } />, { container });
+
+    const placeholderText = domQuery('.bio-properties-panel-placeholder-text', result.container);
+
+    // then
+    expect(placeholderText).to.exist;
+    expect(placeholderText.innerText).to.eql(text);
+  });
+
+
+  it('should render icon', function() {
+
+    // given
+    const Icon = (props) => <svg class={ props.class } />;
+
+    // when
+    const result = render(<Placeholder icon={ Icon } />, { container });
+
+    const placeholderIcon = domQuery('.bio-properties-panel-placeholder-icon', result.container);
+
+    // then
+    expect(placeholderIcon).to.exist;
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // when
+      const { container: node } = render(<Placeholder text="foo" />, { container });
+
+      // then
+      await expectNoViolations(node);
+    });
+
+  });
+
+});

--- a/test/spec/mocks/index.js
+++ b/test/spec/mocks/index.js
@@ -12,3 +12,20 @@ export class HeaderProvider {
     return 'type';
   }
 }
+
+export class PlaceholderProvider {
+
+  static getEmpty(element) {
+    return {
+      text: 'empty',
+      icon: 'empty-icon'
+    };
+  }
+
+  static getMultiple(element) {
+    return {
+      text: 'multiple',
+      icon: 'multiple-icon'
+    };
+  }
+}


### PR DESCRIPTION
Closes #69 

* Improve placeholder to provide multiple and empty states
* Allows integrators (e.g. bpmn-js-properties-panel) to provide contents 

Note (/cc @andreasgeier): I used `--color-grey-225-10-35` for the text color as the color [in the prototype ](https://fluffy-fiesta-212e1c7c.pages.github.io/prototypes/visual-ide/v18/) offers too less contrast (`--color-grey-225-10-55`). It even broke the built-in a11y integration test (which is a good sign our tests work 👍 )

Example

```sh
npx @bpmn-io/sr "bpmn-io/bpmn-js-properties-panel#use-updated-placeholder" -l "bpmn-io/properties-panel#69-multi-and-empty-state" -c "npm run start:cloud" 
```

**Multiple state**

![image](https://user-images.githubusercontent.com/9433996/169307598-0ac1740d-405c-442a-b7f1-6bf4d4bf7bd5.png)

**Empty state**

Only in theory, not possible via UI.

![image](https://user-images.githubusercontent.com/9433996/169307750-3df3c921-f78e-4269-8a9d-72ea633c9d57.png)

