### PR TITLE
Feel Popup event support

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -241,7 +241,10 @@ export default function PropertiesPanel(props) {
           <TooltipContext.Provider value={ tooltipContext }>
             <LayoutContext.Provider value={ layoutContext }>
               <EventContext.Provider value={ eventContext }>
-                <FeelPopupRoot element={ element } popupContainer={ feelPopupContainer }>
+                <FeelPopupRoot
+                  element={ element }
+                  eventBus={ eventBus }
+                  popupContainer={ feelPopupContainer }>
                   <div class="bio-properties-panel">
                     <Header
                       element={ element }

--- a/src/components/entries/FEEL/FeelPopup.js
+++ b/src/components/entries/FEEL/FeelPopup.js
@@ -25,7 +25,7 @@ export const FEEL_POPUP_HEIGHT = 250;
 export default function FEELPopupRoot(props) {
   const {
     element,
-    eventBus,
+    eventBus = { fire() {}, on() {}, off() {} },
     popupContainer
   } = props;
 
@@ -74,10 +74,6 @@ export default function FEELPopupRoot(props) {
   // allow close and open via events
   useEffect(() => {
 
-    if (!eventBus) {
-      return;
-    }
-
     const handlePopupOpen = (context) => {
       const {
         entryId,
@@ -97,10 +93,6 @@ export default function FEELPopupRoot(props) {
     eventBus.on('feelPopup._isOpen', handleIsOpen);
 
     return () => {
-      if (!eventBus) {
-        return;
-      }
-
       eventBus.off('feelPopup._close', handleClose);
       eventBus.off('feelPopup._open', handleOpen);
       eventBus.off('feelPopup._isOpen', handleIsOpen);

--- a/src/features/feel-popup/FeelPopupModule.js
+++ b/src/features/feel-popup/FeelPopupModule.js
@@ -1,0 +1,38 @@
+export default class FeelPopupModule {
+
+  constructor(eventBus) {
+    this._eventBus = eventBus;
+  }
+
+  /**
+   * Check if the FEEL popup is open.
+   * @return {Boolean}
+   */
+  isOpen() {
+    return this._eventBus.fire('feelPopup._isOpen');
+  }
+
+  /**
+   * Open the FEEL popup.
+   *
+   * @param {String} entryId
+   * @param {Object} popupConfig
+   * @param {HTMLElement} sourceElement
+   */
+  open(entryId, popupConfig, sourceElement) {
+    return this._eventBus.fire('feelPopup._open', {
+      entryId,
+      popupConfig,
+      sourceElement
+    });
+  }
+
+  /**
+   * Close the FEEL popup.
+   */
+  close() {
+    return this._eventBus.fire('feelPopup._close');
+  }
+}
+
+FeelPopupModule.$inject = [ 'eventBus' ];

--- a/src/features/feel-popup/index.js
+++ b/src/features/feel-popup/index.js
@@ -1,0 +1,5 @@
+import feelPopup from './FeelPopupModule';
+
+export default {
+  feelPopup: [ 'type', feelPopup ]
+};

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,1 +1,2 @@
 export { default as DebounceInputModule } from './debounce-input';
+export { default as FeelPopupModule } from './feel-popup';


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/974

This provides the capability to hook into the feel popup lifecycle as
* `feelPopup.opened`
* `feelPopup.closed`
* `feelPopup._open`
* `feelPopup._close`
* `feelPopup._isOpen`

Furthermore, this adds a feature service that integrators can use to interact with the popup. Cf. to this example [on how to use it](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/975). I didn't add particular test coverage for this module in this project similar to `debounceInput` as I saw we do not have a proper didi-like test setup in the core framework.

```js
const feelPopup = bpmnjs.get('feelPopup');

console.log('is open', feelPopup._isOpen());

feelPopup.close();

feelPopup.open(someElement, { type: 'feel' }, elementToRestoreFocusAfterClose);
```

Happy to receive your feedback ❤️ @bpmn-io/modeling-dev @bpmn-io/hto-dev 

