### PR TITLE
fix: coherce undefined `<Select />` value to empty string

### DIFF
--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -36,7 +36,7 @@ function Select(props) {
     label,
     onChange,
     options = [],
-    value,
+    value = '',
     disabled,
     onFocus,
     onBlur

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -69,6 +69,49 @@ describe('<Select>', function() {
   });
 
 
+  describe('should select', function() {
+
+    const getOptions = () => [
+      {
+        label: 'A',
+        value: 'A'
+      },
+      {
+        label: 'B',
+        value: 'B'
+      }
+    ];
+
+
+    it('none (undefined value)', function() {
+
+      // when
+      const result = createSelect({ container, getOptions, getValue: () => undefined });
+
+      const selectInput = domQuery('.bio-properties-panel-input', result.container);
+
+      // then
+      expect(selectInput.value).to.equal('');
+    });
+
+
+    it('active entry', function() {
+
+      // when
+      const result = createSelect({ container, getOptions, getValue: () => 'A' });
+
+      const selectInput = domQuery('.bio-properties-panel-input', result.container);
+
+      const optionA = domQuery('option[value="A"]', selectInput);
+
+      // then
+      expect(selectInput.value).to.equal('A');
+      expect(optionA.selected).to.be.true;
+    });
+
+  });
+
+
   it('should render disabled', function() {
 
     // given


### PR DESCRIPTION
Explicitly set select value to empty rather than undefined.

Undefined values cause the browser to render the first selection.

---

Related to https://github.com/camunda/camunda-modeler/issues/3327