### PR TITLE
chore(CHANGELOG): update to v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.19.0
+
+* `FEAT`: make group headers sticky ([#175](https://github.com/bpmn-io/properties-panel/pull/175))
+* `CHORE`: use element as key for entries ([#176](https://github.com/bpmn-io/properties-panel/pull/176))
+
 ## 0.18.0
 
 * `FEAT`: pass variables to FEEL editor ([#171](https://github.com/bpmn-io/properties-panel/pull/171))


### PR DESCRIPTION
Even though sticky headers is a fix, they were disabled in 0.18.0, so we should consider it a feature and we cut a minor release

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
