### PR TITLE
feat: support local `TextArea#validate` hook

### DIFF
--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -304,6 +304,102 @@ describe('<TextArea>', function() {
   });
 
 
+  describe('validation', function() {
+
+    it('should set valid', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextArea({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'foo');
+
+      // then
+      expect(isValid(entry)).to.be.true;
+    });
+
+
+    it('should set invalid', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextArea({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(isValid(entry)).to.be.false;
+    });
+
+
+    it('should keep showing invalid value', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextArea({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(input.value).to.eql('bar');
+    });
+
+
+    it('should show error message', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextArea({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      const error = domQuery('.bio-properties-panel-error', entry);
+
+      // then
+      expect(error).to.exist;
+      expect(error.innerText).to.eql('error');
+    });
+
+  });
+
+
   describe('auto resize', function() {
 
     it('should resize initially', function() {


### PR DESCRIPTION
Mirrors validation behavior of `TextField`.

Closes https://github.com/bpmn-io/properties-panel/issues/233