### PR TITLE
fix(tooltips): remove pre code double borders

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1181,6 +1181,10 @@ textarea.bio-properties-panel-input {
   border-radius: 3px;
 }
 
+.bio-properties-panel-tooltip-content pre code {
+  border: none;
+}
+
 .bio-properties-panel-tooltip p:first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
It's pretty standard for code blocks to use both `<pre>` and `<code>` html tags together. I have removed the double border which arises when using this setup, while keeping the border when they are used individually. 

![grafik](https://github.com/bpmn-io/properties-panel/assets/17801113/8cee26ef-0b69-41ff-949d-ff09f39d877e)

