### PR TITLE
Support tooltips

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -11,12 +11,14 @@
   --color-grey-225-10-90: hsl(225, 10%, 90%);
   --color-grey-225-10-95: hsl(225, 10%, 95%);
   --color-grey-225-10-97: hsl(225, 10%, 97%);
+  --color-grey-0-0-22: hsl(0, 0%, 22%);
 
   --color-blue-205-100-35: hsl(205, 100%, 35%);
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
   --color-blue-205-100-95: hsl(205, 100%, 95%);
-
+  --color-blue-219-99-53: hsl(219, 99%, 53%);
+  --color-blue-218-100-74: hsl(218, 100%, 74%);
   --color-green-150-86-44: hsl(150, 86%, 44%);
 
   --color-red-360-100-40: hsl(360, 100%, 40%);
@@ -110,6 +112,12 @@
 
   --feel-indicator-background-color: var(--color-grey-225-10-90);
 
+  --tooltip-underline-color: var(--color-blue-219-99-53);
+  --tooltip-background-color: var(--color-grey-0-0-22);
+  --tooltip-link: var(--color-blue-218-100-74);
+  --tooltip-code-background-color: var(--color-grey-225-10-97);
+  --tooltip-code-border-color: var(--color-grey-225-10-85);
+  
   --text-size-base: 14px;
   --text-size-small: 13px;
   --text-size-smallest: 12px;
@@ -1121,4 +1129,53 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-feel-checkbox .bio-properties-panel-feel-entry:not(.feel-active) .bio-properties-panel-feel-container,
 .bio-properties-panel-feel-toggle-switch .bio-properties-panel-feel-entry:not(.feel-active) .bio-properties-panel-feel-container {
   margin-left: auto;
+}
+
+.bio-properties-panel-tooltip-wrapper {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.bio-properties-panel-tooltip {
+  display: flex;
+  color: var(--color-white, white);
+  position: fixed;
+  z-index: 1000;
+  padding-right: 6px;
+  max-width: 300px;
+  font-size: var(--text-size-small);
+  font-family: var(--font-family);
+}
+
+.bio-properties-panel-tooltip-content {
+  background-color: var(--tooltip-background-color);
+  padding: 16px;
+  border-radius: 2px;
+  font-weight: 400;
+}
+
+.bio-properties-panel-tooltip-content code,
+.bio-properties-panel-tooltip-content pre {
+  color: var(--description-color);
+  font-family: var(--font-family);
+  font-size: var(--text-size-small);
+  line-height: var(--line-height-condensed);
+  padding: 0 2px;
+  background-color: var(--tooltip-code-background-color);
+  border: 1px solid var(--tooltip-code-border-color);
+  border-radius: 3px;
+}
+
+.bio-properties-panel-tooltip-content a {
+  color: var(--tooltip-link);
+}
+
+.bio-properties-panel-tooltip .bio-properties-panel-tooltip-arrow {
+  width: 0; 
+  height: 0; 
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid var(--tooltip-background-color);
+  margin-top: 16px;
 }

--- a/src/components/entries/Checkbox.js
+++ b/src/components/entries/Checkbox.js
@@ -9,6 +9,7 @@ import {
 } from 'preact/hooks';
 
 import Description from './Description';
+import Tooltip from './Tooltip';
 
 function Checkbox(props) {
   const {
@@ -18,7 +19,8 @@ function Checkbox(props) {
     disabled,
     value = false,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -55,7 +57,11 @@ function Checkbox(props) {
         onChange={ handleChange }
         checked={ localValue }
         disabled={ disabled } />
-      <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label>
+      <label for={ prefixId(id) } class="bio-properties-panel-label">
+        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+          { label }
+        </Tooltip>
+      </label>
     </div>
   );
 }
@@ -71,6 +77,7 @@ function Checkbox(props) {
  * @param {Function} props.setValue
  * @param {Function} props.onFocus
  * @param {Function} props.onBlur
+ * @param {string|import('preact').Component} props.tooltip
  * @param {boolean} [props.disabled]
  */
 export default function CheckboxEntry(props) {
@@ -83,7 +90,8 @@ export default function CheckboxEntry(props) {
     setValue,
     disabled,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const value = getValue(element);
@@ -100,7 +108,8 @@ export default function CheckboxEntry(props) {
         onChange={ setValue }
         onFocus={ onFocus }
         onBlur={ onBlur }
-        value={ value } />
+        value={ value }
+        tooltip={ tooltip } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -28,6 +28,7 @@ import FeelIcon from './FeelIcon';
 import { ToggleSwitch } from '../ToggleSwitch';
 
 import { NumberField } from '../NumberField';
+import Tooltip from '../Tooltip';
 
 const noop = () => { };
 
@@ -43,7 +44,8 @@ function FeelTextfield(props) {
     disabled = false,
     variables,
     tooltipContainer,
-    OptionalComponent = OptionalFeelInput
+    OptionalComponent = OptionalFeelInput,
+    tooltip
   } = props;
 
   const [ localValue, _setLocalValue ] = useState(value);
@@ -186,7 +188,9 @@ function FeelTextfield(props) {
       { 'feel-active': feelActive }
     ) }>
       <label for={ prefixId(id) } class="bio-properties-panel-label" onClick={ () => setFocus() }>
-        {label}
+        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+          {label}
+        </Tooltip>
         <FeelIcon
           label={ label }
           feel={ feel }
@@ -466,6 +470,7 @@ const OptionalFeelCheckbox = forwardRef((props, ref) => {
  * @param {Function} props.variables
  * @param {Function} props.onFocus
  * @param {Function} props.onBlur
+ * @param {string|import('preact').Component} props.tooltip
  */
 export default function FeelEntry(props) {
   const {
@@ -486,7 +491,8 @@ export default function FeelEntry(props) {
     example,
     variables,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const [ validationError, setValidationError ] = useState(null);
@@ -552,7 +558,8 @@ export default function FeelEntry(props) {
         value={ value }
         variables={ variables }
         tooltipContainer={ tooltipContainer }
-        OptionalComponent={ props.OptionalComponent } />
+        OptionalComponent={ props.OptionalComponent }
+        tooltip={ tooltip } />
       {error && <div class="bio-properties-panel-error">{error}</div>}
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -13,6 +13,7 @@ import {
 } from 'preact/hooks';
 
 import Description from './Description';
+import Tooltip from './Tooltip';
 
 /**
  * @typedef { { value: string, label: string, disabled: boolean, children: { value: string, label: string, disabled: boolean } } } Option
@@ -41,7 +42,8 @@ function Select(props) {
     value = '',
     disabled,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const ref = useShowEntryEvent(id);
@@ -68,7 +70,9 @@ function Select(props) {
   return (
     <div class="bio-properties-panel-select">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        {label}
+        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+          {label}
+        </Tooltip>
       </label>
       <select
         ref={ ref }
@@ -122,6 +126,7 @@ function Select(props) {
  * @param {Function} props.getOptions
  * @param {boolean} [props.disabled]
  * @param {Function} [props.validate]
+ * @param {string|import('preact').Component} props.tooltip
  */
 export default function SelectEntry(props) {
   const {
@@ -135,7 +140,8 @@ export default function SelectEntry(props) {
     disabled,
     onFocus,
     onBlur,
-    validate
+    validate,
+    tooltip
   } = props;
 
   const options = getOptions(element);
@@ -182,7 +188,8 @@ export default function SelectEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         options={ options }
-        disabled={ disabled } />
+        disabled={ disabled }
+        tooltip={ tooltip } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -15,6 +15,7 @@ import {
 } from '../../hooks';
 
 import { isFunction } from 'min-dash';
+import Tooltip from './Tooltip';
 
 function resizeToContents(element) {
   element.style.height = 'auto';
@@ -37,7 +38,8 @@ function TextArea(props) {
     onFocus,
     onBlur,
     autoResize,
-    rows = autoResize ? 1 : 2
+    rows = autoResize ? 1 : 2,
+    tooltip
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -71,7 +73,9 @@ function TextArea(props) {
   return (
     <div class="bio-properties-panel-textarea">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        { label }
+        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+          { label }
+        </Tooltip>
       </label>
       <textarea
         ref={ ref }
@@ -126,7 +130,8 @@ export default function TextAreaEntry(props) {
     validate,
     onFocus,
     onBlur,
-    autoResize
+    autoResize,
+    tooltip
   } = props;
 
   const globalError = useError(id);
@@ -176,7 +181,8 @@ export default function TextAreaEntry(props) {
         debounce={ debounce }
         monospace={ monospace }
         disabled={ disabled }
-        autoResize={ autoResize } />
+        autoResize={ autoResize }
+        tooltip={ tooltip } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -1,8 +1,10 @@
 import Description from './Description';
+import Tooltip from './Tooltip';
 
 import {
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'preact/hooks';
 
@@ -25,12 +27,14 @@ function Textfield(props) {
     onInput,
     onFocus,
     onBlur,
-    value = ''
+    value = '',
+    tooltip
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value || '');
 
   const ref = useShowEntryEvent(id);
+  const labelRef = useRef(null);
 
   const handleInputCallback = useMemo(() => {
     return debounce(({ target }) => onInput(target.value.length ? target.value : undefined));
@@ -52,7 +56,9 @@ function Textfield(props) {
   return (
     <div class="bio-properties-panel-textfield">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        { label }
+        <Tooltip value={ tooltip } refElement={ labelRef } labelId={ prefixId(id) }>
+          { label }
+        </Tooltip>
       </label>
       <input
         ref={ ref }
@@ -83,6 +89,7 @@ function Textfield(props) {
  * @param {Function} props.setValue
  * @param {Function} props.onFocus
  * @param {Function} props.onBlur
+ * @param {string|import('preact').Component} props.tooltip
  * @param {Function} props.validate
  */
 export default function TextfieldEntry(props) {
@@ -97,7 +104,8 @@ export default function TextfieldEntry(props) {
     setValue,
     validate,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const globalError = useError(id);
@@ -144,7 +152,8 @@ export default function TextfieldEntry(props) {
         onInput={ onInput }
         onFocus={ onFocus }
         onBlur={ onBlur }
-        value={ value } />
+        value={ value }
+        tooltip={ tooltip } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/ToggleSwitch.js
+++ b/src/components/entries/ToggleSwitch.js
@@ -6,6 +6,7 @@ import {
 } from 'preact/hooks';
 
 import classNames from 'classnames';
+import Tooltip from './Tooltip';
 
 export function ToggleSwitch(props) {
   const {
@@ -17,7 +18,8 @@ export function ToggleSwitch(props) {
     inline,
     onFocus,
     onBlur,
-    inputRef
+    inputRef,
+    tooltip
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -46,7 +48,9 @@ export function ToggleSwitch(props) {
     ) }>
       <label class="bio-properties-panel-label"
         for={ prefixId(id) }>
-        { label }
+        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+          { label }
+        </Tooltip>
       </label>
       <div class="bio-properties-panel-field-wrapper">
         <label class="bio-properties-panel-toggle-switch__switcher">
@@ -80,6 +84,7 @@ export function ToggleSwitch(props) {
  * @param {Function} props.setValue
  * @param {Function} props.onFocus
  * @param {Function} props.onBlur
+ * @param {string|import('preact').Component} props.tooltip
  */
 export default function ToggleSwitchEntry(props) {
   const {
@@ -92,7 +97,8 @@ export default function ToggleSwitchEntry(props) {
     getValue,
     setValue,
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const value = getValue(element);
@@ -106,7 +112,8 @@ export default function ToggleSwitchEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         switcherLabel={ switcherLabel }
-        inline={ inline } />
+        inline={ inline }
+        tooltip={ tooltip } />
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );

--- a/src/components/entries/Tooltip.js
+++ b/src/components/entries/Tooltip.js
@@ -1,0 +1,142 @@
+import { useRef } from 'preact/hooks';
+import {
+  useEffect,
+  useState
+} from 'react';
+
+/**
+ * @param {Object} props
+ * @param {String} props.labelId
+ * @param {String} props.value
+ */
+export default function TooltipWrapper(props) {
+
+  if (!props.value) {
+    return props.children;
+  }
+
+  return <Tooltip { ...props } />;
+}
+
+function Tooltip(props) {
+  const {
+    value,
+    labelId
+  } = props;
+
+  const [ visible, setShow ] = useState(false);
+
+  let timeout = null;
+
+  const wrapperRef = useRef(null);
+  const tooltipRef = useRef(null);
+
+  const showTooltip = async (event) => {
+    const show = () => !visible && setShow(true);
+
+    if (event instanceof MouseEvent) {
+      timeout = setTimeout(show, 200);
+    } else {
+      show();
+    }
+  };
+
+  const hideTooltip = () => setShow(false);
+
+  const hideTooltipViaEscape = (e) => {
+    e.code === 'Escape' && hideTooltip();
+  };
+
+  const isTooltipHovered = ({ x, y }) => {
+    const tooltip = tooltipRef.current;
+    const wrapper = wrapperRef.current;
+
+    return tooltip && (
+      inBounds(x, y, wrapper.getBoundingClientRect()) ||
+      inBounds(x, y, tooltip.getBoundingClientRect())
+    );
+  };
+
+  useEffect(() => {
+    const { current } = wrapperRef;
+
+    if (!current) {
+      return;
+    }
+
+    const hideHoveredTooltip = (e) => {
+      const isFocused = document.activeElement === wrapperRef.current
+                        || document.activeElement.closest('.bio-properties-panel-tooltip');
+
+      if (visible && !isTooltipHovered({ x: e.x, y: e.y }) && !isFocused) {
+        hideTooltip();
+      }
+    };
+
+    const hideFocusedTooltip = (e) => {
+      const { relatedTarget } = e;
+      const isTooltipChild = (el) => el && !!el.closest('.bio-properties-panel-tooltip');
+
+      if (visible && !isHovered(wrapperRef.current) && !isTooltipChild(relatedTarget)) {
+        hideTooltip();
+      }
+    };
+
+    document.addEventListener('focusout', hideFocusedTooltip);
+    document.addEventListener('mousemove', hideHoveredTooltip);
+
+    return () => {
+
+      document.removeEventListener('mousemove', hideHoveredTooltip);
+      document.removeEventListener('focusout', hideFocusedTooltip);
+    };
+  }, [ wrapperRef.current, visible ]);
+
+  return (
+    <div class="bio-properties-panel-tooltip-wrapper" tabIndex="0"
+      ref={ wrapperRef }
+      onMouseEnter={ showTooltip }
+      onMouseLeave={ ()=> clearTimeout(timeout) }
+      onFocus={ showTooltip }
+      onKeyDown={ hideTooltipViaEscape }>
+      {props.children}
+      {visible ?
+        <div
+          class="bio-properties-panel-tooltip"
+          role="tooltip"
+          id="bio-properties-panel-tooltip"
+          aria-labelledby={ labelId }
+          style={ getTooltipPosition(wrapperRef.current) }
+          ref={ tooltipRef }
+          onClick={ (e)=> e.stopPropagation() }
+        >
+          <div class="bio-properties-panel-tooltip-content">
+            {value}
+          </div>
+          <div class="bio-properties-panel-tooltip-arrow" />
+        </div>
+        : null
+      }
+    </div>
+  );
+}
+
+
+// helper
+function inBounds(x, y, bounds) {
+  const { top, right, bottom, left } = bounds;
+  return x >= left && x <= right && y >= top && y <= bottom;
+}
+
+function getTooltipPosition(refElement) {
+  const refPosition = refElement.getBoundingClientRect();
+
+  const right = `calc(100% - ${refPosition.x}px)`;
+  const top = `${refPosition.top - 10}px`;
+
+  return `right: ${right}; top: ${top};`;
+}
+
+function isHovered(element) {
+  return element.matches(':hover');
+}

--- a/test/spec/components/Tooltip.spec.js
+++ b/test/spec/components/Tooltip.spec.js
@@ -1,0 +1,203 @@
+import {
+  render,
+  cleanup
+} from '@testing-library/preact/pure';
+
+import { fireEvent, waitFor } from '@testing-library/preact';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  expectNoViolations,
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import Tooltip from 'src/components/entries/Tooltip';
+import { act } from 'preact/test-utils';
+
+
+insertCoreStyles();
+
+
+describe('<Tooltip>', function() {
+
+  let container, parent, clock;
+
+  beforeEach(function() {
+    parent = TestContainer.get(this);
+    parent.style.marginLeft = 'auto';
+    parent.style.width = '50vw';
+
+    container = document.createElement('div');
+    container.classList.add('bio-properties-panel');
+
+    parent.appendChild(container);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    cleanup();
+    clock.restore();
+  });
+
+  function openTooltip(element) {
+    return act(() => {
+      fireEvent.mouseEnter(element);
+      clock.tick(200);
+    });
+  }
+
+
+  describe('render', function() {
+
+    it('should not render by default', function() {
+
+      // given
+      const result = createTooltip({ container });
+
+      // then
+      expect(domQuery('.bio-properties-panel-tooltip-wrapper', result.container)).to.exist;
+      expect(domQuery('.bio-properties-panel-tooltip', result.container)).to.not.exist;
+    });
+
+
+    it('should render if trigger element is hovered', async function() {
+
+      // given
+      createTooltip({ container });
+      const element = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when
+      await openTooltip(element);
+
+      // then
+      expect(domQuery('.bio-properties-panel-tooltip')).to.exist;
+    });
+
+
+    it('should not render if trigger element no longer hovered', async function() {
+
+      // given
+      createTooltip({ container });
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when
+      await openTooltip(wrapper);
+
+      // then
+      expect(domQuery('.bio-properties-panel-tooltip')).to.exist;
+
+      // when
+      fireEvent.mouseMove(container, {
+        clientX: 16,
+        clientY: 16,
+      });
+
+      // expect
+      expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;
+    });
+
+  });
+
+
+  describe('position', function() {
+
+    it('should render beside trigger element', async function() {
+
+      // given
+      createTooltip({ container });
+      const element = domQuery('#componentId', container);
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when
+      await openTooltip(wrapper);
+
+      // then
+      const elementRect = element.getBoundingClientRect();
+      const tooltipRect = domQuery('.bio-properties-panel-tooltip').getBoundingClientRect();
+
+      expect(tooltipRect.top).to.equal(elementRect.top - 10);
+      expect(tooltipRect.right).to.equal(elementRect.x);
+    });
+
+  });
+
+
+  describe('content', function() {
+
+    it('should render tooltip content', async function() {
+
+      // given
+      const tooltipContent = <div>
+        <div>tooltip text</div>
+        <a href="#">some link</a>
+      </div>;
+
+      createTooltip({ container, value: tooltipContent });
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when
+      await openTooltip(wrapper);
+
+      // then
+      const tooltipContentNode = domQuery('.bio-properties-panel-tooltip-content');
+      expect(tooltipContentNode).to.exist;
+      expect(tooltipContentNode.innerHTML).to.equal(
+        '<div><div>tooltip text</div><a href="#">some link</a></div>'
+      );
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      const { container: node } = createTooltip({ container });
+
+      // then
+      return waitFor(() => {
+        expectNoViolations(node);
+      }, 5000);
+    });
+
+
+    it('should have no violations - tooltip shown', async function() {
+
+      // given
+      createTooltip({ container });
+
+      // when
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+      await openTooltip(wrapper);
+
+      // then
+      return waitFor(() => {
+        expectNoViolations(domQuery('.bio-properties-panel-tooltip', container));
+      }, 5000);
+    });
+
+  });
+
+});
+
+
+// helpers ////////////////////
+
+function createTooltip(options = {}, renderFn = render) {
+  const {
+    container,
+    value = 'tooltip text'
+  } = options;
+
+  return renderFn(
+    <Tooltip labelId="componentId" value={ value }>
+      <div id="componentId">foo</div>
+    </Tooltip>, { container });
+}


### PR DESCRIPTION
Closes #202

* Adds tooltip components
* Adds it to input fields: Checkbox, Feel, Textfield, TextArea, ToggleSwitch

Can be tested against https://github.com/bpmn-io/bpmn-js-properties-panel/tree/tooltips