### PR TITLE
feat: use global layout context as single source of truth

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -119,6 +119,13 @@ export default function PropertiesPanel(props) {
   // set-up layout context
   const [ layout, setLayout ] = useState(createLayout(layoutConfig));
 
+  // react to external changes in the layout config
+  useEffect(() => {
+    const newLayout = createLayout(layoutConfig);
+
+    setLayout(newLayout);
+  }, [ layoutConfig ]);
+
   useEffect(() => {
     if (typeof layoutChanged === 'function') {
       layoutChanged(layout);
@@ -229,9 +236,9 @@ export default function PropertiesPanel(props) {
 
 // helpers //////////////////
 
-function createLayout(overrides) {
+function createLayout(overrides, defaults = DEFAULT_LAYOUT) {
   return {
-    ...DEFAULT_LAYOUT,
+    ...defaults,
     ...overrides
   };
 }

--- a/src/hooks/useLayoutState.js
+++ b/src/hooks/useLayoutState.js
@@ -1,6 +1,6 @@
 import {
-  useContext,
-  useState
+  useCallback,
+  useContext
 } from 'preact/hooks';
 
 import {
@@ -29,16 +29,11 @@ export function useLayoutState(path, defaultValue) {
   } = useContext(LayoutContext);
 
   const layoutForKey = getLayoutForKey(path, defaultValue);
-  const [ value, set ] = useState(layoutForKey);
 
-  const setState = (newValue) => {
-
-    // (1) set component state
-    set(newValue);
-
-    // (2) set context
+  const setState = useCallback ((newValue) => {
     setLayoutForKey(path, newValue);
-  };
+  }, [ setLayoutForKey ]);
 
-  return [ value, setState ];
+
+  return [ layoutForKey, setState ];
 }

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -1,6 +1,7 @@
 import {
   act,
-  render
+  render,
+  cleanup
 } from '@testing-library/preact/pure';
 
 import TestContainer from 'mocha-test-container-support';
@@ -51,6 +52,8 @@ describe('<PropertiesPanel>', function() {
     parent.appendChild(container);
   });
 
+
+  afterEach(cleanup);
 
   it('should render (no element)', function() {
 
@@ -315,10 +318,7 @@ describe('<PropertiesPanel>', function() {
     });
 
 
-    // For some reason, this will make other tests fail if not skipped.
-    // It suceeds when run individually.
-    // Sample of failing test: <Collapsible> should toggle open
-    it.skip('should notify on external layout change', async function() {
+    it('should notify on external layout change', async function() {
 
       // given
       const initialLayoutConfig = {
@@ -342,8 +342,6 @@ describe('<PropertiesPanel>', function() {
         open: false,
         foo: 'baz'
       };
-
-      options.layoutConfig = updatedLayoutConfig;
 
       createPropertiesPanel({
         ...options,

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -314,6 +314,46 @@ describe('<PropertiesPanel>', function() {
       });
     });
 
+
+    // For some reason, this will make other tests fail if not skipped.
+    // It suceeds when run individually.
+    // Sample of failing test: <Collapsible> should toggle open
+    it.skip('should notify on external layout change', async function() {
+
+      // given
+      const initialLayoutConfig = {
+        open: true,
+        foo: 'bar'
+      };
+
+      const layoutChangedSpy = sinon.spy();
+
+      const options = {
+        container,
+        element: noopElement,
+        layoutConfig: initialLayoutConfig,
+        layoutChanged: layoutChangedSpy,
+      };
+
+      const { rerender } = createPropertiesPanel(options);
+
+      // when
+      const updatedLayoutConfig = {
+        open: false,
+        foo: 'baz'
+      };
+
+      options.layoutConfig = updatedLayoutConfig;
+
+      createPropertiesPanel({
+        ...options,
+        layoutConfig: updatedLayoutConfig
+      }, rerender);
+
+      // then
+      expect(layoutChangedSpy).to.have.been.calledWith(updatedLayoutConfig);
+    });
+
   });
 
 
@@ -364,7 +404,7 @@ describe('<PropertiesPanel>', function() {
 
 // helpers //////////
 
-function createPropertiesPanel(options = {}) {
+function createPropertiesPanel(options = {}, renderFn = render) {
 
   const {
     container,
@@ -372,13 +412,13 @@ function createPropertiesPanel(options = {}) {
     headerProvider = HeaderProvider,
     placeholderProvider = PlaceholderProvider,
     groups = [],
-    layoutConfig,
+    layoutConfig = {},
     layoutChanged = noop,
-    descriptionConfig,
+    descriptionConfig = {},
     descriptionLoaded = noop
   } = options;
 
-  return render(
+  return renderFn(
     <PropertiesPanel
       element={ element }
       headerProvider={ headerProvider }

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -110,7 +110,9 @@ describe('<Collapsible>', function() {
     expect(domClasses(entries).has('open')).to.be.false;
 
     // when
-    await header.click();
+    await act(() => {
+      header.click();
+    });
 
     // then
     expect(domClasses(entries).has('open')).to.be.true;

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -417,7 +417,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel active', function() {
+      it('should toggle feel active', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -434,7 +434,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         return waitFor(() => {
@@ -874,7 +876,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel active', function() {
+      it('should toggle feel active', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -891,7 +893,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         return waitFor(() => {
@@ -1086,7 +1090,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should be edited after update', function() {
+      it('should be edited after update', async function() {
 
         // given
         const result = createFeelField({ container, feel: 'required' });
@@ -1098,7 +1102,9 @@ describe('<FeelField>', function() {
         expect(isEdited(input)).to.be.false;
 
         // when
-        contentEditable.textContent = 'foo';
+        await act(() => {
+          contentEditable.textContent = 'foo';
+        });
 
         // then
         return waitFor(() => {
@@ -1147,7 +1153,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should show syntax error', function() {
+      it('should show syntax error', async function() {
 
         // given
         const clock = sinon.useFakeTimers();
@@ -1155,17 +1161,17 @@ describe('<FeelField>', function() {
 
         // when
         // trigger debounced validation
-        clock.tick(1000);
-        clock.restore();
+        await act(() => { clock.tick(1000); });
+        await act(() => { clock.restore(); });
 
         // then
-        return waitFor(() => {
+        await waitFor(() => {
           expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
         });
       });
 
 
-      it('should show local error over global error', function() {
+      it('should show local error over global error', async function() {
 
         // given
         const clock = sinon.useFakeTimers();
@@ -1188,8 +1194,9 @@ describe('<FeelField>', function() {
 
         // when
         // trigger debounced validation
-        clock.tick(1000);
-        clock.restore();
+        await act(() => { clock.tick(1000); });
+        await act(() => { clock.restore(); });
+
 
         // then
         return waitFor(() => {
@@ -1229,7 +1236,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should set invalid', function() {
+      it('should set invalid', async function() {
 
         // given
         const validate = (v) => {
@@ -1244,7 +1251,10 @@ describe('<FeelField>', function() {
         const input = domQuery('[role="textbox"]', entry);
 
         // when
-        input.textContent = 'bar';
+        await act(() => {
+          input.textContent = 'bar';
+        });
+
 
         // then
         return waitFor(() => {
@@ -1277,7 +1287,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should show error message', function() {
+      it('should show error message', async function() {
 
         // given
         const validate = (v) => {
@@ -1292,7 +1302,10 @@ describe('<FeelField>', function() {
         const input = domQuery('[role="textbox"]', entry);
 
         // when
-        input.textContent = 'bar';
+        await act(() => {
+          input.textContent = 'bar';
+        });
+
 
         // then
         return waitFor(() => {
@@ -1455,7 +1468,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel inactive', function() {
+      it('should toggle feel inactive', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -1472,14 +1485,16 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         expect(updateSpy).to.have.been.calledWith('foo');
       });
 
 
-      it('should NOT toggle if FEEL is required', function() {
+      it('should NOT toggle if FEEL is required', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -1496,7 +1511,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         expect(updateSpy).not.to.have.been.called;

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -1,4 +1,4 @@
-import { useContext } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 
 import {
   act,
@@ -22,7 +22,7 @@ import {
 
 import ListGroup from 'src/components/ListGroup';
 
-import { PropertiesPanelContext } from 'src/context';
+import { PropertiesPanelContext, LayoutContext } from 'src/context';
 
 insertCoreStyles();
 
@@ -134,7 +134,7 @@ describe('<ListGroup>', function() {
     const Entry = () => {
       const { onShow } = useContext(PropertiesPanelContext);
 
-      onShow();
+      useEffect(onShow, []);
     };
 
     const items = [
@@ -1122,7 +1122,7 @@ describe('<ListGroup>', function() {
 function createListGroup(options = {}, renderFn = render) {
   const {
     element = noopElement,
-    id,
+    id = 'sampleId',
     label = 'List',
     items = [],
     add,
@@ -1132,14 +1132,16 @@ function createListGroup(options = {}, renderFn = render) {
   } = options;
 
   return renderFn(
-    <ListGroup
-      element={ element }
-      id={ id }
-      label={ label }
-      items={ items }
-      add={ add }
-      shouldSort={ shouldSort }
-      shouldOpen={ shouldOpen } />,
+    <MockLayout>
+      <ListGroup
+        element={ element }
+        id={ id }
+        label={ label }
+        items={ items }
+        add={ add }
+        shouldSort={ shouldSort }
+        shouldOpen={ shouldOpen } />
+    </MockLayout>,
     {
       container
     }
@@ -1158,4 +1160,26 @@ function getListOrdering(list) {
   });
 
   return ordering;
+}
+
+function MockLayout({ children }) {
+  const [ layout, setLayout ] = useState({});
+
+  const getLayoutForKey = (key, defaultValue) => {
+    return layout[key] || defaultValue;
+  };
+
+  const setLayoutForKey = (key, value) => {
+    setLayout({
+      [key]: value
+    });
+  };
+
+  const context = {
+    layout,
+    getLayoutForKey,
+    setLayoutForKey
+  };
+
+  return <LayoutContext.Provider value={ context }>{children}</LayoutContext.Provider>;
 }


### PR DESCRIPTION
- Groups: don't use local state in [`useLayoutState`](https://github.com/bpmn-io/properties-panel/blob/e01dd051aba1b4998bcc6f7a591ad7cdf8fc4cf7/src/hooks/useLayoutState.js#L26). Instead, always use the Context value, so outside changes in the layout are reflected in the Groups.
- PropertiesPanel (root): React to `layoutConfig` changes, e.g. from other tabs. Currently, only the initial value is used.

related to https://github.com/camunda/camunda-modeler/issues/2638
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
