### PR TITLE
feat: pass props to list entry component

### DIFF
--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -51,7 +51,8 @@ export default function List(props) {
     onAdd,
     onRemove,
     autoFocusEntry,
-    compareFn
+    compareFn,
+    ...restProps
   } = props;
 
   const [ open, setOpen ] = useState(!!shouldOpen);
@@ -143,6 +144,7 @@ export default function List(props) {
       {
         hasItems && (
           <ItemsList
+            { ...restProps }
             autoFocusEntry={ autoFocusEntry }
             component={ component }
             element={ element }
@@ -167,7 +169,8 @@ function ItemsList(props) {
     items,
     newItems,
     onRemove,
-    open
+    open,
+    ...restProps
   } = props;
 
   const getKey = useKeyFactory();
@@ -210,6 +213,7 @@ function ItemsList(props) {
 
           return (<li class="bio-properties-panel-list-entry-item" key={ key }>
             <Component
+              { ...restProps }
               element={ element }
               id={ id }
               index={ index }

--- a/test/spec/components/List.spec.js
+++ b/test/spec/components/List.spec.js
@@ -157,6 +157,48 @@ describe('<List>', function() {
   });
 
 
+  it('should pass props', async function() {
+
+    // given
+    const foo = 'bar';
+
+    const Component = (props) => {
+
+      const { foo } = props;
+
+      expect(foo).to.exist;
+
+      return <span class="foo-entry">{ foo }</span>;
+    };
+
+    const items = [
+      {
+        id: 'item-1',
+        label: 'Item 1'
+      }
+    ];
+
+    const options = {
+      container: parentContainer,
+      items,
+      open: true,
+      component: Component,
+      foo,
+      compareFn: defaultCompareFn
+    };
+
+    // when
+    const {
+      container
+    } = createListEntry(options);
+
+    // then
+    const node = domQuery('.foo-entry', container);
+
+    expect(node.innerText).to.eql(foo);
+  });
+
+
   describe('auto-focus', function() {
 
     it('should auto-focus first input entry added', async function() {
@@ -997,11 +1039,13 @@ function createListEntry(options = {}, renderFn = render) {
     container,
     component = DefaultComponent,
     compareFn,
-    autoFocusEntry = false
+    autoFocusEntry = false,
+    ...restProps
   } = options;
 
   return renderFn(
     <List
+      { ...restProps }
       element={ element }
       id={ id }
       label={ label }


### PR DESCRIPTION
This is a (late) follow-up of https://github.com/bpmn-io/properties-panel/pull/134 where we allowed props to be passed to the to-be-rendered entry component. This wasn't possible for `List` entries (maybe it was forgotten).

This might be important while implementing https://github.com/bpmn-io/form-js/issues/256 /cc @Skaiir. 
