### PR TITLE
feat: remove feel input reziser

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1113,7 +1113,7 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-feel-editor-container .bio-properties-panel-input {
-  resize: vertical;
+  resize: none;
   overflow: hidden;
   overflow-y: auto;
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3895

Since the input is auto-resized, FEEL popup editor can be opened to see it better and the FEEL icon is getting in the way of the resizer, i followed the issues' suggestion and removed it.