### PR TITLE
fix(FEEL): show syntax errors

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -517,7 +517,12 @@ textarea.bio-properties-panel-input {
   background-color: var(--input-error-background-color);
 }
 
-.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus {
+.bio-properties-panel-entry.has-error .bio-properties-panel-feel-indicator {
+  border-color: var(--input-error-border-color);
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus,
+.bio-properties-panel-entry.has-error .bio-properties-panel-feel-indicator:focus {
   border-color: var(--input-error-focus-border-color);
 }
 

--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -37,6 +37,7 @@ const CodeEditor = forwardRef((props, ref) => {
     value,
     onInput,
     onFeelToggle,
+    onLint = () => {},
     disabled,
     variables
   } = props;
@@ -78,6 +79,7 @@ const CodeEditor = forwardRef((props, ref) => {
       container: inputRef.current,
       onChange: handleInput,
       onKeyDown: onKeyDown,
+      onLint: onLint,
       value: localValue,
       variables: variables
     });
@@ -87,6 +89,7 @@ const CodeEditor = forwardRef((props, ref) => {
     );
 
     return () => {
+      onLint([]);
       inputRef.current.innerHTML = '';
       setEditor(null);
     };

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -1101,6 +1101,26 @@ describe('<FeelField>', function() {
         expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
       });
 
+
+      it('should show syntax error', async function() {
+
+        // given
+        const clock = sinon.useFakeTimers();
+        const result = createFeelField({ container, getValue: () => '= foo == bar', feel: 'required' });
+
+        // when
+        // trigger debounced validation
+        clock.tick(1000);
+        clock.restore();
+
+        // wait for DOM update
+        await flushPromises();
+
+        // then
+        expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
+
+      });
+
     });
 
 


### PR DESCRIPTION
try it out using 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#feel-editor-syntax-error
```

![image](https://user-images.githubusercontent.com/21984219/185932882-ce2f6d63-b2f4-48db-9c85-d14dfa2485a5.png)

requires https://github.com/bpmn-io/feel-editor/pull/10
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
