### PR TITLE
Integrate `first-item` FEEL validation gracefully, as a warning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -533,10 +533,9 @@
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.0.tgz",
-      "integrity": "sha512-wykQUqGb/wWoQI13M6T5iOPrQUwzLfI7U/SVENx3nOn634L+grQtMCULeAtF0ZVkw8wAuygIQ2m8H/mcUnWo5w==",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.1.tgz",
+      "integrity": "sha512-wcFkJKhOm/iqCt5bzkKvxL5Dr9wKwUD+t164bQYbJsTYouAqmkkxiGsoqck42hXwdIhMSguZ+vqQ3hj5QdiYCA==",
       "dependencies": {
         "@codemirror/language": "^6.10.0",
         "lezer-feel": "^1.2.3"
@@ -10645,9 +10644,9 @@
       }
     },
     "@bpmn-io/feel-lint": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.0.tgz",
-      "integrity": "sha512-wykQUqGb/wWoQI13M6T5iOPrQUwzLfI7U/SVENx3nOn634L+grQtMCULeAtF0ZVkw8wAuygIQ2m8H/mcUnWo5w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.1.tgz",
+      "integrity": "sha512-wcFkJKhOm/iqCt5bzkKvxL5Dr9wKwUD+t164bQYbJsTYouAqmkkxiGsoqck42hXwdIhMSguZ+vqQ3hj5QdiYCA==",
       "requires": {
         "@codemirror/language": "^6.10.0",
         "lezer-feel": "^1.2.3"

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -130,14 +130,15 @@ function FeelTextfieldComponent(props) {
     }
   };
 
-  const handleLint = useStaticCallback(lint => {
+  const handleLint = useStaticCallback((lint = []) => {
 
-    if (!(lint && lint.length)) {
+    const syntaxError = lint.some(report => report.type === 'Syntax Error');
+
+    if (syntaxError) {
+      onError('Unparsable FEEL expression.');
+    } else {
       onError(undefined);
-      return;
     }
-
-    onError('Unparsable FEEL expression.');
   });
 
   const handlePopupOpen = (type = 'feel') => {

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -1986,6 +1986,26 @@ describe('<FeelField>', function() {
       });
 
 
+      it('should not indicate field error on non-syntax errors', async function() {
+
+        // given
+        const clock = sinon.useFakeTimers();
+        const result = createFeelField({ container, getValue: () => '= friend[0]', feel: 'required' });
+
+        // when
+        // trigger debounced validation
+        await act(() => { clock.tick(1000); });
+        await act(() => { clock.restore(); });
+
+        // then
+        await waitFor(() => {
+          const entry = domQuery('.bio-properties-panel-entry', result.container);
+
+          expect(isValid(entry)).to.be.true;
+        });
+      });
+
+
       it('should show global error over local error', async function() {
 
         // given


### PR DESCRIPTION
### Proposed Changes

This ensures that `first-item` is not indicated as a hard error, but a warning. It also prevents `first-item` matches, along with any non-syntax errors, from showing off as a `Unparseable FEEL expression` syntax error.

![capture 1K2elv_optimized](https://github.com/user-attachments/assets/ac60e14d-498c-4149-a8f0-50ea01fb59ce)

Try out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#first-item-warning
```

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/1078

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
