### PR TITLE
fix(hooks): set sticky correctly on element change

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -176,7 +176,7 @@
   background-color: var(--header-background-color);
   border-bottom: 1px solid var(--header-bottom-border-color);
   width: 100%;
-  z-index: 1;
+  z-index: 10;
   max-height: 64px;
   overflow: hidden;
 }
@@ -249,7 +249,7 @@
   position: -webkit-sticky;  /* for safari */
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
 }
 
 .bio-properties-panel-group-header .bio-properties-panel-group-header-title {

--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -246,14 +246,8 @@
   justify-content: space-between;
   margin-bottom: -1px; /* avoid double borders */
   position: relative;  /* browsers not supporting sticky */
-
-  /**
-   * @pinussilvestrus Note: we exclude the sticky header feature until we
-   * find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
-   */
-   
-  /* position: -webkit-sticky;  /* for safari */
-  /* position: sticky; */
+  position: -webkit-sticky;  /* for safari */
+  position: sticky;
   top: 0;
   z-index: 1;
 }

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -25,11 +25,7 @@ import {
 export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
   useEffect(() => {
 
-    /**
-     * @pinussilvestrus Note: we exclude the sticky header feature until we
-     * find a proper fix for https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
-     */
-    const Observer = false /* IntersectionObserver */;
+    const Observer = IntersectionObserver;
 
     // return early if IntersectionObserver is not available
     if (!Observer) {
@@ -42,12 +38,14 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
       const scrollContainer = domQuery(scrollContainerSelector);
 
       observer = new Observer((entries) => {
-        if (entries[0].intersectionRatio < 1) {
-          setSticky(true);
-        }
-        else if (entries[0].intersectionRatio === 1) {
-          setSticky(false);
-        }
+        entries.forEach(entry => {
+          if (entry.intersectionRatio < 1) {
+            setSticky(true);
+          }
+          else if (entry.intersectionRatio === 1) {
+            setSticky(false);
+          }
+        });
       },
       {
         root: scrollContainer,
@@ -64,5 +62,5 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
       }
     };
 
-  }, [ ref ]);
+  }, [ ref, scrollContainerSelector, setSticky ]);
 }


### PR DESCRIPTION
related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/726
(see issue for why this was broken)
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
