### PR TITLE
feat: expose onFocus and onBlur functions on TextAreaEntry

### DIFF
--- a/src/components/entries/Checkbox.js
+++ b/src/components/entries/Checkbox.js
@@ -16,7 +16,9 @@ function Checkbox(props) {
     label,
     onChange,
     disabled,
-    value = false
+    value = false,
+    onFocus,
+    onBlur
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -46,6 +48,8 @@ function Checkbox(props) {
         ref={ ref }
         id={ prefixId(id) }
         name={ id }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         type="checkbox"
         class="bio-properties-panel-input"
         onChange={ handleChange }
@@ -65,6 +69,8 @@ function Checkbox(props) {
  * @param {String} props.label
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {boolean} [props.disabled]
  */
 export default function CheckboxEntry(props) {
@@ -75,7 +81,9 @@ export default function CheckboxEntry(props) {
     label,
     getValue,
     setValue,
-    disabled
+    disabled,
+    onFocus,
+    onBlur
   } = props;
 
   const value = getValue(element);
@@ -90,6 +98,8 @@ export default function CheckboxEntry(props) {
         key={ element }
         label={ label }
         onChange={ setValue }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         value={ value } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -37,6 +37,7 @@ function FeelTextfield(props) {
     feel,
     value = '',
     disabled = false,
+    variables,
     OptionalComponent = OptionalFeelInput
   } = props;
 
@@ -53,7 +54,7 @@ function FeelTextfield(props) {
   const setFocus = (offset = 0) => {
     const hasFocus = containerRef.current.contains(document.activeElement);
 
-    // Keep carret position if it is already focused, otherwise focus at the end
+    // Keep caret position if it is already focused, otherwise focus at the end
     const position = hasFocus ? document.activeElement.selectionStart : Infinity;
 
     _setFocus(position + offset);
@@ -200,7 +201,7 @@ function FeelTextfield(props) {
             onFeelToggle={ () => { handleFeelToggle(); setFocus(true); } }
             onLint={ handleLint }
             value={ feelOnlyValue }
-            variables={ props.variables }
+            variables={ variables }
             ref={ editorRef }
           /> :
           <OptionalComponent
@@ -220,7 +221,9 @@ const OptionalFeelInput = forwardRef((props, ref) => {
     id,
     disabled,
     onInput,
-    value
+    value,
+    onFocus,
+    onBlur
   } = props;
 
   const inputRef = useRef();
@@ -255,8 +258,8 @@ const OptionalFeelInput = forwardRef((props, ref) => {
     disabled={ disabled }
     class="bio-properties-panel-input"
     onInput={ e => onInput(e.target.value) }
-    onFocus={ props.onFocus }
-    onBlur={ props.onBlur }
+    onFocus={ onFocus }
+    onBlur={ onBlur }
     value={ value || '' } />;
 });
 
@@ -266,7 +269,9 @@ const OptionalFeelTextArea = forwardRef((props, ref) => {
     id,
     disabled,
     onInput,
-    value
+    value,
+    onFocus,
+    onBlur
   } = props;
 
   const inputRef = useRef();
@@ -295,8 +300,8 @@ const OptionalFeelTextArea = forwardRef((props, ref) => {
     disabled={ disabled }
     class="bio-properties-panel-input"
     onInput={ e => onInput(e.target.value) }
-    onFocus={ props.onFocus }
-    onBlur={ props.onBlur }
+    onFocus={ onFocus }
+    onBlur={ onBlur }
     value={ value || '' } />;
 });
 
@@ -324,7 +329,11 @@ export default function FeelEntry(props) {
     getValue,
     setValue,
     validate,
-    show = noop
+    show = noop,
+    example,
+    variables,
+    onFocus,
+    onBlur
   } = props;
 
   const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
@@ -392,10 +401,12 @@ export default function FeelEntry(props) {
         label={ label }
         onInput={ onInput }
         onError={ onError }
-        example={ props.example }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
+        example={ example }
         show={ show }
         value={ value }
-        variables={ props.variables }
+        variables={ variables }
         OptionalComponent={ props.OptionalComponent } />
       {error && <div class="bio-properties-panel-error">{error}</div>}
       <Description forId={ id } element={ element } value={ description } />
@@ -414,6 +425,8 @@ export default function FeelEntry(props) {
  * @param {String} props.label
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {Function} props.validate
  */
 export function FeelTextArea(props) {

--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -17,7 +17,9 @@ function NumberField(props) {
     min,
     onInput,
     step,
-    value = ''
+    value = '',
+    onFocus,
+    onBlur
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -63,6 +65,8 @@ function NumberField(props) {
         max={ max }
         min={ min }
         onInput={ handleInput }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         step={ step }
         value={ localValue } />
     </div>
@@ -81,6 +85,8 @@ function NumberField(props) {
  * @param {String} props.max
  * @param {String} props.min
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {String} props.step
  */
 export default function NumberFieldEntry(props) {
@@ -95,7 +101,9 @@ export default function NumberFieldEntry(props) {
     max,
     min,
     setValue,
-    step
+    step,
+    onFocus,
+    onBlur
   } = props;
 
   const value = getValue(element);
@@ -108,6 +116,8 @@ export default function NumberFieldEntry(props) {
         key={ element }
         label={ label }
         onInput={ setValue }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         max={ max }
         min={ min }
         step={ step }

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -24,6 +24,8 @@ import Description from './Description';
  * @param {string[]} props.path
  * @param {string} props.label
  * @param {Function} props.onChange
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {Array<Option>} [props.options]
  * @param {string} props.value
  * @param {boolean} [props.disabled]
@@ -35,7 +37,9 @@ function Select(props) {
     onChange,
     options = [],
     value,
-    disabled
+    disabled,
+    onFocus,
+    onBlur
   } = props;
 
   const ref = useShowEntryEvent(id);
@@ -68,6 +72,8 @@ function Select(props) {
         name={ id }
         class="bio-properties-panel-input"
         onInput={ handleChange }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         value={ localValue }
         disabled={ disabled }
       >
@@ -96,6 +102,8 @@ function Select(props) {
  * @param {string} props.label
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {Function} props.getOptions
  * @param {boolean} [props.disabled]
  */
@@ -108,7 +116,9 @@ export default function SelectEntry(props) {
     getValue,
     setValue,
     getOptions,
-    disabled
+    disabled,
+    onFocus,
+    onBlur
   } = props;
 
   const value = getValue(element);
@@ -129,6 +139,8 @@ export default function SelectEntry(props) {
         label={ label }
         value={ value }
         onChange={ setValue }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         options={ options }
         disabled={ disabled } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -80,6 +80,8 @@ function TextArea(props) {
  * @param {string} props.label
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {number} props.rows
  * @param {boolean} props.monospace
  * @param {boolean} [props.disabled]
@@ -95,7 +97,9 @@ export default function TextAreaEntry(props) {
     setValue,
     rows,
     monospace,
-    disabled
+    disabled,
+    onFocus,
+    onBlur
   } = props;
 
   const value = getValue(element);
@@ -115,6 +119,8 @@ export default function TextAreaEntry(props) {
         label={ label }
         value={ value }
         onInput={ setValue }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         rows={ rows }
         debounce={ debounce }
         monospace={ monospace }

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -23,7 +23,9 @@ function TextArea(props) {
     onInput,
     value = '',
     disabled,
-    monospace
+    monospace,
+    onFocus,
+    onBlur
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -62,8 +64,8 @@ function TextArea(props) {
           monospace ? 'bio-properties-panel-input-monospace' : '')
         }
         onInput={ handleInput }
-        onFocus={ props.onFocus }
-        onBlur={ props.onBlur }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         rows={ rows }
         value={ localValue }
         disabled={ disabled } />

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -24,6 +24,8 @@ function Textfield(props) {
     id,
     label,
     onInput,
+    onFocus,
+    onBlur,
     value = ''
   } = props;
 
@@ -63,8 +65,8 @@ function Textfield(props) {
         disabled={ disabled }
         class="bio-properties-panel-input"
         onInput={ handleInput }
-        onFocus={ props.onFocus }
-        onBlur={ props.onBlur }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         value={ localValue } />
     </div>
   );
@@ -80,6 +82,8 @@ function Textfield(props) {
  * @param {String} props.label
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  * @param {Function} props.validate
  */
 export default function TextfieldEntry(props) {
@@ -92,7 +96,9 @@ export default function TextfieldEntry(props) {
     label,
     getValue,
     setValue,
-    validate
+    validate,
+    onFocus,
+    onBlur
   } = props;
 
   const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
@@ -147,6 +153,8 @@ export default function TextfieldEntry(props) {
         key={ element }
         label={ label }
         onInput={ onInput }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
         value={ value } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />

--- a/src/components/entries/ToggleSwitch.js
+++ b/src/components/entries/ToggleSwitch.js
@@ -11,7 +11,9 @@ function ToggleSwitch(props) {
     label,
     onInput,
     value,
-    switcherLabel
+    switcherLabel,
+    onFocus,
+    onBlur
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -45,6 +47,8 @@ function ToggleSwitch(props) {
             id={ prefixId(id) }
             class="bio-properties-panel-input"
             type="checkbox"
+            onFocus={ onFocus }
+            onBlur={ onBlur }
             name={ id }
             onInput={ handleInput }
             checked={ localValue } />
@@ -65,6 +69,8 @@ function ToggleSwitch(props) {
  * @param {String} props.switcherLabel
  * @param {Function} props.getValue
  * @param {Function} props.setValue
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
  */
 export default function ToggleSwitchEntry(props) {
   const {
@@ -74,13 +80,22 @@ export default function ToggleSwitchEntry(props) {
     label,
     switcherLabel,
     getValue,
-    setValue
+    setValue,
+    onFocus,
+    onBlur
   } = props;
 
   const value = getValue(element);
   return (
     <div class="bio-properties-panel-entry bio-properties-panel-toggle-switch-entry" data-entry-id={ id }>
-      <ToggleSwitch id={ id } label={ label } value={ value } onInput={ setValue } switcherLabel={ switcherLabel } />
+      <ToggleSwitch
+        id={ id }
+        label={ label }
+        value={ value }
+        onInput={ setValue }
+        onFocus={ onFocus }
+        onBlur={ onBlur }
+        switcherLabel={ switcherLabel } />
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );


### PR DESCRIPTION
The inner component `TextArea`  spreads the `props.onBlur` and `props.onFocus` functions to the native textarea component:
``` 
<textarea
        ....
        onFocus={ props.onFocus }
        onBlur={ props.onBlur }
        ... />
```
But the outer component `TextAreaEntry` never actually exposes the same props to the consumer.