### PR TITLE
fix: remove the focus border within feel popups

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1502,6 +1502,10 @@ textarea.bio-properties-panel-input {
   padding-left: 4px;
 }
 
+.bio-properties-panel-feel-popup .bio-properties-panel-input {
+  border: none;
+}
+
 .bio-properties-panel-feel-popup .cm-gutters {
   background-color: var(--feel-popup-gutters-background-color);
   border: none;


### PR DESCRIPTION
Related to https://github.com/camunda/web-modeler/issues/12976

### Proposed Changes

This change remove the focus outline present inside of the popouts. Note this issue was popping up due to a variable naming conflict with [react-pdf](https://www.npmjs.com/package/react-pdf). I don't think it's an absolute necessity to change the variable, but something to consider. 

See the full RCA [here](https://github.com/camunda/web-modeler/issues/12976#issuecomment-2656485410).

#### Image:
![image](https://github.com/user-attachments/assets/29503512-6a21-43c7-9d14-98d2fc793e4c)

#### Replicating the issue:
Easiest way I can think: just set `--input-focus-border-color` to something globally somewhere where you can access the popup, put focus within it.
