### PR TITLE
fix: add error class to text area with error

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -103,7 +103,12 @@ export default function TextAreaEntry(props) {
   const error = useError(id);
 
   return (
-    <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <div
+      class={ classnames(
+        'bio-properties-panel-entry',
+        error ? 'has-error' : '')
+      }
+      data-entry-id={ id }>
       <TextArea
         id={ id }
         label={ label }

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -7,6 +7,7 @@ import {
 import TestContainer from 'mocha-test-container-support';
 
 import {
+  classes as domClasses,
   query as domQuery,
   queryAll as domQueryAll
 } from 'min-dom';
@@ -250,6 +251,7 @@ describe('<Select>', function() {
       const result = createSelect({ container, errors, id: 'foo' });
 
       // then
+      expect(isValid(domQuery('.bio-properties-panel-entry', result.container))).to.be.false;
       expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
     });
 
@@ -446,4 +448,8 @@ function createOptions(overrides = {}) {
   ];
 
   return newOptions;
+}
+
+function isValid(node) {
+  return !domClasses(node).has('has-error');
 }

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -131,6 +131,7 @@ describe('<TextArea>', function() {
       const result = createTextArea({ container, errors, id: 'foo' });
 
       // then
+      expect(isValid(domQuery('.bio-properties-panel-entry', result.container))).to.be.false;
       expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
     });
 
@@ -351,4 +352,8 @@ function createTextArea(options = {}) {
       </EventContext.Provider>
     </ErrorsContext.Provider>,
     { container });
+}
+
+function isValid(node) {
+  return !domClasses(node).has('has-error');
 }

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -159,6 +159,7 @@ describe('<TextField>', function() {
       const result = createTextField({ container, errors, id: 'foo' });
 
       // then
+      expect(isValid(domQuery('.bio-properties-panel-entry', result.container))).to.be.false;
       expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
     });
 


### PR DESCRIPTION
When a text area has an error the styling indicates it (same as text field).

![image](https://user-images.githubusercontent.com/7633572/179464056-cac84dec-4c05-4f4a-af18-dcd04474ecd4.png)

Closes #165

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
