### PR TITLE
fix(ToggleSwitch): disable when value gets undefined

### DIFF
--- a/src/components/entries/ToggleSwitch.js
+++ b/src/components/entries/ToggleSwitch.js
@@ -51,7 +51,7 @@ function ToggleSwitch(props) {
             onBlur={ onBlur }
             name={ id }
             onInput={ handleInput }
-            checked={ localValue } />
+            checked={ !!localValue } />
           <span class="bio-properties-panel-toggle-switch__slider" />
         </label>
         <p class="bio-properties-panel-toggle-switch__label">{ switcherLabel }</p>

--- a/test/spec/components/ToggleSwitch.spec.js
+++ b/test/spec/components/ToggleSwitch.spec.js
@@ -80,24 +80,65 @@ describe('<ToggleSwitch>', function() {
   });
 
 
-  it('should set checked according to value', function() {
+  describe('set checked according to value', function() {
 
-    // given
-    const getValueFunctions = [
-      () => true,
-      () => false
+    // [value, checked]
+    const possibleValues = [
+      [ true, true ],
+      [ false, false ],
+      [ undefined, false ],
+      [ {}, true ]
     ];
 
-    getValueFunctions.forEach(fn => {
+    possibleValues.forEach(([ value, checked ]) => {
 
-      // when
-      const result = createToggleSwitch({ container, getValue: fn });
+      it(`should set checked to ${checked} for ${value}`, function() {
 
-      // then
-      const toggle = domQuery(`#bio-properties-panel-${TEST_TOGGLE_ID}`, result.container);
+        // when
+        const result = createToggleSwitch({ container, getValue: () => value });
 
-      expect(toggle.checked).to.equal(fn());
+        // then
+        const toggle = domQuery(`#bio-properties-panel-${TEST_TOGGLE_ID}`, result.container);
+
+        expect(toggle.checked).to.equal(checked);
+
+      });
+
     });
+
+  });
+
+
+  describe('update on external change', function() {
+
+    // [initialValue, updatedValue, checked]
+    const possibleValues = [
+      [ true, false, false ],
+      [ false, true, true ],
+      [ undefined, {}, true ],
+      [ {}, undefined, false ]
+    ];
+
+    possibleValues.forEach(([ initial, updated, checked ]) => {
+
+      it(`should update ${initial} -> ${updated}`, function() {
+
+        // given
+        const givenFn = () => initial;
+        const updatedFn = () => updated;
+        const result = createToggleSwitch({ container, getValue: givenFn });
+
+        // when
+        createToggleSwitch({ container, getValue: updatedFn }, result.rerender);
+
+        // then
+        const toggle = domQuery(`#bio-properties-panel-${TEST_TOGGLE_ID}`, result.container);
+        expect(toggle.checked).to.equal(checked);
+
+      });
+
+    });
+
   });
 
 
@@ -277,7 +318,7 @@ describe('<ToggleSwitch>', function() {
 
 // helpers ////////////////////
 
-function createToggleSwitch(options = {}) {
+function createToggleSwitch(options = {}, renderFn = render) {
   const {
     element,
     id = TEST_TOGGLE_ID,
@@ -296,7 +337,7 @@ function createToggleSwitch(options = {}) {
     getDescriptionForId
   };
 
-  return render(
+  return renderFn(
     <DescriptionContext.Provider value={ context }>
       <ToggleSwitch
         element={ element }


### PR DESCRIPTION

Root cause: setting `checked = undefined` does not update the toggle state.

![Recording 2022-11-03 at 14 40 54](https://user-images.githubusercontent.com/21984219/199736179-51b1fc67-ca5f-4650-bb7e-b50f6128320f.gif)

related to https://github.com/camunda/camunda-modeler/issues/3233

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
