### PR TITLE
feat: add optgroup option for select

### DIFF
--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -13,7 +13,8 @@ import {
 import Description from './Description';
 
 /**
- * @typedef { { value: string, label: string, disabled: boolean } } Option
+ * @typedef { { value: string, label: string, disabled: boolean, groupKey: (string|undefined) } } Option
+ * @typedef { { key: string, label: string } } OptionGroup
  */
 
 /**
@@ -29,6 +30,7 @@ import Description from './Description';
  * @param {Array<Option>} [props.options]
  * @param {string} props.value
  * @param {boolean} [props.disabled]
+ * @param {Array<OptionGroup>} [props.groups]
  */
 function Select(props) {
   const {
@@ -36,6 +38,7 @@ function Select(props) {
     label,
     onChange,
     options = [],
+    groups = [],
     value = '',
     disabled,
     onFocus,
@@ -65,7 +68,9 @@ function Select(props) {
 
   return (
     <div class="bio-properties-panel-select">
-      <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label>
+      <label for={ prefixId(id) } class="bio-properties-panel-label">
+        {label}
+      </label>
       <select
         ref={ ref }
         id={ prefixId(id) }
@@ -77,18 +82,31 @@ function Select(props) {
         value={ localValue }
         disabled={ disabled }
       >
-        {
-          options.map((option, idx) => {
+        {groups.map((group, idx) => (
+          <optgroup key={ idx } label={ group.label }>
+            {options
+              .filter((option) => option.groupKey === group.key)
+              .map((option, idx) => (
+                <option
+                  key={ idx }
+                  value={ option.name }
+                  disabled={ option.disabled }
+                >
+                  {option.label}
+                </option>
+              ))}
+          </optgroup>
+        ))}
+
+        {options
+          .filter((option) => !option.groupKey)
+          .map((option, idx) => {
             return (
-              <option
-                key={ idx }
-                value={ option.value }
-                disabled={ option.disabled }>
-                { option.label }
+              <option key={ idx } value={ option.value } disabled={ option.disabled }>
+                {option.label}
               </option>
             );
-          })
-        }
+          })}
       </select>
     </div>
   );
@@ -106,6 +124,7 @@ function Select(props) {
  * @param {Function} props.onBlur
  * @param {Function} props.getOptions
  * @param {boolean} [props.disabled]
+ * @param {Function} [props.getGroups]
  */
 export default function SelectEntry(props) {
   const {
@@ -116,6 +135,7 @@ export default function SelectEntry(props) {
     getValue,
     setValue,
     getOptions,
+    getGroups,
     disabled,
     onFocus,
     onBlur
@@ -123,6 +143,11 @@ export default function SelectEntry(props) {
 
   const value = getValue(element);
   const options = getOptions(element);
+  let groups;
+
+  if (getGroups) {
+    groups = getGroups(element);
+  }
 
   const error = useError(id);
 
@@ -142,6 +167,7 @@ export default function SelectEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         options={ options }
+        groups={ groups }
         disabled={ disabled } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -13,8 +13,7 @@ import {
 import Description from './Description';
 
 /**
- * @typedef { { value: string, label: string, disabled: boolean, groupKey: (string|undefined) } } Option
- * @typedef { { key: string, label: string } } OptionGroup
+ * @typedef { { value: string, label: string, disabled: boolean, children: { value: string, label: string, disabled: boolean } } } Option
  */
 
 /**
@@ -30,7 +29,6 @@ import Description from './Description';
  * @param {Array<Option>} [props.options]
  * @param {string} props.value
  * @param {boolean} [props.disabled]
- * @param {Array<OptionGroup>} [props.groups]
  */
 function Select(props) {
   const {
@@ -38,7 +36,6 @@ function Select(props) {
     label,
     onChange,
     options = [],
-    groups = [],
     value = '',
     disabled,
     onFocus,
@@ -82,31 +79,29 @@ function Select(props) {
         value={ localValue }
         disabled={ disabled }
       >
-        {groups.map((group, idx) => (
-          <optgroup key={ idx } label={ group.label }>
-            {options
-              .filter((option) => option.groupKey === group.key)
-              .map((option, idx) => (
-                <option
-                  key={ idx }
-                  value={ option.name }
-                  disabled={ option.disabled }
-                >
-                  {option.label}
-                </option>
-              ))}
-          </optgroup>
-        ))}
-
-        {options
-          .filter((option) => !option.groupKey)
-          .map((option, idx) => {
+        {options.map((option, idx) => {
+          if (option.children) {
             return (
-              <option key={ idx } value={ option.value } disabled={ option.disabled }>
-                {option.label}
-              </option>
+              <optgroup key={ idx } label={ option.label }>
+                {option.children.map((child, idx) => (
+                  <option
+                    key={ idx }
+                    value={ child.value }
+                    disabled={ child.disabled }
+                  >
+                    {child.label}
+                  </option>
+                ))}
+              </optgroup>
             );
-          })}
+          }
+
+          return (
+            <option key={ idx } value={ option.value } disabled={ option.disabled }>
+              {option.label}
+            </option>
+          );
+        })}
       </select>
     </div>
   );
@@ -124,7 +119,6 @@ function Select(props) {
  * @param {Function} props.onBlur
  * @param {Function} props.getOptions
  * @param {boolean} [props.disabled]
- * @param {Function} [props.getGroups]
  */
 export default function SelectEntry(props) {
   const {
@@ -135,7 +129,6 @@ export default function SelectEntry(props) {
     getValue,
     setValue,
     getOptions,
-    getGroups,
     disabled,
     onFocus,
     onBlur
@@ -143,12 +136,6 @@ export default function SelectEntry(props) {
 
   const value = getValue(element);
   const options = getOptions(element);
-  let groups;
-
-  if (getGroups) {
-    groups = getGroups(element);
-  }
-
   const error = useError(id);
 
   return (
@@ -167,7 +154,6 @@ export default function SelectEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         options={ options }
-        groups={ groups }
         disabled={ disabled } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -402,7 +402,7 @@ describe('<Select>', function() {
 
   describe('groups', function() {
 
-    it('should render without groups per default', function() {
+    it('should render without children per default', function() {
 
       // given
       const result = createSelect({
@@ -417,18 +417,28 @@ describe('<Select>', function() {
     });
 
 
-    it('should render with groups if set per props', function() {
+    it('should render with children if set per props', function() {
 
       // given
       const result = createSelect({
         container,
         id: 'groupsSelect',
         label: 'someLabel',
-        getGroups: () => [
+        getOptions: () => [
           {
-            key: 'first-group',
-            label: 'first group'
-          }
+            label: 'first group',
+            children: [
+              {
+                label: 'Test option 1',
+                value: 'test1'
+              },
+              {
+                label: 'Test option 2',
+                value: 'test2',
+                disabled: true
+              },
+            ]
+          },
         ]
       });
 

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -400,6 +400,49 @@ describe('<Select>', function() {
 
   });
 
+  describe('groups', function() {
+
+    it('should render without groups per default', function() {
+
+      // given
+      const result = createSelect({
+        container,
+        id: 'noGroupsSelect'
+      });
+
+      // then
+      const groups = domQuery('[data-entry-id="noGroupsSelect"] optgroup',
+        result.container);
+      expect(groups).not.to.exist;
+    });
+
+
+    it('should render with groups if set per props', function() {
+
+      // given
+      const result = createSelect({
+        container,
+        id: 'groupsSelect',
+        label: 'someLabel',
+        getGroups: () => [
+          {
+            key: 'first-group',
+            label: 'first group'
+          }
+        ]
+      });
+
+      // then
+      const groups = domQuery(
+        '[data-entry-id="groupsSelect"] optgroup',
+        result.container
+      );
+
+      expect(groups).to.exist;
+      expect(groups.label).to.equal('first group');
+    });
+  });
+
 
   describe('a11y', function() {
 


### PR DESCRIPTION
This PR adds `optgroup` props to the `Select.js` component.

You will be able to use this by adding  `getGroups` function, which returns an array of objects with `key` and `label` fields in the select component props.

For proper functioning, you should add a `groupKey` field into the option(s) object, which, in its turn, should be equal to `key` field of group object

Example:

```
function ExampleComponent(props) {
  const { element } = props

  const getGroups = (element) => {
    return [
      {
        key: 'first',
        label: 'first test group'
      },
      {
        key: 'second',
        label: 'second test group'
      }
    ]
  }

  const getOptions = (element) => {
    return [
      {
        groupKey: 'first',
        label: 'Test option 1',
        value: 'test1'
      },
      {
        groupKey: 'first',
        label: 'Test option 2',
        value: 'test2',
        disabled: true
      },
      {
        groupKey: 'second',
        label: 'Test option 3',
        value: 'test3'
      },
      {
        label: 'Test option 4 without group',
        value: 'test4'
      }
    ]
  }

  return [
    SelectEntry({
      element,
      id: 'test',
      getGroups,
      label: translate('test'),
      getValue: () => null,
      setValue: (value) => console.log(value),
      getOptions
    })
  ]
}
```

<img width="288" alt="image" src="https://user-images.githubusercontent.com/38625168/209443067-a8e32f2c-922a-4348-b659-6eb7b342faa0.png">

Closes https://github.com/bpmn-io/properties-panel/issues/169