### PR TITLE
fix: Enable scrolling on FEEL popup editor

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1361,6 +1361,10 @@ textarea.bio-properties-panel-input {
   min-width: 100%;
 }
 
+.bio-properties-panel-feel-popup .bio-properties-panel-feel-editor-container .cm-scroller {
+  overflow: auto !important;
+}
+
 .bio-properties-panel-feel-popup .bio-properties-panel-feelers-editor-container {
   width: 100%;
   display: flex;

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1277,6 +1277,8 @@ textarea.bio-properties-panel-input {
 
 .bio-properties-panel-popup .bio-properties-panel-popup__body:not(:first-child) {
   padding-top: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .bio-properties-panel-popup .bio-properties-panel-popup__header {
@@ -1382,7 +1384,6 @@ textarea.bio-properties-panel-input {
   width: 100%;
   resize: none;
   padding: 0;
-  margin-left: -12px;
   overflow: hidden;
   overflow-y: auto
 }

--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -4,7 +4,7 @@ import { forwardRef } from 'preact/compat';
 
 import FeelEditor from '@bpmn-io/feel-editor';
 
-import { lineNumbers } from '@codemirror/view';
+import { EditorView, lineNumbers } from '@codemirror/view';
 
 import { useStaticCallback } from '../../../hooks';
 
@@ -98,7 +98,8 @@ const CodeEditor = forwardRef((props, ref) => {
       value: localValue,
       variables: variables,
       extensions: [
-        ...enableGutters ? [ lineNumbers() ] : []
+        ...enableGutters ? [ lineNumbers() ] : [],
+        EditorView.lineWrapping
       ]
     });
 


### PR DESCRIPTION
The scrollbar in the FEEL popup editor was hidden when the text was too long.


https://github.com/bpmn-io/properties-panel/assets/1022916/357374e1-0009-4e01-ab55-7fd2572cc72a



Closes #316 