### PR TITLE
fix: increase default debounce value

### DIFF
--- a/src/features/debounce-input/debounceInput.js
+++ b/src/features/debounce-input/debounceInput.js
@@ -3,7 +3,7 @@ import {
   isNumber
 } from 'min-dash';
 
-const DEFAULT_DEBOUNCE_TIME = 300;
+const DEFAULT_DEBOUNCE_TIME = 600;
 
 /**
  * Creates a debounced version of a function, delaying its execution based on `debounceDelay`.


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5085

### Proposed Changes

This PR increases the default debounce delay. The current threshold is very low which causes the debounce to flush while user is pressing a key.

Tested with Desktop Modeler:

https://github.com/user-attachments/assets/0f5b02ab-0542-4f8b-ae24-7b11ae240c66


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
