### PR TITLE
fix(Popup): close popup when properties panel detaches

### DIFF
--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -11,6 +11,7 @@ import * as focusTrap from 'focus-trap';
 import { DragIcon } from './icons';
 
 import { createDragger } from './util/dragger';
+import { useEvent } from '../hooks/useEvent';
 
 
 const noop = () => {};
@@ -115,6 +116,8 @@ function PopupComponent(props, globalRef) {
 
     return () => focusTrapRef.current && focusTrapRef.current.deactivate();
   }, [ popupRef ]);
+
+  useEvent('propertiesPanel.detach', onClose);
 
   return createPortal(
     <div

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -37,7 +37,7 @@ import Tooltip from '../Tooltip';
 
 const noop = () => { };
 
-function FeelTextfield(props) {
+function FeelTextfieldComponent(props) {
   const {
     debounce,
     id,
@@ -266,6 +266,8 @@ function FeelTextfield(props) {
     </div>
   );
 }
+
+const FeelTextfield = withAutoClosePopup(FeelTextfieldComponent);
 
 const OptionalFeelInput = forwardRef((props, ref) => {
   const {
@@ -761,3 +763,24 @@ function getPopupTitle(element, label) {
 
   return `${popupTitle}${label}`;
 }
+
+
+function withAutoClosePopup(Component) {
+  return function(props) {
+    const { id } = props;
+    const {
+      close
+    } = useContext(FeelPopupContext);
+
+    const closePopup = useStaticCallback(close);
+
+    useEffect(() => {
+      return () => {
+        closePopup({ id });
+      };
+    }, [ ]);
+
+    return <Component { ...props } />;
+  };
+}
+

--- a/src/components/entries/FEEL/FeelPopup.js
+++ b/src/components/entries/FEEL/FeelPopup.js
@@ -63,7 +63,12 @@ export default function FEELPopupRoot(props) {
     emit('open');
   };
 
-  const handleClose = () => {
+  const handleClose = (event = { }) => {
+    const { id } = event;
+    if (id && id !== source) {
+      return;
+    }
+
     setOpen(false);
     setSource(null);
   };
@@ -267,7 +272,7 @@ function FeelPopupComponent(props) {
       <Popup.Footer>
         <button
           type="button"
-          onClick={ onClose }
+          onClick={ () => onClose() }
           title="Close pop-up editor"
           class="bio-properties-panel-feel-popup__close-btn">Close</button>
       </Popup.Footer>

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -2288,7 +2288,7 @@ describe('<FeelField>', function() {
     });
 
 
-    describe('open popup editor', function() {
+    describe('popup editor', function() {
 
       it('should render open popup action', async function() {
 
@@ -2327,6 +2327,29 @@ describe('<FeelField>', function() {
         // then
         expect(spy).to.have.been.called;
         expect(spy.args[0][1].type).to.eql('feel');
+      });
+
+
+      it('should close popup editor on unmount', async function() {
+
+        const closeSpy = sinon.spy();
+
+        const props = {
+          container,
+          element: { type: 'foo' },
+          feel: 'required',
+          getValue: () => 'foo',
+          openPopup: () => {},
+          closePopup: closeSpy
+        };
+
+        const result = createFeelField(props);
+
+        // when
+        createFeelField({ Component: 'div', ...props }, result.render);
+
+        // then
+        expect(closeSpy).to.have.been.called;
       });
 
 
@@ -2529,6 +2552,7 @@ function createFeelField(options = {}, renderFn = render) {
     errors = {},
     variables,
     openPopup = noop,
+    closePopup = noop,
     getPopupSource = noop,
     Component = FeelField,
     ...rest
@@ -2553,6 +2577,7 @@ function createFeelField(options = {}, renderFn = render) {
 
   const feelPopupContext = {
     open: openPopup,
+    close: closePopup,
     source: getPopupSource()
   };
 

--- a/test/spec/components/Popup.spec.js
+++ b/test/spec/components/Popup.spec.js
@@ -17,7 +17,7 @@ import {
 } from 'test/TestHelper';
 
 import { Popup } from 'src/components/Popup';
-import { EventContext } from '../../../src/context';
+import { EventContext } from 'src/context';
 
 insertCoreStyles();
 

--- a/test/spec/components/Popup.spec.js
+++ b/test/spec/components/Popup.spec.js
@@ -17,6 +17,7 @@ import {
 } from 'test/TestHelper';
 
 import { Popup } from 'src/components/Popup';
+import { EventContext } from '../../../src/context';
 
 insertCoreStyles();
 
@@ -142,6 +143,48 @@ describe('<Popup>', function() {
 
     // then
     expect(focusSpy).to.have.been.called;
+  });
+
+
+  it('should close on detach', async function() {
+
+    // given
+    const closeSpy = sinon.spy();
+
+    const MockEventBus = (() => {
+      let callback;
+
+      return {
+        on: (ev, cb) => {
+          if (ev !== 'propertiesPanel.detach') {
+            return;
+          }
+          callback = cb;
+        },
+        off: () => {},
+        fire: () => {
+          callback();
+        }
+      };
+    })();
+
+
+    const eventContext = {
+      eventBus: MockEventBus
+    };
+
+    await act(() => {
+      render(
+        <EventContext.Provider value={ eventContext }>
+          <Popup onClose={ closeSpy }><input name="foo"></input></Popup>
+        </EventContext.Provider>, { container });
+    });
+
+    // when
+    MockEventBus.fire('propertiesPanel.detach');
+
+    // then
+    expect(closeSpy).to.have.been.called;
   });
 
 


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpmn-js/issues/312

This PR fixes 2 issues.

1. Automatically close popup when Property panel gets detached
2. Close Popup when source property is removed

![Recording 2024-01-22 at 12 18 00](https://github.com/bpmn-io/properties-panel/assets/21984219/e3870a71-d770-46a7-b9b5-3b13f5676a77)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
