### PR TITLE
feat: pass variables to FEEL editor

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -120,8 +120,11 @@
   overflow: hidden;
 }
 
-.bio-properties-panel * {
+.bio-properties-panel {
   color: var(--text-base-color);
+}
+
+.bio-properties-panel * {
   font-size: var(--text-size-base);
   line-height: var(--text-line-height);
   font-weight: 400;
@@ -988,7 +991,7 @@ textarea.bio-properties-panel-input {
   background-color: var(--feel-indicator-background-color);
   border-right: 0px;
   border-radius: 2px 0 0 2px;
-  z-index: 100;
+  z-index: 1;
   height: 100%;
   width: 2em;
   text-align: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,10 +700,11 @@
       }
     },
     "@bpmn-io/feel-editor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.1.0.tgz",
-      "integrity": "sha512-jH7mMXLaQcwbDXgUECjzYHp1BvAdzOfVXVcYOnFnR9kHu9AD7fVfPDkwgm2f8hspYqqEeakS28gyu7EAZU/iSg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.2.0.tgz",
+      "integrity": "sha512-R85p56nFxffNp0fStNxz561EXJmcTdVZL7NyVhuB3qKS/mt4thuvK1B43YnXKdLx8WessjsbHzjvWkbCYZRWkQ==",
       "requires": {
+        "@codemirror/autocomplete": "^6.0.3",
         "@codemirror/commands": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/lint": "^6.0.0",
@@ -711,6 +712,17 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/highlight": "^1.0.0",
         "lezer-feel": "^0.4.0"
+      }
+    },
+    "@codemirror/autocomplete": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
+      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "@codemirror/commands": {
@@ -725,9 +737,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.0.tgz",
-      "integrity": "sha512-tabB0Ef/BflwoEmTB4a//WZ9P90UQyne9qWB9YFsmeS4bnEqSys7UpGk/da1URMXhyfuzWCwp+AQNMhvu8SfnA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -753,9 +765,9 @@
       "integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg=="
     },
     "@codemirror/view": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.0.2.tgz",
-      "integrity": "sha512-mnVT/q1JvKPjpmjXJNeCi/xHyaJ3abGJsumIVpdQ1nE1MXAyHf7GHWt8QpWMUvDiqF0j+inkhVR2OviTdFFX7Q==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.1.1.tgz",
+      "integrity": "sha512-ZBLsphk+Tbqxv7Z1vZ+rky7QbHV/ILoCN4rtdcboBmSbkDmVwsU0wmfqTGZyrOw5ulBPu2aE8esQf6cIUZbWqQ==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
@@ -8712,9 +8724,9 @@
       "dev": true
     },
     "w3c-keyname": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.5.tgz",
+      "integrity": "sha512-WJrK7i6w+ULuZsGscCezbCH4Aev5U3xY87vnSimzzEgPQhb0Sa0a1rE3c2jtEwrFtSfi61Jefw3jI5/DD/3jbQ=="
     },
     "watchpack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/feel-editor": "0.1.0",
+    "@bpmn-io/feel-editor": "0.2.0",
     "classnames": "^2.3.1",
     "diagram-js": "^8.1.2",
     "min-dash": "^3.7.0",

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -138,6 +138,7 @@ function FeelTextfield(props) {
             disabled={ disabled }
             onFeelToggle={ () => { handleFeelToggle(); setFocus(true); } }
             value={ feelOnlyValue }
+            variables={ props.variables }
             ref={ ref }
           /> :
           <OptionalComponent
@@ -319,6 +320,7 @@ export default function FeelEntry(props) {
         example={ props.example }
         show={ show }
         value={ value }
+        variables={ props.variables }
         OptionalComponent={ props.OptionalComponent } />
       {error && <div class="bio-properties-panel-error">{error}</div>}
       <Description forId={ id } element={ element } value={ description } />

--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -37,7 +37,8 @@ const CodeEditor = forwardRef((props, ref) => {
     value,
     onInput,
     onFeelToggle,
-    disabled
+    disabled,
+    variables
   } = props;
 
   const inputRef = useRef();
@@ -77,13 +78,19 @@ const CodeEditor = forwardRef((props, ref) => {
       container: inputRef.current,
       onChange: handleInput,
       onKeyDown: onKeyDown,
-      value: localValue
+      value: localValue,
+      variables: variables
     });
 
     setEditor(
       editor
     );
-  }, []);
+
+    return () => {
+      inputRef.current.innerHTML = '';
+      setEditor(null);
+    };
+  }, [ variables ]);
 
   useEffect(() => {
     if (!editor) {

--- a/test/spec/components/DropdownButton.spec.js
+++ b/test/spec/components/DropdownButton.spec.js
@@ -225,6 +225,9 @@ describe('<DropdownButton>', function() {
     it('should have no violations', async function() {
 
       // given
+      this.timeout(5000);
+
+      // given
       const menuItems = [
         { entry: 'Click me' }
       ];

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -446,7 +446,6 @@ describe('<FeelField>', function() {
 
       });
 
-
     });
 
   });

--- a/test/spec/components/FeelEditor.spec.js
+++ b/test/spec/components/FeelEditor.spec.js
@@ -1,0 +1,92 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import { useRef } from 'preact/hooks';
+import { fireEvent } from '@testing-library/preact';
+
+import FeelComponent from 'src/components/entries/FEEL/FeelEditor';
+
+insertCoreStyles();
+
+describe('<FeelEditor>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  it('should supply variables to editor', async function() {
+
+    // given
+    const variables = [
+      { name: 'foo' },
+      { name: 'bar' },
+    ];
+
+    render(<Wrapper variables={ variables } />, { container });
+
+    // when
+    const editor = domQuery('[role="textbox"]', container);
+    editor.focus();
+    fireEvent.keyDown(document.activeElement, { key: ' ', ctrlKey: true });
+
+    // then
+    await new Promise(res => setTimeout(res, 50));
+    const suggestions = domQuery('.cm-tooltip-autocomplete > ul', container);
+    expect(suggestions).to.exist;
+    expect(suggestions.children).to.have.length(2);
+  });
+
+
+  it('should use correct variables after prop change', async function() {
+
+    // given
+    const variables = [
+      { name: 'foo' },
+      { name: 'bar' },
+    ];
+
+    const newVariables = [
+      { name: 'baz' },
+    ];
+
+    const component = render(<Wrapper variables={ variables } />, { container });
+
+    // when
+    component.rerender(<Wrapper variables={ newVariables } />);
+
+    const editor = domQuery('[role="textbox"]', container);
+
+    editor.focus();
+    fireEvent.keyDown(document.activeElement, { key: ' ', ctrlKey: true });
+
+    // then
+    await new Promise(res => setTimeout(res, 50));
+    const suggestions = domQuery('.cm-tooltip-autocomplete', container);
+    expect(suggestions).to.exist;
+    expect(suggestions.children).to.have.length(1);
+  });
+
+});
+
+
+// helpers ////////////////////
+
+function Wrapper(props) {
+  const ref = useRef();
+
+  return <FeelComponent { ...props } ref={ ref } />;
+}
+

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -24,6 +24,7 @@ import {
 import Group from 'src/components/Group';
 
 import { PropertiesPanelContext } from 'src/context';
+import { fireEvent } from '@testing-library/preact';
 
 insertCoreStyles();
 
@@ -64,7 +65,7 @@ describe('<Group>', function() {
       expect(domClasses(entries).has('open')).to.be.false;
 
       // when
-      await header.click();
+      await fireEvent.click(header);
 
       // then
       expect(domClasses(entries).has('open')).to.be.true;

--- a/test/spec/components/Placeholder.spec.js
+++ b/test/spec/components/Placeholder.spec.js
@@ -74,6 +74,9 @@ describe('<Placeholder>', function() {
 
     it('should have no violations', async function() {
 
+      // given
+      this.timeout(5000);
+
       // when
       const { container: node } = render(<Placeholder text="foo" />, { container });
 


### PR DESCRIPTION
Adds the ability to pass variables to the FEEL editor. Start typing or use ctrl+space to get suggestions.

![Recording 2022-07-27 at 14 21 59](https://user-images.githubusercontent.com/21984219/181245560-1cf504c9-d616-4ca7-af8b-31d8dd057b70.gif)

Try it out using 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#feel-editor-variables
```
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
