### PR TITLE
chore: remove sticky headers

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -246,8 +246,14 @@
   justify-content: space-between;
   margin-bottom: -1px; /* avoid double borders */
   position: relative;  /* browsers not supporting sticky */
-  position: -webkit-sticky;  /* for safari */
-  position: sticky;
+
+  /**
+   * @pinussilvestrus Note: we exclude the sticky header feature until we
+   * find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
+   */
+   
+  /* position: -webkit-sticky;  /* for safari */
+  /* position: sticky; */
   top: 0;
   z-index: 1;
 }

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -25,8 +25,14 @@ import {
 export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
   useEffect(() => {
 
+    /**
+     * @pinussilvestrus Note: we exclude the sticky header feature until we
+     * find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
+     */
+    const Observer = false /* IntersectionObserver */;
+
     // return early if IntersectionObserver is not available
-    if (!IntersectionObserver) {
+    if (!Observer) {
       return;
     }
 
@@ -35,7 +41,7 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
     if (ref.current) {
       const scrollContainer = domQuery(scrollContainerSelector);
 
-      observer = new IntersectionObserver((entries) => {
+      observer = new Observer((entries) => {
         if (entries[0].intersectionRatio < 1) {
           setSticky(true);
         }

--- a/test/spec/hooks/useStickyIntersectionObserver.spec.js
+++ b/test/spec/hooks/useStickyIntersectionObserver.spec.js
@@ -11,8 +11,11 @@ describe('hooks/userStickyIntersectionObserver', function() {
     global.IntersectionObserver = OriginalIntersectionObserver;
   });
 
-
-  it('should observe', async function() {
+  /**
+   * @pinussilvestrus Note: we exclude the sticky header feature until we
+   * find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
+   */
+  it.skip('should observe', async function() {
 
     // given
     const observeSpy = sinon.spy();
@@ -35,7 +38,7 @@ describe('hooks/userStickyIntersectionObserver', function() {
   });
 
 
-  it('should not observe if DOM not ready', async function() {
+  it.skip('should not observe if DOM not ready', async function() {
 
     // given
     const observeSpy = sinon.spy();
@@ -56,7 +59,7 @@ describe('hooks/userStickyIntersectionObserver', function() {
   });
 
 
-  it('should unobserve after unmount', async function() {
+  it.skip('should unobserve after unmount', async function() {
 
     // given
     const unobserveSpy = sinon.spy();


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726

Removes the sticky headers feature until we find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726.

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#726-opt-out-sticky-headers
```


