### PR TITLE
fix: depend on element instead of value

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -601,6 +601,7 @@ export default function FeelEntry(props) {
   }, [ value, validate ]);
 
   const onInput = useCallback((newValue) => {
+    const value = getValue(element);
     let newValidationError = null;
 
     if (isFunction(validate)) {
@@ -613,7 +614,7 @@ export default function FeelEntry(props) {
     }
 
     setValidationError(newValidationError);
-  },[ setValidationError, setValue, validate, value ]);
+  }, [ element ]);
 
   const onError = useCallback(err => {
     setLocalError(err);

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -185,6 +185,7 @@ export default function TextAreaEntry(props) {
   }, [ value, validate ]);
 
   const onInput = useCallback((newValue) => {
+    const value = getValue(element);
     let newValidationError = null;
 
     if (isFunction(validate)) {
@@ -196,7 +197,7 @@ export default function TextAreaEntry(props) {
     }
 
     setLocalError(newValidationError);
-  }, [ setLocalError, setValue, validate, value ]);
+  }, [ element ]);
 
 
   const error = globalError || localError;

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -152,6 +152,7 @@ export default function TextfieldEntry(props) {
   }, [ value, validate ]);
 
   const onInput = useCallback((newValue) => {
+    const value = getValue(element);
     let newValidationError = null;
 
     if (isFunction(validate)) {
@@ -163,7 +164,7 @@ export default function TextfieldEntry(props) {
     }
 
     setLocalError(newValidationError);
-  }, [ setValue, validate, value ]);
+  }, [ element ]);
 
 
   const error = globalError || localError;


### PR DESCRIPTION
### Proposed Changes

This is supposed to fix the performance issue reported via https://camunda.slack.com/archives/C032H77434N/p1748016281595929
Since we depend on the element only, the debounce callback will not change constantly.

https://github.com/user-attachments/assets/08e70eba-0b6e-4a0c-a66c-06c93c226300


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
