### PR TITLE
docs: simplify hacking the project section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,19 @@ Library for creating bpmn-io properties panels.
 ## Hacking the Project
 
 To get the development setup make sure to have [NodeJS](https://nodejs.org/en/download/) installed.
-As soon as you are set up, clone the project and execute
 
 ```
+# Install dependencies
 npm install
+
+# Spin up development mode
+npm run dev
+
+# Run all tasks (lint, test and bundle)
+npm run all
 ```
-
-
-### Testing
-
-Execute `npm run dev` to run the test suite in watch mode.
 
 Expose an environment variable `TEST_BROWSERS=(Chrome|Firefox|IE)` to execute the tests in a non-headless browser.
-
-
-### Package
-
-Execute `npm run all` to lint and test the project.
-
-__Note:__ We do not generate any build artifacts. Required parts of the library should be bundled by properties panels as needed instead.
 
 
 ## License


### PR DESCRIPTION
+ fix outdated "we're not bundling" notice.