### PR TITLE
fix: keep first character of feel-required expression

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -46,7 +46,7 @@ function FeelTextfield(props) {
   const containerRef = useRef();
 
   const feelActive = localValue.startsWith('=') || feel === 'required';
-  const feelOnlyValue = localValue.substring(1);
+  const feelOnlyValue = localValue.startsWith('=') ? localValue.substring(1) : localValue;
 
   const [ focus, _setFocus ] = useState(undefined);
 

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -946,6 +946,40 @@ describe('<FeelField>', function() {
     });
 
 
+    it('should render with missing = sign', async function() {
+
+      // given
+      const result = createFeelField({ container, feel: 'required', getValue: () => 'foo' });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('[role="textbox"]', entry);
+
+      // then
+      expect(input.textContent).to.eql('foo');
+    });
+
+
+    it('should update with missing = sign', async function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const result = createFeelField({ container, setValue: updateSpy, getValue: () => 'foo', feel: 'required' });
+
+      const input = domQuery('[role="textbox"]', result.container);
+
+      // when
+      input.textContent += 'o';
+      await flushPromises();
+
+      // then
+      setTimeout(() => {
+        expect(updateSpy).to.have.been.calledWith('=fooo');
+      });
+
+    });
+
+
     it('should not submit empty feel expression', function() {
       const updateSpy = sinon.spy();
 


### PR DESCRIPTION
closes #183

![Recording 2022-09-12 at 14 04 58 (1)](https://user-images.githubusercontent.com/21984219/189650506-53d2b7de-d47b-4dc7-b838-8daaea9b3a1f.gif)

test it out: 
```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#183-feel-required-cut-off -c "npm run start:cloud-templates"
```

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
