### PR TITLE
fix: text area will auto resize on every render

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -61,7 +61,7 @@ function TextArea(props) {
 
   useLayoutEffect(() => {
     autoResize && resizeToContents(ref.current);
-  }, []);
+  });
 
   useEffect(() => {
     if (value === localValue) {

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -3,6 +3,7 @@ import { act } from 'preact/test-utils';
 import {
   render
 } from '@testing-library/preact/pure';
+import { waitFor } from '@testing-library/dom';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -487,6 +488,37 @@ GEHTS
 
       // then
       expect(shrinkedHeight).to.be.lessThan(enlargedHeight);
+    });
+
+
+    it('should resize when container display toggles', function() {
+
+      // given
+      const result = createTextArea({
+        container,
+        id: 'textarea',
+        autoResize: true
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+      const initialHeight = input.clientHeight;
+
+      // when
+      container.style.display = 'none';
+      changeInput(input, 'foo\nbar\nbar\nbar');
+      const hiddenHeight = input.clientHeight;
+
+      // then
+      expect(hiddenHeight).to.be.eq(0);
+
+      // when
+      container.style.display = 'block';
+      const visibleHeight = input.clientHeight;
+
+      // then
+      waitFor(() => {
+        expect(visibleHeight).to.be.greaterThan(initialHeight);
+      });
     });
 
 


### PR DESCRIPTION
Closes #314

### Proposed Changes

Text area resizes on every render. If it only resizes on initial render, it will not resize when closing and opening sections on properties panel.

https://github.com/bpmn-io/properties-panel/assets/24656920/4de86866-1a71-40d0-9e4a-8a73915b5c65

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
