### PR TITLE
Refactor `ListGroup` open close handling

### DIFF
--- a/src/hooks/useLayoutState.js
+++ b/src/hooks/useLayoutState.js
@@ -30,7 +30,7 @@ export function useLayoutState(path, defaultValue) {
 
   const layoutForKey = getLayoutForKey(path, defaultValue);
 
-  const setState = useCallback ((newValue) => {
+  const setState = useCallback((newValue) => {
     setLayoutForKey(path, newValue);
   }, [ setLayoutForKey ]);
 

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -589,6 +589,28 @@ describe('<ListGroup>', function() {
 
     describe('open', function() {
 
+      function expectItemOpen(container, item, expected) {
+        const itemEl = domQuery(`[data-entry-id="${item.id || item}"]`, container);
+
+        expect(domClasses(itemEl).has('open'), `[data-entry-id="${item.id || item}"] open=${expected}`).to.eql(expected);
+      }
+
+      function expectListOpen(container, expected) {
+        const list = domQuery('.bio-properties-panel-list', container);
+
+        expect(domClasses(list).has('open'), `.bio-properties-panel-list open=${expected}`).to.eql(expected);
+      }
+
+      function triggerAdd(container) {
+
+        const addButton = domQuery('.bio-properties-panel-add-entry', container);
+
+        return act(() => {
+          addButton.click();
+        });
+      }
+
+
       it('should open on adding new item per default', async function() {
 
         // given
@@ -621,31 +643,24 @@ describe('<ListGroup>', function() {
           container
         } = render(<Component />, parentContainer);
 
-        const list = domQuery('.bio-properties-panel-list', container);
-        const addButton = domQuery('.bio-properties-panel-add-entry', container);
-
         // assume
-        expect(domClasses(list).has('open')).to.be.false;
-
+        expectListOpen(container, false);
 
         // when
-        await act(() => {
-          addButton.click();
-        });
+        await triggerAdd(container);
 
         // then
-        const newItem = domQuery('[data-entry-id="item-2"]', container);
-        const oldItem = domQuery('[data-entry-id="item-1"]', container);
+        expectItemOpen(container, 'item-1', false);
+        expectItemOpen(container, 'item-2', true);
 
-        expect(domClasses(newItem).has('open')).to.be.true;
-        expect(domClasses(oldItem).has('open')).to.be.false;
-        expect(domClasses(list).has('open')).to.be.true;
+        expectListOpen(container, true);
       });
+
 
       it('should open on adding new item in the middle', async function() {
 
         // given
-        const newItems = [
+        let initialItems = [
           {
             id: 'item-1',
             label: 'Item 1'
@@ -653,18 +668,26 @@ describe('<ListGroup>', function() {
           {
             id: 'item-2',
             label: 'Item 2'
+          }
+        ];
+
+        let newItems = [
+          {
+            id: 'item-1',
+            label: 'Item 1'
           },
           {
             id: 'item-3',
             label: 'Item 3'
+          },
+          {
+            id: 'item-2',
+            label: 'Item 2'
           }
         ];
 
-        const items = [ newItems[0], newItems[2] ];
-
-
         const Component = () => {
-          const [ testItems, setTestItems ] = useState(items);
+          const [ testItems, setTestItems ] = useState(initialItems);
 
           const add = () => {
             setTestItems(newItems);
@@ -675,28 +698,20 @@ describe('<ListGroup>', function() {
 
         const {
           container
-        } = render(<Component />, parentContainer);
-
-        const list = domQuery('.bio-properties-panel-list', container);
-        const addButton = domQuery('.bio-properties-panel-add-entry', container);
+        } = render(<Component />, { container: parentContainer });
 
         // assume
-        expect(domClasses(list).has('open')).to.be.false;
+        expectListOpen(container, false);
 
         // when
-        await act(() => {
-          addButton.click();
-        });
+        await triggerAdd(container);
 
         // then
-        const newItem = domQuery('[data-entry-id="item-2"]', container);
-        const oldItem = domQuery('[data-entry-id="item-1"]', container);
-        const otherOldItem = domQuery('[data-entry-id="item-3"]', container);
+        expectListOpen(container, true);
 
-        expect(domClasses(newItem).has('open')).to.be.true;
-        expect(domClasses(oldItem).has('open')).to.be.false;
-        expect(domClasses(otherOldItem).has('open')).to.be.false;
-        expect(domClasses(list).has('open')).to.be.true;
+        expectItemOpen(container, 'item-1', false);
+        expectItemOpen(container, 'item-3', true);
+        expectItemOpen(container, 'item-2', false);
       });
 
 


### PR DESCRIPTION
### Proposed Changes

* Previously we would render the list group items delayed, with old (outdated) items to be rendered against new model data ([ref](https://github.com/bpmn-io/properties-panel/commit/d426c3366f4f313f839bad1213f7f81744abf40a#diff-43a698bffc8d59870451eb32cfa4f82563203bcf7df48c6e8e86fbdc3c21c64cL227))
* This caused bugs in downstream dependencies (https://github.com/camunda/camunda-modeler/issues/4382)

This PR puts list group, on stable foundations, without magic :tm: :registered: 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->

-----

Related to https://github.com/camunda/camunda-modeler/issues/4382
