### PR TITLE
fix: use new value helpers when rerendering

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -622,7 +622,7 @@ export default function FeelEntry(props) {
     }
 
     setValidationError(newValidationError);
-  }, [ element ]);
+  }, [ element, getValue, setValue, validate ]);
 
   const onError = useCallback(err => {
     setLocalError(err);

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -197,7 +197,7 @@ export default function TextAreaEntry(props) {
     }
 
     setLocalError(newValidationError);
-  }, [ element ]);
+  }, [ element, getValue, setValue, validate ]);
 
 
   const error = globalError || localError;

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -164,7 +164,7 @@ export default function TextfieldEntry(props) {
     }
 
     setLocalError(newValidationError);
-  }, [ element ]);
+  }, [ element, getValue, setValue, validate ]);
 
 
   const error = globalError || localError;

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -157,6 +157,70 @@ describe('<FeelEntry>', function() {
     });
 
 
+    describe('rerendering', function() {
+
+      it('should call new setValue if passed', function() {
+
+        // given
+        const updateSpies = [ sinon.spy(), sinon.spy() ];
+
+        const firstRender = createFeelField({ container, setValue: updateSpies[0] });
+
+        // when
+        createFeelField({ container, setValue: updateSpies[1] }, firstRender.rerender);
+        const input = domQuery('.bio-properties-panel-input', firstRender.container);
+        changeInput(input, 'foo');
+
+        // then
+        expect(updateSpies[0]).not.to.have.been.called;
+        expect(updateSpies[1]).to.have.been.calledWith('foo');
+      });
+
+
+      it('should call new getValue if passed', function() {
+
+        // given
+        const element = undefined;
+        const getValueSpies = [ sinon.spy(), sinon.spy() ];
+
+        const firstRender = createFeelField({ container, getValue: getValueSpies[0] });
+
+        // when
+        createFeelField({ container, getValue: getValueSpies[1] }, firstRender.rerender);
+        const input = domQuery('.bio-properties-panel-input', firstRender.container);
+        getValueSpies[0].resetHistory();
+
+        // and when
+        changeInput(input, 'foo');
+
+        // then
+        expect(getValueSpies[0]).not.to.have.been.called;
+        expect(getValueSpies[1]).to.have.been.calledWith(element);
+      });
+
+
+      it('should call new validate if passed', function() {
+
+        // given
+        const validateSpies = [ sinon.spy(), sinon.spy() ];
+
+        const firstRender = createFeelField({ container, validate: validateSpies[0] });
+
+        // when
+        createFeelField({ container, validate: validateSpies[1] }, firstRender.rerender);
+        const input = domQuery('.bio-properties-panel-input', firstRender.container);
+        validateSpies[0].resetHistory();
+
+        // and when
+        changeInput(input, 'foo');
+
+        // then
+        expect(validateSpies[0]).not.to.have.been.called;
+        expect(validateSpies[1]).to.have.been.calledWith('foo');
+      });
+    });
+
+
     describe('#isEdited', function() {
 
       it('should NOT be edited', function() {

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -205,6 +205,70 @@ describe('<TextArea>', function() {
   });
 
 
+  describe('rerendering', function() {
+
+    it('should call new setValue if passed', function() {
+
+      // given
+      const updateSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextArea({ container, setValue: updateSpies[0] });
+
+      // when
+      createTextArea({ container, setValue: updateSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      changeInput(input, 'foo');
+
+      // then
+      expect(updateSpies[0]).not.to.have.been.called;
+      expect(updateSpies[1]).to.have.been.calledWith('foo');
+    });
+
+
+    it('should call new getValue if passed', function() {
+
+      // given
+      const element = undefined;
+      const getValueSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextArea({ container, getValue: getValueSpies[0] });
+
+      // when
+      createTextArea({ container, getValue: getValueSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      getValueSpies[0].resetHistory();
+
+      // and when
+      changeInput(input, 'foo');
+
+      // then
+      expect(getValueSpies[0]).not.to.have.been.called;
+      expect(getValueSpies[1]).to.have.been.calledWith(element);
+    });
+
+
+    it('should call new validate if passed', function() {
+
+      // given
+      const validateSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextArea({ container, validate: validateSpies[0] });
+
+      // when
+      createTextArea({ container, validate: validateSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      validateSpies[0].resetHistory();
+
+      // and when
+      changeInput(input, 'foo');
+
+      // then
+      expect(validateSpies[0]).not.to.have.been.called;
+      expect(validateSpies[1]).to.have.been.calledWith('foo');
+    });
+  });
+
+
   describe('events', function() {
 
     it('should show entry', function() {

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -165,6 +165,70 @@ describe('<TextField>', function() {
   });
 
 
+  describe('rerendering', function() {
+
+    it('should call new setValue if passed', function() {
+
+      // given
+      const updateSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextField({ container, setValue: updateSpies[0] });
+
+      // when
+      createTextField({ container, setValue: updateSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      changeInput(input, 'foo');
+
+      // then
+      expect(updateSpies[0]).not.to.have.been.called;
+      expect(updateSpies[1]).to.have.been.calledWith('foo');
+    });
+
+
+    it('should call new getValue if passed', function() {
+
+      // given
+      const element = undefined;
+      const getValueSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextField({ container, getValue: getValueSpies[0] });
+
+      // when
+      createTextField({ container, getValue: getValueSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      getValueSpies[0].resetHistory();
+
+      // and when
+      changeInput(input, 'foo');
+
+      // then
+      expect(getValueSpies[0]).not.to.have.been.called;
+      expect(getValueSpies[1]).to.have.been.calledWith(element);
+    });
+
+
+    it('should call new validate if passed', function() {
+
+      // given
+      const validateSpies = [ sinon.spy(), sinon.spy() ];
+
+      const firstRender = createTextField({ container, validate: validateSpies[0] });
+
+      // when
+      createTextField({ container, validate: validateSpies[1] }, firstRender.rerender);
+      const input = domQuery('.bio-properties-panel-input', firstRender.container);
+      validateSpies[0].resetHistory();
+
+      // and when
+      changeInput(input, 'foo');
+
+      // then
+      expect(validateSpies[0]).not.to.have.been.called;
+      expect(validateSpies[1]).to.have.been.calledWith('foo');
+    });
+  });
+
+
   describe('#isEdited', function() {
 
     it('should NOT be edited', function() {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5071

### Proposed Changes

This makes sure that we use new value setters when a component is rerendered. This is required for the element templates conditional fields to work correctly, cf. https://github.com/camunda/camunda-modeler/issues/5071#issuecomment-2944421901

Verified with Desktop Modeler:

https://github.com/user-attachments/assets/3f5b9cd9-007b-469d-8772-c169575c8734

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
