### PR TITLE
fix(ListGroup): don't open on external changes

### DIFF
--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -247,8 +247,9 @@ export default function ListGroup(props) {
 
             const { id } = item;
 
-            // if item was added, open first or last item based on ordering
-            const autoOpen = newItemAdded && (shouldSort ? index === 0 : index === ordering.length - 1);
+            // if item was added, open it
+            // Existing items will not be affected as autoOpen is only applied on first render
+            const autoOpen = newItemAdded;
 
             return (
               <ListItem

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -980,6 +980,64 @@ describe('<ListGroup>', function() {
       });
 
 
+      it('should open on adding new item in the middle', async function() {
+
+        // given
+        const newItems = [
+          {
+            id: 'item-1',
+            label: 'Item 1'
+          },
+          {
+            id: 'item-2',
+            label: 'Item 2'
+          },
+          {
+            id: 'item-3',
+            label: 'Item 3'
+          }
+        ];
+
+        const items = [ newItems[0], newItems[2] ];
+
+
+        const Component = () => {
+          const [ testItems, setTestItems ] = useState(items);
+
+          const add = () => {
+            setTestItems(newItems);
+          };
+
+          return <TestGroup items={ testItems } add={ add } shouldSort={ true }></TestGroup>;
+        };
+
+        const {
+          container
+        } = render(<Component />, parentContainer);
+
+        const list = domQuery('.bio-properties-panel-list', container);
+        const addButton = domQuery('.bio-properties-panel-add-entry', container);
+
+        // assume
+        expect(domClasses(list).has('open')).to.be.false;
+
+        // when
+        await act(() => {
+          addButton.click();
+        });
+
+        // then
+        const newItem = domQuery('[data-entry-id="item-2"]', container);
+        const oldItem = domQuery('[data-entry-id="item-1"]', container);
+        const otherOldItem = domQuery('[data-entry-id="item-3"]', container);
+
+        expect(domClasses(newItem).has('open')).to.be.true;
+        expect(domClasses(oldItem).has('open')).to.be.false;
+        expect(domClasses(otherOldItem).has('open')).to.be.false;
+        expect(domClasses(list).has('open')).to.be.true;
+      });
+
+
       it('should NOT open when change was not triggered by clicking add button', function() {
 
         // given

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -1,4 +1,4 @@
-import { useContext } from 'preact/hooks';
+import { useContext, useState } from 'preact/hooks';
 
 import {
   act,
@@ -873,7 +873,114 @@ describe('<ListGroup>', function() {
 
     describe('open', function() {
 
-      it('should open on adding new item per default', function() {
+      it('should open on adding new item per default', async function() {
+
+        // given
+        const items = [
+          {
+            id: 'item-1',
+            label: 'Item 1'
+          }
+        ];
+
+        const newItems = [
+          ...items,
+          {
+            id: 'item-2',
+            label: 'Item 2'
+          },
+        ];
+
+        const Component = () => {
+          const [ testItems, setTestItems ] = useState(items);
+
+          const add = () => {
+            setTestItems(newItems);
+          };
+
+          return <TestGroup items={ testItems } add={ add } shouldSort={ true }></TestGroup>;
+        };
+
+        const {
+          container
+        } = render(<Component />, parentContainer);
+
+        const list = domQuery('.bio-properties-panel-list', container);
+        const addButton = domQuery('.bio-properties-panel-add-entry', container);
+
+        // assume
+        expect(domClasses(list).has('open')).to.be.false;
+
+
+        // when
+        await act(() => {
+          addButton.click();
+        });
+
+        // then
+        const newItem = domQuery('[data-entry-id="item-2"]', container);
+        const oldItem = domQuery('[data-entry-id="item-1"]', container);
+
+        expect(domClasses(newItem).has('open')).to.be.true;
+        expect(domClasses(oldItem).has('open')).to.be.false;
+        expect(domClasses(list).has('open')).to.be.true;
+      });
+
+
+      it('should open on adding new item per default given no sorting', async function() {
+
+        // given
+        const items = [
+          {
+            id: 'item-1',
+            label: 'Item 1'
+          }
+        ];
+
+        const newItems = [
+          ...items,
+          {
+            id: 'item-2',
+            label: 'Item 2'
+          }
+        ];
+
+        const Component = () => {
+          const [ testItems, setTestItems ] = useState(items);
+
+          const add = () => {
+            setTestItems(newItems);
+          };
+
+          return <TestGroup items={ testItems } add={ add } shouldSort={ false }></TestGroup>;
+        };
+
+        const {
+          container
+        } = render(<Component />, parentContainer);
+
+        const list = domQuery('.bio-properties-panel-list', container);
+        const addButton = domQuery('.bio-properties-panel-add-entry', container);
+
+        // assume
+        expect(domClasses(list).has('open')).to.be.false;
+
+        // when
+        await act(() => {
+          addButton.click();
+        });
+
+        // then
+        const newItem = domQuery('[data-entry-id="item-2"]', container);
+        const oldItem = domQuery('[data-entry-id="item-1"]', container);
+
+        expect(domClasses(newItem).has('open')).to.be.true;
+        expect(domClasses(oldItem).has('open')).to.be.false;
+        expect(domClasses(list).has('open')).to.be.true;
+      });
+
+
+      it('should NOT open when change was not triggered by clicking add button', function() {
 
         // given
         const items = [
@@ -908,49 +1015,9 @@ describe('<ListGroup>', function() {
         const newItem = domQuery('[data-entry-id="item-2"]', container);
         const oldItem = domQuery('[data-entry-id="item-1"]', container);
 
-        expect(domClasses(newItem).has('open')).to.be.true;
+        expect(domClasses(newItem).has('open')).to.be.false;
         expect(domClasses(oldItem).has('open')).to.be.false;
-      });
-
-
-      it('should open on adding new item per default given no sorting', function() {
-
-        // given
-        const items = [
-          {
-            id: 'item-1',
-            label: 'Item 1'
-          }
-        ];
-
-        const {
-          container,
-          rerender
-        } = createListGroup({ container: parentContainer, items });
-
-        const list = domQuery('.bio-properties-panel-list', container);
-
-        // assume
         expect(domClasses(list).has('open')).to.be.false;
-
-        const newItems = [
-          ...items,
-          {
-            id: 'item-2',
-            label: 'Item 2'
-          }
-        ];
-
-        // when
-        createListGroup({ items: newItems, shouldSort: false }, rerender);
-
-        // then
-        const newItem = domQuery('[data-entry-id="item-2"]', container);
-        const oldItem = domQuery('[data-entry-id="item-1"]', container);
-
-        expect(domClasses(newItem).has('open')).to.be.true;
-        expect(domClasses(oldItem).has('open')).to.be.false;
-        expect(domClasses(list).has('open')).to.be.true;
       });
 
 
@@ -1119,6 +1186,29 @@ describe('<ListGroup>', function() {
 
 // helpers ////////////////////
 
+function TestGroup(props) {
+  const {
+    element = noopElement,
+    id = 'sampleId',
+    label = 'List',
+    items = [],
+    add,
+    shouldSort,
+    shouldOpen
+  } = props;
+
+  return (
+    <ListGroup
+      element={ element }
+      id={ id }
+      label={ label }
+      items={ items }
+      add={ add }
+      shouldSort={ shouldSort }
+      shouldOpen={ shouldOpen } />
+  );
+}
+
 function createListGroup(options = {}, renderFn = render) {
   const {
     element = noopElement,
@@ -1132,7 +1222,7 @@ function createListGroup(options = {}, renderFn = render) {
   } = options;
 
   return renderFn(
-    <ListGroup
+    <TestGroup
       element={ element }
       id={ id }
       label={ label }


### PR DESCRIPTION
Found while working on https://github.com/bpmn-io/bpmn-js-example-data-extension/issues/1, cf. https://camunda.slack.com/archives/GP70M0J6M/p1679407286325119

This ensures that we only open the section when the change originated from the `add` button click:

![Recording 2023-03-22 at 14 01 11](https://user-images.githubusercontent.com/21984219/226912426-5d64292a-31c9-4fd9-a749-a4e6287446d1.gif)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
