### PR TITLE
trim whitespaces when user leaves the field

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -62,6 +62,13 @@ function TextArea(props) {
     setLocalValue(e.target.value);
   };
 
+  const handleOnBlur = e => {
+    if (onBlur) {
+      onBlur(e);
+    }
+    setLocalValue(e.target.value.trim());
+  };
+
   useLayoutEffect(() => {
     autoResize && resizeToContents(ref.current);
   }, []);
@@ -97,7 +104,7 @@ function TextArea(props) {
         }
         onInput={ handleInput }
         onFocus={ onFocus }
-        onBlur={ onBlur }
+        onBlur={ handleOnBlur }
         placeholder={ placeholder }
         rows={ rows }
         value={ localValue }

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -39,6 +39,13 @@ function Textfield(props) {
     return debounce((target) => onInput(target.value.length ? target.value : undefined));
   }, [ onInput, debounce ]);
 
+  const handleOnBlur = e => {
+    if (onBlur) {
+      onBlur(e);
+    }
+    setLocalValue(e.target.value.trim());
+  };
+
   const handleInput = e => {
     handleInputCallback(e.target);
     setLocalValue(e.target.value);
@@ -70,7 +77,7 @@ function Textfield(props) {
         class="bio-properties-panel-input"
         onInput={ handleInput }
         onFocus={ onFocus }
-        onBlur={ onBlur }
+        onBlur={ handleOnBlur }
         placeholder={ placeholder }
         value={ localValue } />
     </div>

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -136,6 +136,27 @@ describe('<TextArea>', function() {
   });
 
 
+  it('should have no trailing spaces', async function() {
+
+    // given
+    const result = createTextArea({ container });
+
+    const input = domQuery('.bio-properties-panel-input', result.container);
+
+    // when
+    changeInput(input, 'foo    ');
+
+    input.focus();
+    input.blur();
+
+    // then
+    await waitFor(() => {
+      expect(input.value).to.equal('foo');
+    });
+
+  });
+
+
   describe('events', function() {
 
     it('should show entry', function() {

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -4,6 +4,8 @@ import {
   render
 } from '@testing-library/preact/pure';
 
+import { waitFor } from '@testing-library/preact';
+
 import TestContainer from 'mocha-test-container-support';
 
 import {
@@ -93,6 +95,27 @@ describe('<TextField>', function() {
     const newInput = domQuery('.bio-properties-panel-input', container);
 
     expect(newInput).to.not.eql(input);
+  });
+
+
+  it('should have no trailing spaces', async function() {
+
+    // given
+    const result = createTextField({ container });
+
+    const input = domQuery('.bio-properties-panel-input', result.container);
+
+    // when
+    changeInput(input, 'foo    ');
+
+    input.focus();
+    input.blur();
+
+    // then
+    await waitFor(() => {
+      expect(input.value).to.equal('foo');
+    });
+
   });
 
 


### PR DESCRIPTION
Closes #309

### Proposed Changes
Extra whitespaces at the end are trimmed in both text area and text field
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 
![Feb-24-2025 16-10-59](https://github.com/user-attachments/assets/7cc39c6f-8bbf-4849-a634-66c9c666f860)


You can test this works via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#trim-whitespaces
```
### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
