### PR TITLE
feat(FEEL): adjust lifecycle events to match conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FEAT`: improve FEEL popup lifecycle events:
-  - `feelPopup.open` - fired before the popup is mounted
-  - `feelPopup.opened` - fired before the popup is unmounted. Event context contains the DOM node of the popup
-  - `feelPopup.close`- fired before the popup is unmounted. Event context contains the DOM node of the popup.
-  - `feelPopup.closed`- fired after the popup is unmounted
-
+* `FEAT`: improve FEEL popup lifecycle events ([#294](https://github.com/bpmn-io/properties-panel/pull/294))
 
 ## 3.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: improve FEEL popup lifecycle events:
+  - `feelPopup.open` - fired before the popup is mounted
+  - `feelPopup.opened` - fired before the popup is unmounted. Event context contains the DOM node of the popup
+  - `feelPopup.close`- fired before the popup is unmounted. Event context contains the DOM node of the popup.
+  - `feelPopup.closed`- fired after the popup is unmounted
+
+
 ## 3.7.1
 
 * `FIX`: remove `undefined` in FEEL popup label ([#288](https://github.com/bpmn-io/properties-panel/pull/288)) 

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -1,4 +1,4 @@
-import { createPortal } from 'preact/compat';
+import { createPortal, forwardRef } from 'preact/compat';
 
 import { useEffect, useRef } from 'preact/hooks';
 
@@ -33,8 +33,9 @@ const noop = () => {};
  * @param {boolean} [props.returnFocus]
  * @param {boolean} [props.closeOnEscape]
  * @param {string} props.title
+ * @param {Ref} [ref]
  */
-export function Popup(props) {
+function PopupComponent(props, globalRef) {
 
   const {
     container,
@@ -52,7 +53,8 @@ export function Popup(props) {
   } = props;
 
   const focusTrapRef = useRef(null);
-  const popupRef = useRef(null);
+  const localRef = useRef(null);
+  const popupRef = globalRef || localRef;
 
   const handleKeydown = event => {
 
@@ -127,6 +129,8 @@ export function Popup(props) {
     , container || document.body
   );
 }
+
+export const Popup = forwardRef(PopupComponent);
 
 Popup.Title = Title;
 Popup.Body = Body;

--- a/src/components/entries/FEEL/FeelPopup.js
+++ b/src/components/entries/FEEL/FeelPopup.js
@@ -22,8 +22,8 @@ export const FEEL_POPUP_HEIGHT = 250;
 /**
  * FEEL popup component, built as a singleton. Emits lifecycle events as follows:
  *  - `feelPopup.open` - fired before the popup is mounted
- *  - `feelPopup.opened` - fired after the popup is mounted. Event context contains the DOM node of the popup.
- *  - `feelPopup.close` - fired before the popup is unmounted. Event context contains the DOM node of the popup.
+ *  - `feelPopup.opened` - fired after the popup is mounted. Event context contains the DOM node of the popup
+ *  - `feelPopup.close` - fired before the popup is unmounted. Event context contains the DOM node of the popup
  *  - `feelPopup.closed` - fired after the popup is unmounted
  */
 export default function FEELPopupRoot(props) {


### PR DESCRIPTION
Adds new lifecycle events:

  - `feelPopup.open` - fired before the popup is mounted
  - `feelPopup.opened` - fired after the popup is mounted. Event context contains the DOM node of the popup
  - `feelPopup.close` - fired before the popup is unmounted. Event context contains the DOM node of the popup.
  - `feelPopup.closed` - fired after the popup is unmounted
 
---


Context: 
This might be a bit over-engineered. We basically need 2 events to allow us to implement `focusin` and `focusout` as a separate component as described in #290. These are:
 - `opened`, fired after mounting the DOM element
 - `close`, fired before unmounting

I also added the corresponding `open` (before mount) and `closed` (after unmount) events for completeness, even if we do not use them. I'm not sure on this one, as it adds a bit more complexity than we don't need.
The `opened` and `close` events also provide the DOM node of the popup which allows us to add additional event handlers outside of the properties panel code. I tested locally that this allows us to properly handle focus state in the desktop modeler.

Previously, `opened` was fired before the Component was mounted and `closed` before the element was unmounted.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
