### PR TITLE
fix(Groups): update sticky observer on attach/detach

### DIFF
--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -60,7 +60,7 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
 
     const observer = new Observer((entries) => {
 
-      // The ScrollContainer is unmounted, do not update sticky state
+      // scroll container is unmounted, do not update sticky state
       if (scrollContainer.scrollHeight === 0) {
         return;
       }


### PR DESCRIPTION
related to https://github.com/camunda/web-modeler/issues/4650

This PR:
 - subscribes to attach/detach events
 - then updates the scroll container
 - Removes/Adds an Intersection Observer to the new scrollContainer
 
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
