### PR TITLE
feat: auto resize text areas by default

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -38,7 +38,7 @@ function TextArea(props) {
     monospace,
     onFocus,
     onBlur,
-    autoResize,
+    autoResize = true,
     placeholder,
     rows = autoResize ? 1 : 2,
     tooltip


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/713 
Related to https://github.com/camunda/camunda-modeler/issues/3660

### Proposed Changes

Text area will auto resize by default.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
