### PR TITLE
chore: refactor shared text input functionality into a single component

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -1,7 +1,6 @@
 import Description from './Description';
 
 import {
-  useCallback,
   useEffect,
   useLayoutEffect,
   useState
@@ -16,8 +15,8 @@ import {
   useShowEntryEvent
 } from '../../hooks';
 
-import { isFunction } from 'min-dash';
 import Tooltip from './Tooltip';
+import { TextInput } from '../shared/TextInput';
 
 function resizeToContents(element) {
   element.style.height = 'auto';
@@ -72,15 +71,8 @@ function TextArea(props) {
     handleInput(e.target.value);
   };
 
-  const handleOnBlur = e => {
-    const trimmedValue = e.target.value.trim();
-
-    // trim and commit on blur
-    onInput(trimmedValue);
-
-    if (onBlur) {
-      onBlur(e);
-    }
+  const handleOnBlur = () => {
+    onBlur?.(localValue);
   };
 
   useLayoutEffect(() => {
@@ -165,34 +157,11 @@ export default function TextAreaEntry(props) {
     tooltip
   } = props;
 
+  const value = getValue(element);
+
   const globalError = useError(id);
-  const [ localError, setLocalError ] = useState(null);
 
-  let value = getValue(element);
-
-  useEffect(() => {
-    if (isFunction(validate)) {
-      const newValidationError = validate(value) || null;
-
-      setLocalError(newValidationError);
-    }
-  }, [ value, validate ]);
-
-  const onInput = useCallback((newValue) => {
-    const value = getValue(element);
-    let newValidationError = null;
-
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
-    }
-
-    if (newValue !== value) {
-      setValue(newValue, newValidationError);
-    }
-
-    setLocalError(newValidationError);
-  }, [ element, getValue, setValue, validate ]);
-
+  const localError = validate?.(value) || null;
 
   const error = globalError || localError;
 
@@ -203,12 +172,15 @@ export default function TextAreaEntry(props) {
         error ? 'has-error' : '')
       }
       data-entry-id={ id }>
-      <TextArea
+      <TextInput
+        Component={ TextArea }
+        getValue={ getValue }
+        setValue={ setValue }
+        validate={ validate }
         id={ id }
         key={ element }
         label={ label }
         value={ value }
-        onInput={ onInput }
         onFocus={ onFocus }
         onBlur={ onBlur }
         rows={ rows }

--- a/src/components/shared/TextInput.js
+++ b/src/components/shared/TextInput.js
@@ -1,0 +1,57 @@
+import { useCallback } from 'preact/hooks';
+import { isFunction } from 'min-dash';
+import { useDebounce } from '../../hooks';
+
+export function TextInput({
+  debounce,
+  element,
+  id,
+  getValue,
+  onBlur,
+  setValue,
+  validate,
+  Component,
+  ...props
+}) {
+  const modelValue = getValue(element);
+
+  const setModelValue = useCallback((newValue, error) => {
+    if (isFunction(validate)) {
+      error = validate(newValue) || null;
+    }
+
+    setValue(newValue, error);
+  }, [ setValue, validate ]);
+
+  const debouncedSetValue = useDebounce(setModelValue, debounce);
+
+  const handleInput = useCallback(newValue => {
+    if (newValue !== modelValue) {
+      debouncedSetValue(newValue);
+    }
+  }, [ modelValue, debouncedSetValue ]);
+
+  const handleBlur = useCallback(value => {
+    const newValue = value.trim?.() || value;
+
+    if (newValue !== modelValue) {
+      setModelValue(newValue);
+    }
+
+    if (isFunction(onBlur)) {
+      onBlur(newValue);
+    }
+  }, [ modelValue, setModelValue ]);
+
+  return (
+    <Component
+      { ...props }
+      debounce={ debounce }
+      element={ element }
+      id={ id }
+      onInput={ handleInput }
+      onBlur={ handleBlur }
+      value={ modelValue }
+    />
+  );
+}

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -219,17 +219,17 @@ describe('<FeelEntry>', function() {
       it('should flush previous change before rerendering', function() {
 
         // given
-        const flushSpy = sinon.spy();
-        const debounce = () => {
+        const setValueSpy = sinon.spy();
+        const debounce = fn => {
           const spy = () => {};
-          spy.flush = flushSpy;
+          spy.flush = fn;
           return spy;
         };
 
         const result = createFeelField({
           container,
           debounce,
-          setValue() {}
+          setValue: setValueSpy
         });
 
         const input = domQuery('.bio-properties-panel-input', result.container);
@@ -239,7 +239,7 @@ describe('<FeelEntry>', function() {
         createFeelField({ container, setValue() {} }, result.rerender);
 
         // then
-        expect(flushSpy).to.have.been.calledOnce;
+        expect(setValueSpy).to.have.been.calledOnce;
       });
     });
 

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -272,17 +272,17 @@ describe('<TextArea>', function() {
     it('should flush previous change before rerendering', function() {
 
       // given
-      const flushSpy = sinon.spy();
-      const debounce = () => {
+      const setValueSpy = sinon.spy();
+      const debounce = fn => {
         const spy = () => {};
-        spy.flush = flushSpy;
+        spy.flush = fn;
         return spy;
       };
 
       const result = createTextArea({
         container,
         debounce,
-        setValue() {}
+        setValue: setValueSpy
       });
 
       const input = domQuery('.bio-properties-panel-input', result.container);
@@ -292,7 +292,7 @@ describe('<TextArea>', function() {
       createTextArea({ container, setValue() {} }, result.rerender);
 
       // then
-      expect(flushSpy).to.have.been.calledOnce;
+      expect(setValueSpy).to.have.been.calledOnce;
     });
   });
 

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -232,17 +232,17 @@ describe('<TextField>', function() {
     it('should flush previous change before rerendering', function() {
 
       // given
-      const flushSpy = sinon.spy();
-      const debounce = () => {
+      const setValueSpy = sinon.spy();
+      const debounce = fn => {
         const spy = () => {};
-        spy.flush = flushSpy;
+        spy.flush = fn;
         return spy;
       };
 
       const result = createTextField({
         container,
         debounce,
-        setValue() {}
+        setValue: setValueSpy
       });
 
       const input = domQuery('.bio-properties-panel-input', result.container);
@@ -252,7 +252,7 @@ describe('<TextField>', function() {
       createTextField({ container, setValue() {} }, result.rerender);
 
       // then
-      expect(flushSpy).to.have.been.calledOnce;
+      expect(setValueSpy).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
### Proposed Changes

This PR extracts the text input features, namely updating value, debounce, and trimming on blur, into a shared component. Small adjustments for the tests which depended on the implementation details are added. 
It seems that the performance has improved, but we still [suffer from low debounce delay](https://github.com/camunda/camunda-modeler/issues/5085#issuecomment-2966285767).

https://github.com/user-attachments/assets/8c49b74f-9e32-49af-96f7-6372ec42a581


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
