### PR TITLE
feat(feel-popup): allow defining popup container

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -117,6 +117,7 @@ const DEFAULT_TOOLTIP = {};
  * @param {Function} [props.descriptionLoaded]
  * @param {TooltipConfig} [props.tooltipConfig]
  * @param {Function} [props.tooltipLoaded]
+ * @param {HTMLElement} [props.feelPopupContainer]
  * @param {Object} [props.eventBus]
  */
 export default function PropertiesPanel(props) {
@@ -131,6 +132,7 @@ export default function PropertiesPanel(props) {
     descriptionLoaded,
     tooltipConfig,
     tooltipLoaded,
+    feelPopupContainer,
     eventBus
   } = props;
 
@@ -239,7 +241,7 @@ export default function PropertiesPanel(props) {
           <TooltipContext.Provider value={ tooltipContext }>
             <LayoutContext.Provider value={ layoutContext }>
               <EventContext.Provider value={ eventContext }>
-                <FeelPopupRoot element={ element }>
+                <FeelPopupRoot element={ element } popupContainer={ feelPopupContainer }>
                   <div class="bio-properties-panel">
                     <Header
                       element={ element }

--- a/src/components/entries/FEEL/FeelPopup.js
+++ b/src/components/entries/FEEL/FeelPopup.js
@@ -23,7 +23,8 @@ export const FEEL_POPUP_HEIGHT = 250;
  */
 export default function FEELPopupRoot(props) {
   const {
-    element
+    element,
+    popupContainer
   } = props;
 
   const prevElement = usePrevious(element);
@@ -63,6 +64,7 @@ export default function FEELPopupRoot(props) {
       { open && (
         <FeelPopupComponent
           onClose={ handleClose }
+          container={ popupContainer }
           sourceElement={ sourceElement }
           { ...popupConfig } />
       )}
@@ -73,6 +75,7 @@ export default function FEELPopupRoot(props) {
 
 function FeelPopupComponent(props) {
   const {
+    container,
     id,
     hostLanguage,
     onInput,
@@ -103,6 +106,7 @@ function FeelPopupComponent(props) {
 
   return (
     <Popup
+      container={ container }
       className="bio-properties-panel-feel-popup"
       position={ position }
       title={ title }

--- a/test/spec/components/FeelPopup.spec.js
+++ b/test/spec/components/FeelPopup.spec.js
@@ -51,6 +51,31 @@ describe('<FeelPopup>', function() {
   });
 
 
+  it('should render popup in container', async function() {
+
+    // given
+    const parent = document.createElement('div');
+
+    // when
+    createFeelPopup({ popupContainer: parent }, container);
+
+    const childComponent = domQuery('.child-component', container);
+
+    const btn = domQuery('button', childComponent);
+
+    // when
+    await act(() => {
+      btn.click();
+    });
+
+    // assume
+    expect(domQuery('.bio-properties-panel-feel-editor-container', parent)).to.exist;
+
+    // then
+    expect(childComponent).to.exist;
+  });
+
+
   it('should restore focus on source element', async function() {
 
     // given
@@ -267,12 +292,13 @@ describe('<FeelPopup>', function() {
 
 function createFeelPopup(props, container) {
   const {
+    popupContainer,
     element = noopElement,
     type
   } = props;
 
   return render(
-    <FEELPopupRoot element={ element }>
+    <FEELPopupRoot popupContainer={ popupContainer } element={ element }>
       <ChildComponent type={ type } />
     </FEELPopupRoot>,
     { container }


### PR DESCRIPTION
Related to https://github.com/bpmn-io/properties-panel/issues/277

This allows to set the parent container of the FEEL popup via a property. The default keeps `document.body`.

For context: We had problems in the Web Modeler properly cleaning up the popups when navigating outside of the editor (cf. https://camunda.slack.com/archives/C046XS3GGCR/p1693400946971909). For example, in the forms editor, we can set the container to the Form Playground Root.

Cf. to the implementation in form-js as an example of how to use this.
* https://github.com/bpmn-io/form-js/pull/795
* https://github.com/camunda/form-playground/pull/101 ([Demo](https://feel-popup-root--camunda-form-playground.netlify.app/))

![image](https://github.com/bpmn-io/properties-panel/assets/9433996/3fa750fd-8bf9-4e22-9421-31cf057af94f)


