### PR TITLE
pass event.target instead of event to make it also work in the shadow dom 

### DIFF
--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -35,21 +35,16 @@ export function NumberField(props) {
   const [ localValue, setLocalValue ] = useState(value);
 
   const handleInputCallback = useMemo(() => {
-    return debounce(event => {
+    return debounce((target) => {
 
-      const {
-        validity,
-        value
-      } = event.target;
-
-      if (validity.valid) {
-        onInput(value ? parseFloat(value) : undefined);
+      if (target.validity.valid) {
+        onInput(target.value ? parseFloat(target.value) : undefined);
       }
     });
   }, [ onInput, debounce ]);
 
   const handleInput = e => {
-    handleInputCallback(e);
+    handleInputCallback(e.target);
     setLocalValue(e.target.value);
   };
 

--- a/src/components/entries/Simple.js
+++ b/src/components/entries/Simple.js
@@ -32,11 +32,11 @@ export default function Simple(props) {
   const [ localValue, setLocalValue ] = useState(value);
 
   const handleInputCallback = useMemo(() => {
-    return debounce(({ target }) => setValue(target.value.length ? target.value : undefined));
+    return debounce((target) => setValue(target.value.length ? target.value : undefined));
   }, [ setValue, debounce ]);
 
   const handleInput = e => {
-    handleInputCallback(e);
+    handleInputCallback(e.target);
     setLocalValue(e.target.value);
   };
 

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -47,11 +47,11 @@ function TextArea(props) {
   const ref = useShowEntryEvent(id);
 
   const handleInputCallback = useMemo(() => {
-    return debounce(({ target }) => onInput(target.value.length ? target.value : undefined));
+    return debounce((target) => onInput(target.value.length ? target.value : undefined));
   }, [ onInput, debounce ]);
 
   const handleInput = e => {
-    handleInputCallback(e);
+    handleInputCallback(e.target);
 
     autoResize && resizeToContents(e.target);
 

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -35,11 +35,11 @@ function Textfield(props) {
   const ref = useShowEntryEvent(id);
 
   const handleInputCallback = useMemo(() => {
-    return debounce(({ target }) => onInput(target.value.length ? target.value : undefined));
+    return debounce((target) => onInput(target.value.length ? target.value : undefined));
   }, [ onInput, debounce ]);
 
   const handleInput = e => {
-    handleInputCallback(e);
+    handleInputCallback(e.target);
     setLocalValue(e.target.value);
   };
 


### PR DESCRIPTION
Closes #313 

Passed event.target instead of event as parameter to the debounce method.

To fix issue https://github.com/bpmn-io/properties-panel/issues/313