### PR TITLE
fix: make tooltip persist when trying to copy from it + refactor

### DIFF
--- a/test/spec/components/Tooltip.spec.js
+++ b/test/spec/components/Tooltip.spec.js
@@ -94,30 +94,7 @@ describe('<Tooltip>', function() {
       expect(domQuery('.bio-properties-panel-tooltip')).to.exist;
 
       // when
-      fireEvent.mouseMove(container, {
-        clientX: 16,
-        clientY: 16,
-      });
-
-      // expect
-      expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;
-    });
-
-
-    it('should not render if trigger element no longer hovered - scroll', async function() {
-
-      // given
-      createTooltip({ container });
-      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
-
-      // when
-      await openTooltip(wrapper);
-
-      // then
-      expect(domQuery('.bio-properties-panel-tooltip')).to.exist;
-
-      // when
-      fireEvent.wheel(container);
+      fireEvent.mouseLeave(wrapper);
 
       // expect
       expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;
@@ -336,7 +313,7 @@ describe('<Tooltip>', function() {
         await openTooltip(wrapper);
 
         // when
-        fireEvent.mouseMove(container);
+        fireEvent.mouseLeave(wrapper);
 
         // then
         expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;
@@ -355,7 +332,7 @@ describe('<Tooltip>', function() {
 
         // when
         wrapper.focus();
-        fireEvent.mouseMove(container);
+        fireEvent.mouseLeave(wrapper);
 
         // then
         expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;
@@ -414,7 +391,7 @@ describe('<Tooltip>', function() {
         const link = domQuery('#link', container);
 
         link.focus();
-        fireEvent.mouseMove(container);
+        fireEvent.mouseLeave(wrapper);
 
         // then
         expect(domQuery('.bio-properties-panel-tooltip')).to.not.exist;


### PR DESCRIPTION
### Proposed Changes

I reworked the Tooltip component to rely on the React event handlers instead of hooking into document events and running hundreds of checks for every `mousemove`, `wheel` and `focusout` event.

In the process, I fixed the bug that made the tooltip disappear when you click on it to try to copy something after opening it with a click on the header, not hovering. (cf. https://github.com/camunda/camunda-modeler/pull/4841#issuecomment-2671382075)

The removed test `should not render if trigger element no longer hovered - scroll` doesn't seem to make sense. Scrolling shouldn't hide the tooltip itself, only if it actually moves the cursor out of it. If it does, it fires `mouseleave` event anyway.

Interesting finding: potentially we could rely on [sourceCapabilities](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/sourceCapabilities) property of FocusEvent to tell if it was triggered by mouse or keyboard, but it's still experimental.

Looks a'ight.

https://github.com/user-attachments/assets/6b376427-71a5-449d-9fd2-df32ced3238a

### Try it 

```
npx @bpmn-io/sr -l="bpmn-io/properties-panel#tooltip-refactor" bpmn-io/bpmn-js-properties-panel
```

Related to https://github.com/camunda/camunda-modeler/issues/4834

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
