### PR TITLE
Sticky list headers

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -827,7 +827,6 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-list-entry-header.position-sticky {
-  position: -webkit-sticky;  /* for safari */
   position: sticky;
   top: 0;
   z-index: 5;

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -826,6 +826,18 @@ textarea.bio-properties-panel-input {
   height: 32px;
 }
 
+.bio-properties-panel-list-entry-header.position-sticky {
+  position: -webkit-sticky;  /* for safari */
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.bio-properties-panel-list-entry-header.sticky {
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--sticky-group-bottom-border-color);
+}
+
 /* Nested list dot */
 .bio-properties-panel-list-entry::before {
   content: "";

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -819,22 +819,18 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-list-entry-header {
-  position: relative;
+  position: sticky;
   overflow: hidden;
   display: flex;
   justify-content: space-between;
   height: 32px;
 }
 
-.bio-properties-panel-list-entry-header.position-sticky {
-  position: sticky;
-  top: 0;
-  z-index: 5;
-}
-
 .bio-properties-panel-list-entry-header.sticky {
   background-color: var(--color-white);
   border-bottom: 1px solid var(--sticky-group-bottom-border-color);
+  top: 32px;
+  z-index: 10;
 }
 
 /* Nested list dot */

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -830,7 +830,7 @@ textarea.bio-properties-panel-input {
   background-color: var(--color-white);
   border-bottom: 1px solid var(--sticky-group-bottom-border-color);
   top: 32px;
-  z-index: 10;
+  z-index: 9;
 }
 
 /* Nested list dot */

--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -51,7 +51,6 @@ export default function List(props) {
     onAdd,
     onRemove,
     autoFocusEntry,
-    headerNestingLevel,
     ...restProps
   } = props;
 

--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -38,7 +38,6 @@ import {
  * @param {Item[]} [props.items]
  * @param {boolean} [props.open]
  * @param {string|boolean} [props.autoFocusEntry] either a custom selector string or true to focus the first input
- * @param {number} [props.headerNestingLevel]
  * @returns
  */
 export default function List(props) {
@@ -84,27 +83,8 @@ export default function List(props) {
     }
   }
 
-  let headerStyle = {};
-  let headerTop = 0;
-  if (headerNestingLevel) {
-
-    // height of header elements defined in classes bio-properties-panel-group-header and bio-properties-panel-list-entry-header
-    const headersHeight = 32;
-
-    // z-index based on value defined in class bio-properties-panel-group-header
-    const baseZIndex = 10;
-
-    headerTop = headersHeight * headerNestingLevel;
-
-    headerStyle = {
-      top: headerTop,
-      zIndex: baseZIndex - headerNestingLevel,
-    };
-  }
-
   // set css class when entry is sticky to top
-  // fourth parameter sets top margin for intersection observer
-  useStickyIntersectionObserver(entryRef, 'div.bio-properties-panel-scroll-container', setSticky, -headerTop);
+  useStickyIntersectionObserver(entryRef, 'div.bio-properties-panel-scroll-container', setSticky);
 
   return (
     <div
@@ -119,11 +99,9 @@ export default function List(props) {
       <div
         class={ classnames(
           'bio-properties-panel-list-entry-header',
-          headerNestingLevel && 'position-sticky',
-          (headerNestingLevel && sticky && open) ? 'sticky' : ''
+          (sticky && open) ? 'sticky' : ''
         ) }
-        onClick={ toggleOpen }
-        style={ headerStyle }>
+        onClick={ toggleOpen }>
         <div
           title={ label }
           class={ classnames(

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -25,9 +25,8 @@ import { useEvent } from './useEvent';
  * @param {Object} ref
  * @param {string} scrollContainerSelector
  * @param {setSticky} setSticky
- * @param {number} rootMarginTop
  */
-export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky, rootMarginTop = 0) {
+export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
 
   const [ scrollContainer, setScrollContainer ] = useState(domQuery(scrollContainerSelector));
 
@@ -77,7 +76,7 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
     },
     {
       root: scrollContainer,
-      rootMargin: `${rootMarginTop}px 0px 999999% 0px`, // Use bottom margin to avoid stickyness when scrolling out to bottom
+      rootMargin: '0px 0px 999999% 0px', // Use bottom margin to avoid stickyness when scrolling out to bottom
       threshold: [ 1 ]
     });
     observer.observe(ref.current);

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -25,8 +25,9 @@ import { useEvent } from './useEvent';
  * @param {Object} ref
  * @param {string} scrollContainerSelector
  * @param {setSticky} setSticky
+ * @param {number} rootMarginTop
  */
-export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
+export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky, rootMarginTop = 0) {
 
   const [ scrollContainer, setScrollContainer ] = useState(domQuery(scrollContainerSelector));
 
@@ -76,7 +77,7 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
     },
     {
       root: scrollContainer,
-      rootMargin: '0px 0px 999999% 0px', // Use bottom margin to avoid stickyness when scrolling out to bottom
+      rootMargin: `${rootMarginTop}px 0px 999999% 0px`, // Use bottom margin to avoid stickyness when scrolling out to bottom
       threshold: [ 1 ]
     });
     observer.observe(ref.current);


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/1103

These changes allow list headers to become sticky to the properties panel when scrolled past. This is particularly useful when managing long lists of values, as it eliminates the need to constantly scroll back up to add new elements to a list or map. It is especially convenient for maps where each entry contains multiple fields making scrolling distance quite long.

Additionally, there is the ability to set nesting levels for headers, which is useful when working with multiple nested lists or maps. This value is used to set z-index and top margin for the sticky position and to properly detect stickiness with `useStickyIntersectionObserver` hook.

A value of 1 means that the list is at the first nesting level within its group section. If this property is not set, the header will behave as before.

#### How it looks like

![Sticky list headers](https://github.com/user-attachments/assets/2f2ed291-75f4-4123-adba-7f1b3b69bf95)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
