### PR TITLE
Allow tooltip via context

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -1153,6 +1153,7 @@ textarea.bio-properties-panel-input {
   padding: 16px;
   border-radius: 2px;
   font-weight: 400;
+  white-space: pre-wrap;
 }
 
 .bio-properties-panel-tooltip-content code,
@@ -1165,6 +1166,14 @@ textarea.bio-properties-panel-input {
   background-color: var(--tooltip-code-background-color);
   border: 1px solid var(--tooltip-code-border-color);
   border-radius: 3px;
+}
+
+.bio-properties-panel-tooltip p:first-child {
+  margin-top: 0;
+}
+
+.bio-properties-panel-tooltip p:last-child {
+  margin-bottom: 0;
 }
 
 .bio-properties-panel-tooltip-content a {

--- a/src/components/entries/Checkbox.js
+++ b/src/components/entries/Checkbox.js
@@ -58,7 +58,7 @@ function Checkbox(props) {
         checked={ localValue }
         disabled={ disabled } />
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           { label }
         </Tooltip>
       </label>
@@ -109,7 +109,8 @@ export default function CheckboxEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         value={ value }
-        tooltip={ tooltip } />
+        tooltip={ tooltip }
+        element={ element } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -188,7 +188,7 @@ function FeelTextfield(props) {
       { 'feel-active': feelActive }
     ) }>
       <label for={ prefixId(id) } class="bio-properties-panel-label" onClick={ () => setFocus() }>
-        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           {label}
         </Tooltip>
         <FeelIcon

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -70,7 +70,7 @@ function Select(props) {
   return (
     <div class="bio-properties-panel-select">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           {label}
         </Tooltip>
       </label>
@@ -189,7 +189,8 @@ export default function SelectEntry(props) {
         onBlur={ onBlur }
         options={ options }
         disabled={ disabled }
-        tooltip={ tooltip } />
+        tooltip={ tooltip }
+        element={ element } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -73,7 +73,7 @@ function TextArea(props) {
   return (
     <div class="bio-properties-panel-textarea">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           { label }
         </Tooltip>
       </label>
@@ -182,7 +182,8 @@ export default function TextAreaEntry(props) {
         monospace={ monospace }
         disabled={ disabled }
         autoResize={ autoResize }
-        tooltip={ tooltip } />
+        tooltip={ tooltip }
+        element={ element } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -4,7 +4,6 @@ import Tooltip from './Tooltip';
 import {
   useEffect,
   useMemo,
-  useRef,
   useState
 } from 'preact/hooks';
 
@@ -34,7 +33,6 @@ function Textfield(props) {
   const [ localValue, setLocalValue ] = useState(value || '');
 
   const ref = useShowEntryEvent(id);
-  const labelRef = useRef(null);
 
   const handleInputCallback = useMemo(() => {
     return debounce(({ target }) => onInput(target.value.length ? target.value : undefined));
@@ -56,7 +54,7 @@ function Textfield(props) {
   return (
     <div class="bio-properties-panel-textfield">
       <label for={ prefixId(id) } class="bio-properties-panel-label">
-        <Tooltip value={ tooltip } refElement={ labelRef } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           { label }
         </Tooltip>
       </label>
@@ -153,7 +151,8 @@ export default function TextfieldEntry(props) {
         onFocus={ onFocus }
         onBlur={ onBlur }
         value={ value }
-        tooltip={ tooltip } />
+        tooltip={ tooltip }
+        element={ element } />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/src/components/entries/ToggleSwitch.js
+++ b/src/components/entries/ToggleSwitch.js
@@ -48,7 +48,7 @@ export function ToggleSwitch(props) {
     ) }>
       <label class="bio-properties-panel-label"
         for={ prefixId(id) }>
-        <Tooltip value={ tooltip } labelId={ prefixId(id) }>
+        <Tooltip value={ tooltip } forId={ id } element={ props.element }>
           { label }
         </Tooltip>
       </label>
@@ -113,7 +113,8 @@ export default function ToggleSwitchEntry(props) {
         onBlur={ onBlur }
         switcherLabel={ switcherLabel }
         inline={ inline }
-        tooltip={ tooltip } />
+        tooltip={ tooltip }
+        element={ element } />
       <Description forId={ id } element={ element } value={ description } />
     </div>
   );

--- a/src/components/entries/Tooltip.js
+++ b/src/components/entries/Tooltip.js
@@ -3,25 +3,34 @@ import {
   useEffect,
   useState
 } from 'react';
+import { useTooltipContext } from '../../hooks/useTooltipContext';
 
 /**
  * @param {Object} props
- * @param {String} props.labelId
+ * @param {String} props.forId
  * @param {String} props.value
  */
 export default function TooltipWrapper(props) {
+  const {
+    forId,
+    element
+  } = props;
 
-  if (!props.value) {
+  const contextDescription = useTooltipContext(forId, element);
+
+  const value = props.value || contextDescription;
+
+  if (!value) {
     return props.children;
   }
 
-  return <Tooltip { ...props } />;
+  return <Tooltip { ...props } value={ value } forId={ prefixId(forId) } />;
 }
 
 function Tooltip(props) {
   const {
-    value,
-    labelId
+    forId,
+    value
   } = props;
 
   const [ visible, setShow ] = useState(false);
@@ -105,7 +114,7 @@ function Tooltip(props) {
           class="bio-properties-panel-tooltip"
           role="tooltip"
           id="bio-properties-panel-tooltip"
-          aria-labelledby={ labelId }
+          aria-labelledby={ forId }
           style={ getTooltipPosition(wrapperRef.current) }
           ref={ tooltipRef }
           onClick={ (e)=> e.stopPropagation() }
@@ -139,4 +148,8 @@ function getTooltipPosition(refElement) {
 
 function isHovered(element) {
   return element.matches(':hover');
+}
+
+function prefixId(id) {
+  return `bio-properties-panel-${ id }`;
 }

--- a/src/context/TooltipContext.js
+++ b/src/context/TooltipContext.js
@@ -1,0 +1,10 @@
+import {
+  createContext
+} from 'preact';
+
+const TooltipContext = createContext({
+  tooltip: {},
+  getTooltipForId: () => {}
+});
+
+export default TooltipContext;

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -3,3 +3,4 @@ export { default as ErrorsContext } from './ErrorsContext';
 export { default as EventContext } from './EventContext';
 export { default as LayoutContext } from './LayoutContext';
 export { default as PropertiesPanelContext } from './LayoutContext';
+export { default as TooltipContext } from './TooltipContext';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -7,3 +7,4 @@ export { usePrevious } from './usePrevious';
 export { useShowEntryEvent } from './useShowEntryEvent';
 export { useStickyIntersectionObserver } from './useStickyIntersectionObserver';
 export { useStaticCallback } from './useStaticCallback';
+export { useTooltipContext } from './useTooltipContext';

--- a/src/hooks/useTooltipContext.js
+++ b/src/hooks/useTooltipContext.js
@@ -1,0 +1,30 @@
+import {
+  useContext
+} from 'preact/hooks';
+
+import {
+  TooltipContext
+} from '../context';
+
+/**
+ * Accesses the global TooltipContext and returns a tooltip for a given id and element.
+ *
+ * @example
+ * ```jsx
+ * function TextField(props) {
+ *   const tooltip = useTooltipContext('input1', element);
+ * }
+ * ```
+ *
+ * @param {string} id
+ * @param {object} element
+ *
+ * @returns {string}
+ */
+export function useTooltipContext(id, element) {
+  const {
+    getTooltipForId
+  } = useContext(TooltipContext);
+
+  return getTooltipForId(id, element);
+}

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -420,6 +420,51 @@ describe('<PropertiesPanel>', function() {
 
   });
 
+
+  describe('tooltip context', function() {
+
+    it('should notify on tooltip loaded', function() {
+
+      // given
+      const tooltipConfig = {
+        input1: (element, translate) => undefined
+      };
+
+      const tooltipLoadedSpy = sinon.spy();
+
+      // when
+      createPropertiesPanel({
+        container,
+        element: noopElement,
+        tooltipConfig,
+        tooltipLoaded: tooltipLoadedSpy
+      });
+
+      // then
+      expect(tooltipLoadedSpy).to.have.been.calledOnce;
+      expect(tooltipLoadedSpy).to.have.been.calledWith(tooltipConfig);
+    });
+
+    it('should use default config, given no config provided', async function() {
+
+      // given
+      const tooltipLoadedSpy = sinon.spy();
+
+      // when
+      createPropertiesPanel({
+        container,
+        element: noopElement,
+        tooltipLoaded: tooltipLoadedSpy
+      });
+
+
+      // then
+      expect(tooltipLoadedSpy).to.have.been.calledOnce;
+      expect(tooltipLoadedSpy).to.have.been.calledWith({});
+    });
+
+  });
+
 });
 
 
@@ -436,7 +481,9 @@ function createPropertiesPanel(options = {}, renderFn = render) {
     layoutConfig,
     layoutChanged = noop,
     descriptionConfig,
-    descriptionLoaded = noop
+    descriptionLoaded = noop,
+    tooltipConfig,
+    tooltipLoaded = noop
   } = options;
 
   return renderFn(
@@ -449,6 +496,8 @@ function createPropertiesPanel(options = {}, renderFn = render) {
       layoutChanged={ layoutChanged }
       descriptionConfig={ descriptionConfig }
       descriptionLoaded={ descriptionLoaded }
+      tooltipConfig={ tooltipConfig }
+      tooltipLoaded={ tooltipLoaded }
     />,
     {
       container

--- a/test/spec/components/Tooltip.spec.js
+++ b/test/spec/components/Tooltip.spec.js
@@ -19,6 +19,7 @@ import {
 import Tooltip from 'src/components/entries/Tooltip';
 import { act } from 'preact/test-utils';
 
+import { TooltipContext } from '../../../src/context';
 
 insertCoreStyles();
 
@@ -154,6 +155,54 @@ describe('<Tooltip>', function() {
   });
 
 
+  it('should render with tooltip if set per context', async function() {
+
+    // given
+    const tooltipConfig = { tooltipCheckbox: (element) => 'myContextDesc' };
+
+    createTooltip({
+      container,
+      id: 'tooltipCheckbox',
+      value: null,
+      tooltipConfig,
+      getTooltipForId: (id, element) => tooltipConfig[id](element)
+    });
+
+    const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+    // then
+    await openTooltip(wrapper);
+
+    const tooltipContentNode = domQuery('.bio-properties-panel-tooltip-content');
+    expect(tooltipContentNode).to.exist;
+    expect(tooltipContentNode.textContent).to.equal('myContextDesc');
+  });
+
+
+  it('should render tooltip set per props over context', async function() {
+
+    // given
+    const tooltipConfig = { tooltipCheckbox: (element) => 'myContextDesc' };
+
+    createTooltip({
+      container,
+      id: 'tooltipCheckbox',
+      value: 'myPropsTooltip',
+      tooltipConfig,
+      getTooltipForId: (id, element) => tooltipConfig[id](element)
+    });
+
+    const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+    // then
+    await openTooltip(wrapper);
+
+    const tooltipContentNode = domQuery('.bio-properties-panel-tooltip-content');
+    expect(tooltipContentNode).to.exist;
+    expect(tooltipContentNode.textContent).to.equal('myPropsTooltip');
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {
@@ -192,12 +241,26 @@ describe('<Tooltip>', function() {
 
 function createTooltip(options = {}, renderFn = render) {
   const {
+    value = 'tooltip text',
+    id = 'componentId',
     container,
-    value = 'tooltip text'
+    tooltipConfig = {},
+    getTooltipForId = ()=>{},
   } = options;
 
+  const tooltipContext = {
+    tooltip: tooltipConfig,
+    getTooltipForId
+  };
+
   return renderFn(
-    <Tooltip labelId="componentId" value={ value }>
-      <div id="componentId">foo</div>
-    </Tooltip>, { container });
+    <TooltipContext.Provider value={ tooltipContext }>
+      <Tooltip forId={ id } value={ value }>
+        <div id={ id }>foo</div>
+      </Tooltip>
+    </TooltipContext.Provider>,
+    {
+      container
+    }
+  );
 }

--- a/test/spec/hooks/useTooltipContext.spec.js
+++ b/test/spec/hooks/useTooltipContext.spec.js
@@ -1,0 +1,118 @@
+import {
+  renderHook
+} from '@testing-library/preact-hooks';
+
+import {
+  useTooltipContext
+} from 'src/hooks';
+
+import {
+  TooltipContext
+} from 'src/context';
+
+const noop = () => {};
+
+
+describe('hooks/useTooltipContext', function() {
+
+  it('should get from tooltip context', function() {
+
+    // given
+    const tooltip = {
+      input1: () => 'foobar'
+    };
+
+    const getTooltipForId = (id, element) => tooltip[id](element);
+
+    const id = 'input1';
+
+    const wrapper = createTooltip({
+      getTooltipForId,
+      tooltip
+    });
+
+    // when
+    const { result } = renderHook(() =>
+      useTooltipContext(id, undefined, undefined), { wrapper });
+
+    const value = result.current;
+
+    // then
+    expect(value).to.eql('foobar');
+  });
+
+
+  it('should return undefined if id not found in tooltip context', function() {
+
+    // given
+    const tooltip = {
+      input1: () => 'foobar'
+    };
+
+    const getTooltipForId = (id, element) => tooltip[id] && tooltip[id](element);
+
+    const id = 'input2';
+
+    const wrapper = createTooltip({
+      getTooltipForId,
+      tooltip
+    });
+
+    // when
+    const { result } = renderHook(() =>
+      useTooltipContext(id, undefined, undefined), { wrapper });
+
+    const value = result.current;
+
+    // then
+    expect(value).to.be.undefined;
+  });
+
+
+  it('should pass element argument', function() {
+
+    // given
+    const getTooltipSpy = sinon.spy();
+
+    const tooltip = {
+      input1: getTooltipSpy
+    };
+
+    const getTooltipForId = (id, element) => tooltip[id](element);
+
+    const id = 'input1';
+
+    const wrapper = createTooltip({
+      getTooltipForId,
+      tooltip
+    });
+
+    const element = { id: 'someElement' };
+
+    // when
+    renderHook(() =>
+      useTooltipContext(id, element), { wrapper });
+
+    // then
+    expect(getTooltipSpy).to.have.been.calledWith(element);
+    expect(getTooltipSpy).to.have.been.calledOnce;
+  });
+
+});
+
+
+// helper ////////////////////
+
+function createTooltip(props = {}) {
+  const {
+    tooltip = {},
+    getTooltipForId = noop
+  } = props;
+
+  const context = {
+    tooltip,
+    getTooltipForId
+  };
+
+  return ({ children }) => <TooltipContext.Provider value={ context }>{children}</TooltipContext.Provider>;
+}


### PR DESCRIPTION
Closes #261 

Test against [this branch](https://github.com/bpmn-io/bpmn-js-properties-panel/tree/tooltips): Existing [descriptions provided by context](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/src/contextProvider/zeebe/DescriptionProvider.js) were changed to tooltips provided by context.

<img width="552" alt="Screenshot 2023-07-20 at 12 13 13" src="https://github.com/bpmn-io/properties-panel/assets/25825387/b96b1e71-4f89-4dd3-9ad5-8b58af0e868a">

_The actual tooltip content and where they appear will be tackled later_