### PR TITLE
fix: attach popup-editor trigger to top

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1414,9 +1414,12 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup,
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup {
   position: absolute;
-  display: none;
+  top: 0;
   right: 0;
-  bottom: -1px;
+  line-height: 1;
+  padding: 2px 4px;
+  margin: 3px;
+  display: none;
   background: none;
   border: none;
   color: var(--feel-open-popup-color);


### PR DESCRIPTION
This prevents it from being hidden below the fold for long expressions:

![capture vBDurf_optimized](https://github.com/bpmn-io/properties-panel/assets/58601/69e62796-d91b-4504-8e3d-1f2b41751299)
