### PR TITLE
fix(FEEL): allow value `0` in FEEL number fields

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -91,7 +91,7 @@ function FeelTextfield(props) {
   const setLocalValue = newValue => {
     _setLocalValue(newValue);
 
-    if (!newValue || newValue === '=') {
+    if (typeof newValue === 'undefined' || newValue === '' || newValue === '=') {
       handleInputCallback(undefined);
     } else {
       handleInputCallback(newValue);

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -563,6 +563,23 @@ describe('<FeelField>', function() {
     });
 
 
+    it('should update (0)', function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const result = createFeelNumber({ container, setValue: updateSpy, step: 'any' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      changeInput(input, 0);
+
+      // then
+      expect(updateSpy).to.have.been.calledWith(0);
+    });
+
+
     describe('#isEdited', function() {
 
       it('should NOT be edited', function() {


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3913

Root cause: the `Number` Component returns parsed floats, so `0` is a falsy value. We need to consider that in propagation of `empty` values.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
