### PR TITLE
fix(PropertiesPanel): only call callbacks once on first render

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -109,9 +109,9 @@ export default function PropertiesPanel(props) {
     headerProvider,
     placeholderProvider,
     groups,
-    layoutConfig = {},
+    layoutConfig,
     layoutChanged,
-    descriptionConfig = {},
+    descriptionConfig,
     descriptionLoaded,
     eventBus
   } = props;
@@ -236,14 +236,14 @@ export default function PropertiesPanel(props) {
 
 // helpers //////////////////
 
-function createLayout(overrides, defaults = DEFAULT_LAYOUT) {
+function createLayout(overrides = {}, defaults = DEFAULT_LAYOUT) {
   return {
     ...defaults,
     ...overrides
   };
 }
 
-function createDescriptionContext(overrides) {
+function createDescriptionContext(overrides = {}) {
   return {
     ...DEFAULT_DESCRIPTION,
     ...overrides

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -119,6 +119,13 @@ export default function PropertiesPanel(props) {
   // set-up layout context
   const [ layout, setLayout ] = useState(createLayout(layoutConfig));
 
+  // react to external changes in the layout config
+  useEffect(() => {
+    const newLayout = createLayout(layoutConfig);
+
+    setLayout(newLayout);
+  }, [ layoutConfig ]);
+
   useEffect(() => {
     if (typeof layoutChanged === 'function') {
       layoutChanged(layout);
@@ -229,9 +236,9 @@ export default function PropertiesPanel(props) {
 
 // helpers //////////////////
 
-function createLayout(overrides) {
+function createLayout(overrides, defaults = DEFAULT_LAYOUT) {
   return {
-    ...DEFAULT_LAYOUT,
+    ...defaults,
     ...overrides
   };
 }

--- a/src/hooks/useLayoutState.js
+++ b/src/hooks/useLayoutState.js
@@ -1,6 +1,6 @@
 import {
-  useContext,
-  useState
+  useCallback,
+  useContext
 } from 'preact/hooks';
 
 import {
@@ -29,16 +29,11 @@ export function useLayoutState(path, defaultValue) {
   } = useContext(LayoutContext);
 
   const layoutForKey = getLayoutForKey(path, defaultValue);
-  const [ value, set ] = useState(layoutForKey);
 
-  const setState = (newValue) => {
-
-    // (1) set component state
-    set(newValue);
-
-    // (2) set context
+  const setState = useCallback ((newValue) => {
     setLayoutForKey(path, newValue);
-  };
+  }, [ setLayoutForKey ]);
 
-  return [ value, setState ];
+
+  return [ layoutForKey, setState ];
 }

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -276,6 +276,7 @@ describe('<PropertiesPanel>', function() {
       });
 
       // then
+      expect(layoutChangedSpy).to.have.been.calledOnce;
       expect(layoutChangedSpy).to.have.been.calledWith(layoutConfig);
     });
 
@@ -375,6 +376,7 @@ describe('<PropertiesPanel>', function() {
       });
 
       // then
+      expect(descriptionLoadedSpy).to.have.been.calledOnce;
       expect(descriptionLoadedSpy).to.have.been.calledWith(descriptionConfig);
     });
 
@@ -392,6 +394,7 @@ describe('<PropertiesPanel>', function() {
       });
 
       // then
+      expect(descriptionLoadedSpy).to.have.been.calledOnce;
       expect(descriptionLoadedSpy).to.have.been.calledWith({});
     });
 

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -281,6 +281,25 @@ describe('<PropertiesPanel>', function() {
     });
 
 
+    it('should notify on initial layout loaded (default layout)', async function() {
+
+      // given
+      const DEFAULT_LAYOUT = { open: true };
+      const layoutChangedSpy = sinon.spy();
+
+      // when
+      createPropertiesPanel({
+        container,
+        element: noopElement,
+        layoutChanged: layoutChangedSpy
+      });
+
+      // then
+      expect(layoutChangedSpy).to.have.been.calledOnce;
+      expect(layoutChangedSpy).to.have.been.calledWith(DEFAULT_LAYOUT);
+    });
+
+
     it('should notify on layout changed', async function() {
 
       // given
@@ -310,6 +329,7 @@ describe('<PropertiesPanel>', function() {
       });
 
       // then
+      expect(layoutChangedSpy).to.have.been.calledTwice;
       expect(layoutChangedSpy).to.have.been.calledWith({
         open: true,
         groups: {
@@ -381,7 +401,7 @@ describe('<PropertiesPanel>', function() {
     });
 
 
-    it('should use default config, given no config provided', function() {
+    it('should use default config, given no config provided', async function() {
 
       // given
       const descriptionLoadedSpy = sinon.spy();
@@ -392,6 +412,7 @@ describe('<PropertiesPanel>', function() {
         element: noopElement,
         descriptionLoaded: descriptionLoadedSpy
       });
+
 
       // then
       expect(descriptionLoadedSpy).to.have.been.calledOnce;
@@ -413,9 +434,9 @@ function createPropertiesPanel(options = {}, renderFn = render) {
     headerProvider = HeaderProvider,
     placeholderProvider = PlaceholderProvider,
     groups = [],
-    layoutConfig = {},
+    layoutConfig,
     layoutChanged = noop,
-    descriptionConfig = {},
+    descriptionConfig,
     descriptionLoaded = noop
   } = options;
 

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -1,6 +1,7 @@
 import {
   act,
-  render
+  render,
+  cleanup
 } from '@testing-library/preact/pure';
 
 import TestContainer from 'mocha-test-container-support';
@@ -51,6 +52,8 @@ describe('<PropertiesPanel>', function() {
     parent.appendChild(container);
   });
 
+
+  afterEach(cleanup);
 
   it('should render (no element)', function() {
 
@@ -314,6 +317,41 @@ describe('<PropertiesPanel>', function() {
       });
     });
 
+
+    it('should notify on external layout change', async function() {
+
+      // given
+      const initialLayoutConfig = {
+        open: true,
+        foo: 'bar'
+      };
+
+      const layoutChangedSpy = sinon.spy();
+
+      const options = {
+        container,
+        element: noopElement,
+        layoutConfig: initialLayoutConfig,
+        layoutChanged: layoutChangedSpy,
+      };
+
+      const { rerender } = createPropertiesPanel(options);
+
+      // when
+      const updatedLayoutConfig = {
+        open: false,
+        foo: 'baz'
+      };
+
+      createPropertiesPanel({
+        ...options,
+        layoutConfig: updatedLayoutConfig
+      }, rerender);
+
+      // then
+      expect(layoutChangedSpy).to.have.been.calledWith(updatedLayoutConfig);
+    });
+
   });
 
 
@@ -364,7 +402,7 @@ describe('<PropertiesPanel>', function() {
 
 // helpers //////////
 
-function createPropertiesPanel(options = {}) {
+function createPropertiesPanel(options = {}, renderFn = render) {
 
   const {
     container,
@@ -372,13 +410,13 @@ function createPropertiesPanel(options = {}) {
     headerProvider = HeaderProvider,
     placeholderProvider = PlaceholderProvider,
     groups = [],
-    layoutConfig,
+    layoutConfig = {},
     layoutChanged = noop,
-    descriptionConfig,
+    descriptionConfig = {},
     descriptionLoaded = noop
   } = options;
 
-  return render(
+  return renderFn(
     <PropertiesPanel
       element={ element }
       headerProvider={ headerProvider }

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -110,7 +110,9 @@ describe('<Collapsible>', function() {
     expect(domClasses(entries).has('open')).to.be.false;
 
     // when
-    await header.click();
+    await act(() => {
+      header.click();
+    });
 
     // then
     expect(domClasses(entries).has('open')).to.be.true;

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -417,7 +417,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel active', function() {
+      it('should toggle feel active', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -434,7 +434,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         return waitFor(() => {
@@ -874,7 +876,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel active', function() {
+      it('should toggle feel active', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -891,7 +893,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         return waitFor(() => {
@@ -1086,7 +1090,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should be edited after update', function() {
+      it('should be edited after update', async function() {
 
         // given
         const result = createFeelField({ container, feel: 'required' });
@@ -1098,7 +1102,9 @@ describe('<FeelField>', function() {
         expect(isEdited(input)).to.be.false;
 
         // when
-        contentEditable.textContent = 'foo';
+        await act(() => {
+          contentEditable.textContent = 'foo';
+        });
 
         // then
         return waitFor(() => {
@@ -1147,7 +1153,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should show syntax error', function() {
+      it('should show syntax error', async function() {
 
         // given
         const clock = sinon.useFakeTimers();
@@ -1155,17 +1161,17 @@ describe('<FeelField>', function() {
 
         // when
         // trigger debounced validation
-        clock.tick(1000);
-        clock.restore();
+        await act(() => { clock.tick(1000); });
+        await act(() => { clock.restore(); });
 
         // then
-        return waitFor(() => {
+        await waitFor(() => {
           expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
         });
       });
 
 
-      it('should show local error over global error', function() {
+      it('should show local error over global error', async function() {
 
         // given
         const clock = sinon.useFakeTimers();
@@ -1188,8 +1194,9 @@ describe('<FeelField>', function() {
 
         // when
         // trigger debounced validation
-        clock.tick(1000);
-        clock.restore();
+        await act(() => { clock.tick(1000); });
+        await act(() => { clock.restore(); });
+
 
         // then
         return waitFor(() => {
@@ -1229,7 +1236,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should set invalid', function() {
+      it('should set invalid', async function() {
 
         // given
         const validate = (v) => {
@@ -1244,7 +1251,10 @@ describe('<FeelField>', function() {
         const input = domQuery('[role="textbox"]', entry);
 
         // when
-        input.textContent = 'bar';
+        await act(() => {
+          input.textContent = 'bar';
+        });
+
 
         // then
         return waitFor(() => {
@@ -1277,7 +1287,7 @@ describe('<FeelField>', function() {
       });
 
 
-      it('should show error message', function() {
+      it('should show error message', async function() {
 
         // given
         const validate = (v) => {
@@ -1292,7 +1302,10 @@ describe('<FeelField>', function() {
         const input = domQuery('[role="textbox"]', entry);
 
         // when
-        input.textContent = 'bar';
+        await act(() => {
+          input.textContent = 'bar';
+        });
+
 
         // then
         return waitFor(() => {
@@ -1455,7 +1468,7 @@ describe('<FeelField>', function() {
 
     describe('toggle', function() {
 
-      it('should toggle feel inactive', function() {
+      it('should toggle feel inactive', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -1472,14 +1485,16 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         expect(updateSpy).to.have.been.calledWith('foo');
       });
 
 
-      it('should NOT toggle if FEEL is required', function() {
+      it('should NOT toggle if FEEL is required', async function() {
 
         // given
         const updateSpy = sinon.spy();
@@ -1496,7 +1511,9 @@ describe('<FeelField>', function() {
           field.container);
 
         // when
-        icon.click();
+        await act(() => {
+          icon.click();
+        });
 
         // then
         expect(updateSpy).not.to.have.been.called;

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 
 import {
   act,
@@ -22,7 +22,7 @@ import {
 
 import ListGroup from 'src/components/ListGroup';
 
-import { PropertiesPanelContext } from 'src/context';
+import { PropertiesPanelContext, LayoutContext } from 'src/context';
 
 insertCoreStyles();
 
@@ -134,7 +134,7 @@ describe('<ListGroup>', function() {
     const Entry = () => {
       const { onShow } = useContext(PropertiesPanelContext);
 
-      onShow();
+      useEffect(onShow, []);
     };
 
     const items = [
@@ -1256,21 +1256,23 @@ function TestGroup(props) {
   } = props;
 
   return (
-    <ListGroup
-      element={ element }
-      id={ id }
-      label={ label }
-      items={ items }
-      add={ add }
-      shouldSort={ shouldSort }
-      shouldOpen={ shouldOpen } />
+    <MockLayout>
+      <ListGroup
+        element={ element }
+        id={ id }
+        label={ label }
+        items={ items }
+        add={ add }
+        shouldSort={ shouldSort }
+        shouldOpen={ shouldOpen } />
+    </MockLayout>
   );
 }
 
 function createListGroup(options = {}, renderFn = render) {
   const {
     element = noopElement,
-    id,
+    id = 'sampleId',
     label = 'List',
     items = [],
     add,
@@ -1287,7 +1289,8 @@ function createListGroup(options = {}, renderFn = render) {
       items={ items }
       add={ add }
       shouldSort={ shouldSort }
-      shouldOpen={ shouldOpen } />,
+      shouldOpen={ shouldOpen }
+    /> ,
     {
       container
     }
@@ -1306,4 +1309,26 @@ function getListOrdering(list) {
   });
 
   return ordering;
+}
+
+function MockLayout({ children }) {
+  const [ layout, setLayout ] = useState({});
+
+  const getLayoutForKey = (key, defaultValue) => {
+    return layout[key] || defaultValue;
+  };
+
+  const setLayoutForKey = (key, value) => {
+    setLayout({
+      [key]: value
+    });
+  };
+
+  const context = {
+    layout,
+    getLayoutForKey,
+    setLayoutForKey
+  };
+
+  return <LayoutContext.Provider value={ context }>{children}</LayoutContext.Provider>;
 }


### PR DESCRIPTION
with https://github.com/bpmn-io/properties-panel/pull/225 we introduced changes so the layout reacts to external changes.

With the changes, we introduced another re-render cycle during bootstrapping, causing `layoutChanged` and `descriptionLoaded` to be called twice. 

This PR ensures the callbacks are only called once.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
