### PR TITLE
feat(feel): add number feel entry

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -28,6 +28,8 @@ import FeelIcon from './FeelIcon';
 
 import { ToggleSwitch } from '../ToggleSwitch';
 
+import { NumberField } from '../NumberField';
+
 const noop = () => { };
 
 function FeelTextfield(props) {
@@ -273,6 +275,59 @@ const OptionalFeelInput = forwardRef((props, ref) => {
 });
 
 
+const OptionalFeelNumberField = forwardRef((props, ref) => {
+  const {
+    id,
+    debounce,
+    disabled,
+    onInput,
+    value,
+    min,
+    max,
+    step,
+    onFocus,
+    onBlur
+  } = props;
+
+  const inputRef = useRef();
+
+  // To be consistent with the FEEL editor, set focus at start of input
+  // this ensures clean editing experience when switching with the keyboard
+  ref.current = {
+    focus: (position) => {
+      const input = inputRef.current;
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+      if (typeof position === 'number' && position !== Infinity) {
+        if (position > value.length) {
+          position = value.length;
+        }
+        input.setSelectionRange(position, position);
+      }
+
+    }
+  };
+
+  return <NumberField
+    id={ id }
+    debounce={ debounce }
+    disabled={ disabled }
+    displayLabel={ false }
+    inputRef={ inputRef }
+    max={ max }
+    min={ min }
+    onInput={ onInput }
+    step={ step }
+    value={ value }
+    onFocus={ onFocus }
+    onBlur={ onBlur }
+  />;
+});
+
+
 const OptionalFeelTextArea = forwardRef((props, ref) => {
   const {
     id,
@@ -492,6 +547,7 @@ export default function FeelEntry(props) {
       }
       data-entry-id={ id }>
       <FeelTextfield
+        { ...props }
         debounce={ debounce }
         disabled={ disabled }
         feel={ feel }
@@ -514,6 +570,32 @@ export default function FeelEntry(props) {
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );
+}
+
+/**
+ * @param {Object} props
+ * @param {Object} props.element
+ * @param {String} props.id
+ * @param {String} props.description
+ * @param {Boolean} props.debounce
+ * @param {Boolean} props.disabled
+ * @param {String} props.max
+ * @param {String} props.min
+ * @param {String} props.step
+ * @param {Boolean} props.feel
+ * @param {String} props.label
+ * @param {Function} props.getValue
+ * @param {Function} props.setValue
+ * @param {Function} props.tooltipContainer
+ * @param {Function} props.validate
+ * @param {Function} props.show
+ * @param {Function} props.example
+ * @param {Function} props.variables
+ * @param {Function} props.onFocus
+ * @param {Function} props.onBlur
+ */
+export function FeelNumberEntry(props) {
+  return <FeelEntry class="bio-properties-panel-feel-number" OptionalComponent={ OptionalFeelNumberField } { ...props } />;
 }
 
 /**

--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -15,12 +15,14 @@ import {
   usePrevious
 } from '../../hooks';
 
-function NumberField(props) {
+export function NumberField(props) {
 
   const {
     debounce,
     disabled,
+    displayLabel = true,
     id,
+    inputRef,
     label,
     max,
     min,
@@ -62,9 +64,10 @@ function NumberField(props) {
 
   return (
     <div class="bio-properties-panel-numberfield">
-      <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label>
+      {displayLabel && <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label> }
       <input
         id={ prefixId(id) }
+        ref={ inputRef }
         type="number"
         name={ id }
         spellCheck="false"

--- a/src/components/entries/index.js
+++ b/src/components/entries/index.js
@@ -4,6 +4,7 @@ export { default as DescriptionEntry } from './Description';
 export {
   default as FeelEntry,
   FeelCheckboxEntry,
+  FeelNumberEntry,
   FeelTextAreaEntry,
   FeelTemplatingEntry,
   FeelToggleSwitchEntry,

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -30,6 +30,7 @@ import {
 
 import FeelField, {
   FeelCheckboxEntry,
+  FeelNumberEntry,
   FeelTextAreaEntry,
   FeelToggleSwitchEntry,
   isEdited
@@ -501,6 +502,464 @@ describe('<FeelField>', function() {
         // then
         return waitFor(() => {
           expect(updateSpy).to.have.been.calledWith('=foo');
+        });
+      });
+
+    });
+
+  });
+
+
+  describe('FEEL disabled (NumberField)', function() {
+
+    it('should render', function() {
+
+      // given
+      const result = createFeelNumber({ container });
+
+      // then
+      expect(domQuery('.bio-properties-panel-feel-entry', result.container)).to.exist;
+    });
+
+
+    it('should update', function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const result = createFeelNumber({ container, setValue: updateSpy });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      changeInput(input, 2);
+
+      // then
+      expect(updateSpy).to.have.been.calledWith(2);
+    });
+
+
+    it('should update (floating point number)', function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const result = createFeelNumber({ container, setValue: updateSpy, step: 'any' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      changeInput(input, 20.5);
+
+      // then
+      expect(updateSpy).to.have.been.calledWith(20.5);
+    });
+
+
+    describe('#isEdited', function() {
+
+      it('should NOT be edited', function() {
+
+        // given
+        const result = createFeelNumber({ container });
+
+        const input = domQuery('.bio-properties-panel-input', result.container);
+
+        // when
+        const edited = isEdited(input);
+
+        // then
+        expect(edited).to.be.false;
+      });
+
+
+      it('should be edited', function() {
+
+        // given
+        const result = createFeelNumber({ container, getValue: () => 2 });
+
+        const input = domQuery('.bio-properties-panel-input', result.container);
+
+        // when
+        const edited = isEdited(input);
+
+        // then
+        expect(edited).to.be.true;
+      });
+
+
+      it('should be edited after update', function() {
+
+        // given
+        const result = createFeelNumber({ container });
+
+        const input = domQuery('.bio-properties-panel-input', result.container);
+
+        // assume
+        expect(isEdited(input)).to.be.false;
+
+        // when
+        changeInput(input, 2);
+
+        // then
+        expect(isEdited(input)).to.be.true;
+      });
+
+    });
+
+
+    it('should use unique input element on element change', function() {
+
+      // given
+      const result = createFeelNumber({ element: {}, container });
+
+      const input = domQuery('.bio-properties-panel-input', container);
+
+      // when
+      createFeelNumber({ element: {}, container }, result.render);
+
+      // then
+      const newInput = domQuery('.bio-properties-panel-input', container);
+
+      expect(newInput).to.not.eql(input);
+    });
+
+
+    describe('events', function() {
+
+      it('should show entry', function() {
+
+        // given
+        const eventBus = new EventBus();
+
+        const onShowSpy = sinon.spy();
+
+        createFeelNumber({ id: 'foo', container, eventBus, onShow: onShowSpy });
+
+        // when
+        act(() => eventBus.fire('propertiesPanel.showEntry', { id: 'foo' }));
+
+        // then
+        expect(onShowSpy).to.have.been.called;
+      });
+
+    });
+
+
+    describe('errors', function() {
+
+      it('should get error', function() {
+
+        // given
+        const errors = {
+          foo: 'bar'
+        };
+
+        const result = createFeelNumber({ container, errors, id: 'foo' });
+
+        // then
+        expect(domQuery('.bio-properties-panel-error', result.container)).to.exist;
+      });
+
+    });
+
+    describe('validation', function() {
+
+      it('should set valid', function() {
+
+        // given
+        const validate = (v) => {
+          if (v === 3) {
+            return 'error';
+          }
+        };
+
+        const result = createFeelNumber({ container, validate });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 2);
+
+        // then
+        expect(isValid(entry)).to.be.true;
+      });
+
+
+      it('should set invalid', function() {
+
+        // given
+        const validate = (v) => {
+          if (v === 3) {
+            return 'error';
+          }
+        };
+
+        const result = createFeelNumber({ container, validate });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 3);
+
+        // then
+        expect(isValid(entry)).to.be.false;
+      });
+
+
+      it('should keep showing invalid value', function() {
+
+        // given
+        const validate = (v) => {
+          if (v === 3) {
+            return 'error';
+          }
+        };
+
+        const result = createFeelNumber({ container, validate });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 3);
+
+        // then
+        expect(input.value).to.eql('3');
+      });
+
+
+      it('should show error message', function() {
+
+        // given
+        const validate = (v) => {
+          if (v === 3) {
+            return 'error';
+          }
+        };
+
+        const result = createFeelNumber({ container, validate });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 3);
+
+        const error = domQuery('.bio-properties-panel-error', entry);
+
+        // then
+        expect(error).to.exist;
+        expect(error.innerText).to.eql('error');
+      });
+
+    });
+
+
+    describe('disabled', function() {
+
+      it('should render enabled per default', function() {
+
+        // given
+        const result = createFeelNumber({ container });
+
+        // then
+        const textInput = domQuery('.bio-properties-panel-feel-entry input', result.container);
+        expect(textInput.disabled).to.be.false;
+      });
+
+
+      it('should render enabled if set', function() {
+
+        // given
+        const result = createFeelNumber({
+          container,
+          disabled: false
+        });
+
+        // then
+        const textInput = domQuery('.bio-properties-panel-feel-entry input', result.container);
+        expect(textInput.disabled).to.be.false;
+      });
+
+
+      it('should render disabled if set', function() {
+
+        // given
+        const result = createFeelNumber({
+          container,
+          disabled: true
+        });
+
+        // then
+        const textInput = domQuery('.bio-properties-panel-feel-entry input', result.container);
+        expect(textInput.disabled).to.be.true;
+      });
+
+    });
+
+
+    describe('description', function() {
+
+      it('should render without description per default', function() {
+
+        // given
+        const result = createFeelNumber({
+          container,
+          id: 'noDescriptionNumberField'
+        });
+
+        // then
+        const description = domQuery('[data-entry-id="noDescriptionNumberField"] .bio-properties-panel-description',
+          result.container);
+        expect(description).not.to.exist;
+      });
+
+
+      it('should render with description if set per props', function() {
+
+        // given
+        const result = createFeelNumber({
+          container,
+          id: 'descriptionNumberField',
+          label: 'someLabel',
+          description: 'my description'
+        });
+
+        // then
+        const description = domQuery('[data-entry-id="descriptionNumberField"] .bio-properties-panel-description',
+          result.container);
+
+        expect(description).to.exist;
+        expect(description.innerText).to.equal('my description');
+      });
+
+
+      it('should render with description if set per context', function() {
+
+        // given
+        const descriptionConfig = { descriptionNumberField: (element) => 'myContextDesc' };
+
+        const result = createFeelNumber({
+          container,
+          id: 'descriptionNumberField',
+          label: 'someLabel',
+          descriptionConfig,
+          getDescriptionForId: (id, element) => descriptionConfig[id](element)
+        });
+
+        // then
+        const description = domQuery('[data-entry-id="descriptionNumberField"] .bio-properties-panel-description',
+          result.container);
+
+        expect(description).to.exist;
+        expect(description.innerText).to.equal('myContextDesc');
+      });
+
+
+      it('should render description set per props over context', function() {
+
+        // given
+        const descriptionConfig = { descriptionNumberField: (element) => 'myContextDesc' };
+
+        const result = createFeelNumber({
+          container,
+          id: 'descriptionNumberField',
+          label: 'someLabel',
+          description: 'myExplicitDescription',
+          descriptionConfig,
+          getDescriptionForId: (id, element) => descriptionConfig[id](element)
+        });
+
+        // then
+        const description = domQuery('[data-entry-id="descriptionNumberField"] .bio-properties-panel-description',
+          result.container);
+
+        expect(description).to.exist;
+        expect(description.innerText).to.equal('myExplicitDescription');
+      });
+
+    });
+
+
+    it('should render optional feel icon', function() {
+
+      // given
+      const field = createFeelNumber({
+        container,
+        id: 'feelField',
+        feel: 'optional'
+      });
+
+      // then
+      const icon = domQuery('[data-entry-id="feelField"] .bio-properties-panel-feel-icon',
+        field.container);
+      expect(icon).to.exist;
+    });
+
+
+    describe('toggle', function() {
+
+      it('should toggle feel active', async function() {
+
+        // given
+        const updateSpy = sinon.spy();
+
+        const field = createFeelNumber({
+          container,
+          id: 'feelField',
+          feel: 'optional',
+          getValue: () => 2,
+          setValue: updateSpy
+        });
+
+        const icon = domQuery('[data-entry-id="feelField"] .bio-properties-panel-feel-icon',
+          field.container);
+
+        // when
+        await act(() => {
+          icon.click();
+        });
+
+        // then
+        return waitFor(() => {
+          expect(updateSpy).to.have.been.calledWith('=2');
+          expect(domQuery('.bio-properties-panel-feel-editor-container', field.container)).to.exist;
+        });
+      });
+
+
+      it('should toggle on paste with FEEL mime type', function() {
+
+        // given
+        const updateSpy = sinon.spy();
+
+        const result = createFeelField({
+          container,
+          feel: 'optional',
+          getValue: () => 2,
+          setValue: updateSpy
+        });
+
+        const input = domQuery('.bio-properties-panel-input', result.container);
+
+        const data = new DataTransfer();
+        data.setData('application/FEEL', 2);
+
+        const paste = new ClipboardEvent('paste', {
+          bubbles: true,
+          clipboardData: data
+        });
+
+        // when
+        input.dispatchEvent(paste);
+
+        // then
+        return waitFor(() => {
+          expect(updateSpy).to.have.been.calledWith('=2');
         });
       });
 
@@ -1814,6 +2273,21 @@ describe('<FeelField>', function() {
     });
 
 
+    it('should have no violations - number', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container: node } = createFeelNumber({
+        container,
+        label: 'foo'
+      });
+
+      // then
+      await expectNoViolations(node);
+    });
+
+
     it('should have no violations - text area', async function() {
 
       // given
@@ -1936,7 +2410,8 @@ function createFeelField(options = {}, renderFn = render) {
     onShow = noop,
     errors = {},
     variables,
-    Component = FeelField
+    Component = FeelField,
+    ...rest
   } = options;
 
   const errorsContext = {
@@ -1973,6 +2448,7 @@ function createFeelField(options = {}, renderFn = render) {
               validate={ validate }
               feel={ feel }
               variables={ variables }
+              { ...rest }
             />
           </DescriptionContext.Provider>
         </PropertiesPanelContext.Provider>
@@ -1984,6 +2460,12 @@ function createFeelField(options = {}, renderFn = render) {
   );
 }
 
+function createFeelNumber(options = {}, renderFn = render) {
+  return createFeelField({
+    ...options,
+    Component: FeelNumberEntry
+  }, renderFn);
+}
 
 function createFeelTextArea(options = {}, renderFn = render) {
   return createFeelField({


### PR DESCRIPTION
Related to bpmn-io/form-js#653

Adds an optional FEEL number field entry. This enabled us to create number properties with FEEL support (e.g. `min`, `max`, `minLength`, `maxLength` in form-js, https://github.com/bpmn-io/form-js/pull/668).
