### PR TITLE
test: increase timeout for a slow test

### DIFF
--- a/test/spec/components/FeelEditor.spec.js
+++ b/test/spec/components/FeelEditor.spec.js
@@ -29,6 +29,9 @@ describe('<FeelEditor>', function() {
 
   it('should supply variables to editor', async function() {
 
+    // increased timeout for slow Windows CI
+    this.timeout(5000);
+
     // given
     const variables = [
       { name: 'foo' },
@@ -51,6 +54,7 @@ describe('<FeelEditor>', function() {
     const variableSuggestion = [ ...suggestions.children ].find(el => {
       return el.textContent === 'foo';
     });
+
     expect(variableSuggestion).to.exist;
   });
 


### PR DESCRIPTION
### Proposed Changes

This increases the timeout for a flaky test which on Windows CI is close to the default 2s limit ([example](https://github.com/bpmn-io/properties-panel/actions/runs/15560004123/job/43809676822#step:7:254)). I don't see anything wrong with the test itself, and it consistently passed with the increased timeout.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
