### PR TITLE
feat: propagate invalid values to `setValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ ___Note:__ Yet to be released changes appear here._
 
 __Breaking Changes__
 
-* `setValue` is now also called when `validate` returns an error. Ensure that your `setValue` callback can handle invalid values.
+* `setValue` is now also called when `validate` returns an error. The error message is provided as a second argument to the `setValue` callback.
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: propagate invalid values ([#252](https://github.com/bpmn-io/properties-panel/pull/252))
+
+__Breaking Changes__
+
+* `setValue` is now also called when `validate` returns an error. Ensure that your `setValue` callback can handle invalid values.
+
 ## 2.2.1
 
 * `FIX`: improve FX toggle styles ([#249](https://github.com/bpmn-io/properties-panel/pull/249))

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -16,7 +16,6 @@ import classnames from 'classnames';
 import { isFunction, isString } from 'min-dash';
 
 import {
-  usePrevious,
   useShowEntryEvent,
   useError,
   useStaticCallback
@@ -490,13 +489,10 @@ export default function FeelEntry(props) {
     onBlur
   } = props;
 
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const [ validationError, setValidationError ] = useState(null);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -513,14 +509,9 @@ export default function FeelEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-
-      // don't create multiple commandStack entries for the same value
-      if (newValue !== value) {
-        setValue(newValue);
-      }
+    // don't create multiple commandStack entries for the same value
+    if (newValue !== value) {
+      setValue(newValue);
     }
 
     setValidationError(newValidationError);
@@ -529,10 +520,6 @@ export default function FeelEntry(props) {
   const onError = useCallback(err => {
     setLocalError(err);
   }, []);
-
-  if (previousValue === value && validationError) {
-    value = cachedInvalidValue;
-  }
 
   const temporaryError = useError(id);
 

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -511,7 +511,7 @@ export default function FeelEntry(props) {
 
     // don't create multiple commandStack entries for the same value
     if (newValue !== value) {
-      setValue(newValue);
+      setValue(newValue, newValidationError);
     }
 
     setValidationError(newValidationError);

--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -11,8 +11,7 @@ import classnames from 'classnames';
 import { isFunction } from 'min-dash';
 
 import {
-  useError,
-  usePrevious
+  useError
 } from '../../hooks';
 
 export function NumberField(props) {
@@ -120,13 +119,10 @@ export default function NumberFieldEntry(props) {
     validate
   } = props;
 
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const globalError = useError(id);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -143,18 +139,9 @@ export default function NumberFieldEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-      setValue(newValue);
-    }
-
+    setValue(newValue);
     setLocalError(newValidationError);
   };
-
-  if (previousValue === value && localError) {
-    value = cachedInvalidValue;
-  }
 
   const error = globalError || localError;
 

--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -139,7 +139,7 @@ export default function NumberFieldEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    setValue(newValue);
+    setValue(newValue, newValidationError);
     setLocalError(newValidationError);
   };
 

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -160,7 +160,7 @@ export default function SelectEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    setValue(newValue);
+    setValue(newValue, newValidationError);
     setLocalError(newValidationError);
   };
 

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -4,7 +4,6 @@ import { isFunction } from 'min-dash';
 
 import {
   useError,
-  usePrevious,
   useShowEntryEvent
 } from '../../hooks';
 
@@ -140,14 +139,10 @@ export default function SelectEntry(props) {
   } = props;
 
   const options = getOptions(element);
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const globalError = useError(id);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
-
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -165,18 +160,9 @@ export default function SelectEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-      setValue(newValue);
-    }
-
+    setValue(newValue);
     setLocalError(newValidationError);
   };
-
-  if (previousValue === value && localError) {
-    value = cachedInvalidValue;
-  }
 
   const error = globalError || localError;
 

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -11,7 +11,6 @@ import classnames from 'classnames';
 
 import {
   useError,
-  usePrevious,
   useShowEntryEvent
 } from '../../hooks';
 
@@ -130,13 +129,10 @@ export default function TextAreaEntry(props) {
     autoResize
   } = props;
 
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const globalError = useError(id);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -153,18 +149,11 @@ export default function TextAreaEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-      setValue(newValue);
-    }
+    setValue(newValue);
 
     setLocalError(newValidationError);
   };
 
-  if (previousValue === value && localError) {
-    value = cachedInvalidValue;
-  }
 
   const error = globalError || localError;
 

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -149,7 +149,7 @@ export default function TextAreaEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    setValue(newValue);
+    setValue(newValue, newValidationError);
 
     setLocalError(newValidationError);
   };

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -12,7 +12,6 @@ import { isFunction } from 'min-dash';
 
 import {
   useError,
-  usePrevious,
   useShowEntryEvent
 } from '../../hooks';
 
@@ -101,13 +100,10 @@ export default function TextfieldEntry(props) {
     onBlur
   } = props;
 
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const globalError = useError(id);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -124,18 +120,11 @@ export default function TextfieldEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-      setValue(newValue);
-    }
+    setValue(newValue);
 
     setLocalError(newValidationError);
   };
 
-  if (previousValue === value && localError) {
-    value = cachedInvalidValue;
-  }
 
   const error = globalError || localError;
 

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -120,7 +120,7 @@ export default function TextfieldEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    setValue(newValue);
+    setValue(newValue, newValidationError);
 
     setLocalError(newValidationError);
   };

--- a/src/components/entries/templating/Templating.js
+++ b/src/components/entries/templating/Templating.js
@@ -59,7 +59,7 @@ export default function TemplatingEntry(props) {
 
     // don't create multiple commandStack entries for the same value
     if (newValue !== value) {
-      setValue(newValue);
+      setValue(newValue, newValidationError);
     }
 
     setValidationError(newValidationError);

--- a/src/components/entries/templating/Templating.js
+++ b/src/components/entries/templating/Templating.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useMemo, useRef } from 'preact/hooks';
-import { usePrevious, useStaticCallback, useShowEntryEvent } from '../../../hooks';
+import { useStaticCallback, useShowEntryEvent } from '../../../hooks';
 import { isFunction } from 'min-dash';
 import { useError } from '../../../hooks';
 import classnames from 'classnames';
@@ -37,13 +37,10 @@ export default function TemplatingEntry(props) {
     show = noop,
   } = props;
 
-  const [ cachedInvalidValue, setCachedInvalidValue ] = useState(null);
   const [ validationError, setValidationError ] = useState(null);
   const [ localError, setLocalError ] = useState(null);
 
   let value = getValue(element);
-
-  const previousValue = usePrevious(value);
 
   useEffect(() => {
     if (isFunction(validate)) {
@@ -60,14 +57,9 @@ export default function TemplatingEntry(props) {
       newValidationError = validate(newValue) || null;
     }
 
-    if (newValidationError) {
-      setCachedInvalidValue(newValue);
-    } else {
-
-      // don't create multiple commandStack entries for the same value
-      if (newValue !== value) {
-        setValue(newValue);
-      }
+    // don't create multiple commandStack entries for the same value
+    if (newValue !== value) {
+      setValue(newValue);
     }
 
     setValidationError(newValidationError);
@@ -76,10 +68,6 @@ export default function TemplatingEntry(props) {
   const onError = useCallback(err => {
     setLocalError(err);
   }, []);
-
-  if (previousValue === value && validationError) {
-    value = cachedInvalidValue;
-  }
 
   const temporaryError = useError(id);
 

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -277,6 +277,29 @@ describe('<FeelField>', function() {
         expect(error.innerText).to.eql('error');
       });
 
+
+      it('should pass error to `setValue`', function() {
+
+        // given
+        const setValueSpy = sinon.spy();
+        const validate = (v) => {
+          if (v === 'bar') {
+            return 'error';
+          }
+        };
+
+        const result = createFeelField({ container, validate, setValue: setValueSpy });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 'bar');
+
+        // then
+        expect(setValueSpy).to.have.been.calledWith('bar', 'error');
+      });
+
     });
 
 
@@ -756,6 +779,28 @@ describe('<FeelField>', function() {
         expect(error.innerText).to.eql('error');
       });
 
+
+      it('should pass error to `setValue`', function() {
+
+        // given
+        const setValueSpy = sinon.spy();
+        const validate = (v) => {
+          if (v === 3) {
+            return 'error';
+          }
+        };
+
+        const result = createFeelNumber({ container, validate, setValue: setValueSpy });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 3);
+
+        // then
+        expect(setValueSpy).to.have.been.calledWith(3, 'error');
+      });
     });
 
 
@@ -1192,6 +1237,29 @@ describe('<FeelField>', function() {
         // then
         expect(error).to.exist;
         expect(error.innerText).to.eql('error');
+      });
+
+
+      it('should pass error to `setValue`', function() {
+
+        // given
+        const setValueSpy = sinon.spy();
+        const validate = (v) => {
+          if (v === 'bar') {
+            return 'error';
+          }
+        };
+
+        const result = createFeelTextArea({ container, validate, setValue: setValueSpy });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('.bio-properties-panel-input', entry);
+
+        // when
+        changeInput(input, 'bar');
+
+        // then
+        expect(setValueSpy).to.have.been.calledWith('bar', 'error');
       });
 
     });
@@ -2044,6 +2112,31 @@ describe('<FeelField>', function() {
           expect(error).to.exist;
           expect(error.innerText).to.eql('error');
         });
+      });
+
+
+      it('should pass error to `setValue`', async function() {
+
+        // given
+        const setValueSpy = sinon.spy();
+        const validate = (v) => {
+          if (v === '=bar') {
+            return 'error';
+          }
+        };
+
+        const result = createFeelTextArea({ container, validate, setValue: setValueSpy, feel: 'required' });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('[role="textbox"]', entry);
+
+        // when
+        await act(() => {
+          input.textContent = 'bar';
+        });
+
+        // then
+        expect(setValueSpy).to.have.been.calledWith('=bar', 'error');
       });
 
     });

--- a/test/spec/components/NumberField.spec.js
+++ b/test/spec/components/NumberField.spec.js
@@ -319,7 +319,7 @@ describe('<NumberField>', function() {
     });
 
 
-    it('should NOT call setValue if validation fails', function() {
+    it('should call setValue even if validation fails', function() {
 
       // given
       const validate = (v) => {
@@ -337,7 +337,7 @@ describe('<NumberField>', function() {
       changeInput(entry, 3);
 
       // then
-      expect(setValueSpy).to.not.have.been.called;
+      expect(setValueSpy).to.have.been.called;
     });
 
   });

--- a/test/spec/components/NumberField.spec.js
+++ b/test/spec/components/NumberField.spec.js
@@ -297,7 +297,7 @@ describe('<NumberField>', function() {
     });
 
 
-    it('should call setValue if validation succeeds', function() {
+    it('should pass error to `setValue`', function() {
 
       // given
       const validate = (v) => {
@@ -312,32 +312,10 @@ describe('<NumberField>', function() {
       const entry = domQuery('.bio-properties-panel-entry .bio-properties-panel-input', result.container);
 
       // when
-      changeInput(entry, 2);
+      changeInput(entry, 1);
 
       // then
-      expect(setValueSpy).to.have.been.calledWith(2);
-    });
-
-
-    it('should call setValue even if validation fails', function() {
-
-      // given
-      const validate = (v) => {
-        if (v % 2 !== 0) {
-          return 'should be even';
-        }
-      };
-
-      const setValueSpy = sinon.spy();
-
-      const result = createNumberField({ container, validate, setValue: setValueSpy });
-      const entry = domQuery('.bio-properties-panel-entry .bio-properties-panel-input', result.container);
-
-      // when
-      changeInput(entry, 3);
-
-      // then
-      expect(setValueSpy).to.have.been.called;
+      expect(setValueSpy).to.have.been.calledWith(1, 'should be even');
     });
 
   });

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -419,6 +419,29 @@ describe('<Select>', function() {
       expect(error.innerText).to.eql('error');
     });
 
+
+    it('should pass error to `setValue`', function() {
+
+      // given
+      const setValueSpy = sinon.spy();
+      const validate = (v) => {
+        if (v === 'A') {
+          return 'error';
+        }
+      };
+      const getOptions = () => createOptions();
+
+      const result = createSelect({ container, validate, getOptions, setValue: setValueSpy });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'A');
+
+      // then
+      expect(setValueSpy).to.have.been.calledWith('A', 'error');
+    });
   });
 
 

--- a/test/spec/components/Templating.spec.js
+++ b/test/spec/components/Templating.spec.js
@@ -390,6 +390,31 @@ describe('<Templating>', function() {
         });
       });
 
+
+      it('should set invalid', async function() {
+
+        // given
+        const setValueSpy = sinon.spy();
+        const validate = (v) => {
+          if (v === '{{bar}}') {
+            return 'error';
+          }
+        };
+
+        const result = createTemplatingEntry({ container, validate, setValue: setValueSpy });
+
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        const input = domQuery('[role="textbox"]', entry);
+
+        // when
+        await act(() => input.textContent = '{{bar}}');
+
+        // then
+        return await waitFor(() => {
+          expect(setValueSpy).to.have.been.calledWith('{{bar}}', 'error');
+        });
+      });
+
     });
 
 

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -397,6 +397,28 @@ describe('<TextArea>', function() {
       expect(error.innerText).to.eql('error');
     });
 
+    it('should set invalid', function() {
+
+      // given
+      const setValueSpy = sinon.spy();
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextArea({ container, validate, setValue: setValueSpy });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(setValueSpy).to.have.been.calledWith('bar', 'error');
+    });
+
   });
 
 

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -276,6 +276,29 @@ describe('<TextField>', function() {
       expect(error.innerText).to.eql('error');
     });
 
+
+    it('should set invalid', function() {
+
+      // given
+      const setValueSpy = sinon.spy();
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextField({ container, validate, setValue: setValueSpy });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(setValueSpy).to.have.been.calledWith('bar', 'error');
+    });
+
   });
 
 


### PR DESCRIPTION
Whether invalid values are persisted on errors or not should be a concern of the application. This PR introduces that we also propagate invalid values to the app.

Integrates into bpmn-js-properties-panel: https://github.com/bpmn-io/bpmn-js-properties-panel/pull/938

related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/928
related to https://github.com/camunda/camunda-modeler/issues/3357
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
