### PR TITLE
feat: scroll focused element into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: do not sort list items alphabetically ([#311](https://github.com/bpmn-io/properties-panel/issues/311))
+* `FEAT`: scroll focused list item entry into view ([#360](https://github.com/bpmn-io/properties-panel/pull/360))
 * `CHORE`: remove `shouldSort` behavior for list groups ([#353](https://github.com/bpmn-io/properties-panel/pull/353))
 * `CHORE`: remove `compareFn` prop for `List` component, the caller may decide on insertion points of new items ([#353](https://github.com/bpmn-io/properties-panel/pull/353))
 

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -34,6 +34,7 @@ export default function ListItem(props) {
           focusableInput.focus();
         }
 
+        focusableInput.scrollIntoView();
       }
     }
   }, [ autoOpen, autoFocusEntry ]);


### PR DESCRIPTION
This ensures that a newly created (and focused) entry is in view:

![capture Giz5NV_optimized](https://github.com/bpmn-io/properties-panel/assets/58601/c83fb9a7-eef7-4382-868d-99b23a6cde28)

Related to #311
