### PR TITLE
chore: disable Grammarly on `<textarea />` elements

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -304,7 +304,9 @@ const OptionalFeelTextArea = forwardRef((props, ref) => {
     onInput={ e => onInput(e.target.value) }
     onFocus={ onFocus }
     onBlur={ onBlur }
-    value={ value || '' } />;
+    value={ value || '' }
+    data-gramm="false"
+  />;
 });
 
 /**

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -68,7 +68,9 @@ function TextArea(props) {
         onBlur={ onBlur }
         rows={ rows }
         value={ localValue }
-        disabled={ disabled } />
+        disabled={ disabled }
+        data-gramm="false"
+      />
     </div>
   );
 }

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -512,6 +512,19 @@ describe('<FeelField>', function() {
     });
 
 
+    // https://github.com/bpmn-io/bpmn-js-properties-panel/issues/810
+    it('should be flagged with data-gramm="false"', function() {
+
+      // when
+      createFeelTextArea({ container });
+
+      const input = domQuery('.bio-properties-panel-input', container);
+
+      // then
+      expect(input.dataset.gramm).to.eql('false');
+    });
+
+
     it('should update', function() {
 
       // given

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -110,6 +110,19 @@ describe('<TextArea>', function() {
   });
 
 
+  // https://github.com/bpmn-io/bpmn-js-properties-panel/issues/810
+  it('should be flagged with data-gramm="false"', function() {
+
+    // when
+    createTextArea({ container });
+
+    const input = domQuery('.bio-properties-panel-input', container);
+
+    // then
+    expect(input.dataset.gramm).to.eql('false');
+  });
+
+
   describe('events', function() {
 
     it('should show entry', function() {


### PR DESCRIPTION
Reported to break focus, cf. https://github.com/bpmn-io/bpmn-js-properties-panel/issues/810.

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/810.