### PR TITLE
Revert `mjs` rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.10.1
+
+* `FIX`: revert `mjs` module export
+
 ## 3.10.0
 
 * `FIX`: add error style to popup editor opened fields ([#298](https://github.com/bpmn-io/properties-panel/pull/298))

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.10.0",
   "description": "Library for creating bpmn-io properties panels.",
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.esm.js",
   "files": [
     "dist",
     "assets",


### PR DESCRIPTION
This causes [unintended side-effects](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/985#issuecomment-1761162479) in module bundling.