### PR TITLE
fix: prevent button from taking entire height

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1433,10 +1433,6 @@ textarea.bio-properties-panel-input {
   display: block;
 }
 
-.bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup {
-  bottom: 0;
-}
-
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup:hover,
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup:hover {
   color: var(--feel-open-popup-hover-color);


### PR DESCRIPTION
@nikku There was a missing fix on the popup editor button from [this PR](https://github.com/bpmn-io/properties-panel/pull/337), on `form-js` it was still wrong
![image](https://github.com/bpmn-io/properties-panel/assets/1022916/c41f5954-5f6b-4ce1-bd97-1df35700d4fb)
