### PR TITLE
styles: allow `pre` code blocks

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -421,6 +421,14 @@
   border-radius: 3px;
 }
 
+.bio-properties-panel-description pre code {
+  width: 100%;
+  display: block;
+  overflow-x: auto;
+  padding: 4px 6px;
+  font-family: var(--font-family-monospace);
+}
+
 .bio-properties-panel-description ul {
   padding: 0;
   margin: 0 0 0 12px;


### PR DESCRIPTION
Related to https://github.com/bpmn-io/form-js/pull/316

This allows using code blocks inside descriptions. 

[Example](https://github.com/bpmn-io/form-js/pull/316)

![image](https://user-images.githubusercontent.com/9433996/218485437-6f0715cb-bb38-4c12-b8a4-28405f7efa77.png)

