### PR TITLE
fix: text area resizes properly every time it becomes visible

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -63,6 +63,10 @@ function TextArea(props) {
   };
 
   useLayoutEffect(() => {
+    autoResize && resizeToContents(ref.current);
+  }, []);
+
+  useLayoutEffect(() => {
     visible && autoResize && resizeToContents(ref.current);
   }, [ visible ]);
 

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -11,7 +11,8 @@ import classnames from 'classnames';
 
 import {
   useError,
-  useShowEntryEvent
+  useShowEntryEvent,
+  useElementVisible,
 } from '../../hooks';
 
 import { isFunction } from 'min-dash';
@@ -47,6 +48,8 @@ function TextArea(props) {
 
   const ref = useShowEntryEvent(id);
 
+  const visible = useElementVisible(ref.current);
+
   const handleInputCallback = useMemo(() => {
     return debounce((target) => onInput(target.value.length ? target.value : undefined));
   }, [ onInput, debounce ]);
@@ -60,8 +63,8 @@ function TextArea(props) {
   };
 
   useLayoutEffect(() => {
-    autoResize && resizeToContents(ref.current);
-  }, []);
+    visible && autoResize && resizeToContents(ref.current);
+  }, [ visible ]);
 
   useEffect(() => {
     if (value === localValue) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,3 +8,4 @@ export { useShowEntryEvent } from './useShowEntryEvent';
 export { useStickyIntersectionObserver } from './useStickyIntersectionObserver';
 export { useStaticCallback } from './useStaticCallback';
 export { useTooltipContext } from './useTooltipContext';
+export { useElementVisible } from './useElementVisible';

--- a/src/hooks/useElementVisible.js
+++ b/src/hooks/useElementVisible.js
@@ -10,8 +10,15 @@ export function useElementVisible(element) {
     const resizeObserver = new ResizeObserver(([ entry ]) => {
 
       // Prevents ResizeObserver from going into infinite loop.
-      requestAnimationFrame(() => setVisible(!!entry.contentRect.height));
+      requestAnimationFrame(() => {
+
+        const newVisible = !!entry.contentRect.height;
+        if (newVisible !== visible) {
+          setVisible(newVisible);
+        }
+      });
     });
+
     resizeObserver.observe(element);
 
     return () => resizeObserver.disconnect();

--- a/src/hooks/useElementVisible.js
+++ b/src/hooks/useElementVisible.js
@@ -2,27 +2,22 @@ import { useLayoutEffect, useState } from 'preact/hooks';
 
 export function useElementVisible(element) {
 
-  const [ visible, setVisible ] = useState(false);
+  const [ visible, setVisible ] = useState(!!element && !!element.clientHeight);
 
   useLayoutEffect(() => {
     if (!element) return;
 
     const resizeObserver = new ResizeObserver(([ entry ]) => {
-
-      // Prevents ResizeObserver from going into infinite loop.
-      requestAnimationFrame(() => {
-
-        const newVisible = !!entry.contentRect.height;
-        if (newVisible !== visible) {
-          setVisible(newVisible);
-        }
-      });
+      const newVisible = !!entry.contentRect.height;
+      if (newVisible !== visible) {
+        setVisible(newVisible);
+      }
     });
 
     resizeObserver.observe(element);
 
     return () => resizeObserver.disconnect();
-  }, [ element ]);
+  }, [ element, visible ]);
 
   return visible;
 }

--- a/src/hooks/useElementVisible.js
+++ b/src/hooks/useElementVisible.js
@@ -8,10 +8,12 @@ export function useElementVisible(element) {
     if (!element) return;
 
     const resizeObserver = new ResizeObserver(([ entry ]) => {
-      const newVisible = !!entry.contentRect.height;
-      if (newVisible !== visible) {
-        setVisible(newVisible);
-      }
+      requestAnimationFrame(() => {
+        const newVisible = !!entry.contentRect.height;
+        if (newVisible !== visible) {
+          setVisible(newVisible);
+        }
+      });
     });
 
     resizeObserver.observe(element);

--- a/src/hooks/useElementVisible.js
+++ b/src/hooks/useElementVisible.js
@@ -1,0 +1,21 @@
+import { useLayoutEffect, useState } from 'preact/hooks';
+
+export function useElementVisible(element) {
+
+  const [ visible, setVisible ] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver(([ entry ]) => {
+
+      // Prevents ResizeObserver from going into infinite loop.
+      requestAnimationFrame(() => setVisible(!!entry.contentRect.height));
+    });
+    resizeObserver.observe(element);
+
+    return () => resizeObserver.disconnect();
+  }, [ element ]);
+
+  return visible;
+}

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -4,7 +4,7 @@ import {
   render
 } from '@testing-library/preact/pure';
 
-import { waitFor } from '@testing-library/dom';
+import { waitFor } from '@testing-library/preact';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -437,35 +437,6 @@ describe('<TextArea>', function() {
 
   describe('auto resize', function() {
 
-    it('should resize initially', function() {
-
-      // given
-      const result = createTextArea({
-        container,
-        id: 'textarea',
-        getValue() {
-          return `
-HALLO
-WELT
-WIE
-GEHTS
-`;
-        },
-        autoResize: true
-      });
-
-      const input = domQuery('.bio-properties-panel-input', result.container);
-
-      // when
-      const initialHeight = input.clientHeight;
-
-      // then
-      waitFor(() => {
-        expect(initialHeight).to.be.greaterThan(60);
-      });
-    });
-
-
     it('should resize on input', function() {
 
       // given
@@ -522,33 +493,33 @@ GEHTS
     });
 
 
-    it('should resize when becomes visible', function() {
+    it('should resize when becomes visible', async function() {
 
       // given
       const result = createTextArea({
         container,
         id: 'textarea',
-        autoResize: true
+        autoResize: true,
       });
 
       const input = domQuery('.bio-properties-panel-input', result.container);
       const initialHeight = input.clientHeight;
 
       // when
-      container.style.display = 'none';
       changeInput(input, 'foo\nbar\nbar\nbar');
+      result.container.style.display = 'none';
       const hiddenHeight = input.clientHeight;
 
       // then
       expect(hiddenHeight).to.be.eq(0);
 
       // when
-      container.style.display = 'block';
+      result.container.style.display = 'block';
       const visibleHeight = input.clientHeight;
 
       // then
-      waitFor(() => {
-        expect(visibleHeight).to.be.greaterThan(initialHeight);
+      await waitFor(() => {
+        expect(visibleHeight).to.be.greaterThan(initialHeight * 2);
       });
     });
 

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -4,6 +4,8 @@ import {
   render
 } from '@testing-library/preact/pure';
 
+import { waitFor } from '@testing-library/dom';
+
 import TestContainer from 'mocha-test-container-support';
 
 import {
@@ -458,7 +460,9 @@ GEHTS
       const initialHeight = input.clientHeight;
 
       // then
-      expect(initialHeight).to.be.greaterThan(60);
+      waitFor(() => {
+        expect(initialHeight).to.be.greaterThan(60);
+      });
     });
 
 
@@ -515,6 +519,37 @@ GEHTS
       // then
       // no visual resize took place
       expect(input.clientHeight).to.be.lessThan(35);
+    });
+
+
+    it('should resize when becomes visible', function() {
+
+      // given
+      const result = createTextArea({
+        container,
+        id: 'textarea',
+        autoResize: true
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+      const initialHeight = input.clientHeight;
+
+      // when
+      container.style.display = 'none';
+      changeInput(input, 'foo\nbar\nbar\nbar');
+      const hiddenHeight = input.clientHeight;
+
+      // then
+      expect(hiddenHeight).to.be.eq(0);
+
+      // when
+      container.style.display = 'block';
+      const visibleHeight = input.clientHeight;
+
+      // then
+      waitFor(() => {
+        expect(visibleHeight).to.be.greaterThan(initialHeight);
+      });
     });
 
   });

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -437,6 +437,34 @@ describe('<TextArea>', function() {
 
   describe('auto resize', function() {
 
+    it('should resize initially', async function() {
+
+      // given
+      const result = createTextArea({
+        container,
+        id: 'textarea',
+        getValue() {
+          return `
+            1
+            2
+            3
+            4`;
+        },
+        autoResize: true
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const initialHeight = input.clientHeight;
+
+      // then
+      await waitFor(() => {
+        expect(initialHeight).to.be.greaterThan(60);
+      });
+    });
+
+
     it('should resize on input', function() {
 
       // given

--- a/test/spec/hooks/useElementVisible.spec.js
+++ b/test/spec/hooks/useElementVisible.spec.js
@@ -22,13 +22,10 @@ describe('hooks/useElementVisible', function() {
     container.appendChild(element);
 
     // when
-    const { rerender, result } = renderHook(() => useElementVisible(element));
+    const { result } = renderHook(() => useElementVisible(element));
 
     // then
-    await waitFor(() => {
-      rerender();
-      expect(result.current).to.be.true;
-    });
+    expect(result.current).to.be.true;
   });
 
 
@@ -38,13 +35,10 @@ describe('hooks/useElementVisible', function() {
     const element = global.document.createElement('div');
 
     // when
-    const { rerender, result } = renderHook(() => useElementVisible(element));
+    const { result } = renderHook(() => useElementVisible(element));
 
     // then
-    await waitFor(() => {
-      rerender();
-      expect(result.current).to.be.false;
-    });
+    expect(result.current).to.be.false;
   });
 
 
@@ -54,13 +48,10 @@ describe('hooks/useElementVisible', function() {
     const element = undefined;
 
     // when
-    const { rerender, result } = renderHook(() => useElementVisible(element));
+    const { result } = renderHook(() => useElementVisible(element));
 
     // then
-    await waitFor(() => {
-      rerender();
-      expect(result.current).to.be.false;
-    });
+    expect(result.current).to.be.false;
   });
 
 
@@ -91,7 +82,7 @@ describe('hooks/useElementVisible', function() {
   });
 
 
-  it('should return true when element becomes hidden', async function() {
+  it('should return false when element becomes hidden', async function() {
 
     // given
     const element = global.document.createElement('div');

--- a/test/spec/hooks/useElementVisible.spec.js
+++ b/test/spec/hooks/useElementVisible.spec.js
@@ -23,10 +23,11 @@ describe('hooks/useElementVisible', function() {
     container.appendChild(element);
 
     // when
-    const { result } = renderHook(() => useElementVisible(element));
+    const { rerender, result } = renderHook(() => useElementVisible(element));
 
     // then
     await waitFor(() => {
+      rerender();
       expect(result.current).to.be.true;
     });
   });
@@ -38,10 +39,11 @@ describe('hooks/useElementVisible', function() {
     const element = global.document.createElement('div');
 
     // when
-    const { result } = renderHook(() => useElementVisible(element));
+    const { rerender, result } = renderHook(() => useElementVisible(element));
 
     // then
     await waitFor(() => {
+      rerender();
       expect(result.current).to.be.false;
     });
   });
@@ -53,10 +55,11 @@ describe('hooks/useElementVisible', function() {
     const element = undefined;
 
     // when
-    const { result } = renderHook(() => useElementVisible(element));
+    const { rerender, result } = renderHook(() => useElementVisible(element));
 
     // then
     await waitFor(() => {
+      rerender();
       expect(result.current).to.be.false;
     });
   });

--- a/test/spec/hooks/useElementVisible.spec.js
+++ b/test/spec/hooks/useElementVisible.spec.js
@@ -19,7 +19,6 @@ describe('hooks/useElementVisible', function() {
 
     // given
     const element = global.document.createElement('div');
-    element.innerText = 'foo';
     container.appendChild(element);
 
     // when
@@ -56,6 +55,59 @@ describe('hooks/useElementVisible', function() {
 
     // when
     const { rerender, result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      rerender();
+      expect(result.current).to.be.false;
+    });
+  });
+
+
+  it('should return true when element becomes visible', async function() {
+
+    // given
+    const element = global.document.createElement('div');
+    container.appendChild(element);
+    element.style.display = 'none';
+
+    // when
+    const { rerender, result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      rerender();
+      expect(result.current).to.be.false;
+    });
+
+    // when
+    element.style.display = 'block';
+
+    // then
+    await waitFor(() => {
+      rerender();
+      expect(result.current).to.be.true;
+    });
+  });
+
+
+  it('should return true when element becomes hidden', async function() {
+
+    // given
+    const element = global.document.createElement('div');
+    container.appendChild(element);
+
+    // when
+    const { rerender, result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      rerender();
+      expect(result.current).to.be.true;
+    });
+
+    // when
+    element.style.display = 'none';
 
     // then
     await waitFor(() => {

--- a/test/spec/hooks/useElementVisible.spec.js
+++ b/test/spec/hooks/useElementVisible.spec.js
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/preact-hooks';
+
+import { waitFor } from '@testing-library/preact';
+
+import { useElementVisible } from 'src/hooks';
+
+import TestContainer from 'mocha-test-container-support';
+
+
+describe('hooks/useElementVisible', function() {
+
+  let container;
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  it('should return true for visible element', async function() {
+
+    // given
+    const element = global.document.createElement('div');
+    element.innerText = 'foo';
+    container.appendChild(element);
+
+    // when
+    const { result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.be.true;
+    });
+  });
+
+
+  it('should return false for not visible element', async function() {
+
+    // given
+    const element = global.document.createElement('div');
+
+    // when
+    const { result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.be.false;
+    });
+  });
+
+
+  it('should return false when element does not exist', async function() {
+
+    // given
+    const element = undefined;
+
+    // when
+    const { result } = renderHook(() => useElementVisible(element));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Closes #314

### Problem

Text area with `autoResize` property only resizes on initial render and on input. When it's initially rendered inside of closed group or collapsable, it won't properly resize after opening the container.

https://github.com/user-attachments/assets/47a1a43a-078d-4309-a617-4bcd52b4574e

### Solution

Watch for change of element's visibility and trigger resize when it becomes visible. Since when toggling the container, the text area's style doesn't change directly, I use `ResizeObserver` to detect change of element's size.

https://github.com/user-attachments/assets/c18f790e-8aa2-44e3-a67c-ae902238661c

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
