### PR TITLE
fix: allow tooltip on number field

### DIFF
--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -1,4 +1,5 @@
 import Description from './Description';
+import Tooltip from './Tooltip';
 
 import {
   useEffect,
@@ -29,7 +30,8 @@ export function NumberField(props) {
     step,
     value = '',
     onFocus,
-    onBlur
+    onBlur,
+    tooltip
   } = props;
 
   const [ localValue, setLocalValue ] = useState(value);
@@ -58,7 +60,13 @@ export function NumberField(props) {
 
   return (
     <div class="bio-properties-panel-numberfield">
-      {displayLabel && <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label> }
+      {displayLabel && (
+        <label for={ prefixId(id) } class="bio-properties-panel-label">
+          <Tooltip value={ tooltip } forId={ id } element={ props.element }>
+            { label }
+          </Tooltip>
+        </label>
+      )}
       <input
         id={ prefixId(id) }
         ref={ inputRef }
@@ -111,7 +119,8 @@ export default function NumberFieldEntry(props) {
     step,
     onFocus,
     onBlur,
-    validate
+    validate,
+    tooltip
   } = props;
 
   const globalError = useError(id);
@@ -156,7 +165,9 @@ export default function NumberFieldEntry(props) {
         max={ max }
         min={ min }
         step={ step }
-        value={ value } />
+        value={ value }
+        tooltip={ tooltip }
+      />
       { error && <div class="bio-properties-panel-error">{ error }</div> }
       <Description forId={ id } element={ element } value={ description } />
     </div>

--- a/test/spec/components/NumberField.spec.js
+++ b/test/spec/components/NumberField.spec.js
@@ -1,5 +1,7 @@
 import {
-  render
+  render,
+  fireEvent,
+  findByText
 } from '@testing-library/preact/pure';
 
 import TestContainer from 'mocha-test-container-support';
@@ -447,6 +449,22 @@ describe('<NumberField>', function() {
   });
 
 
+  describe('tooltip', function() {
+
+    it('should render tooltip', async function() {
+
+      // given
+      const result = createNumberField({ container, tooltip: 'tooltip-test' });
+
+      // when
+      fireEvent.mouseEnter(domQuery('.bio-properties-panel-tooltip-wrapper', result.container));
+
+      // then
+      await findByText(result.container, 'tooltip-test');
+    });
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {
@@ -487,7 +505,8 @@ function createNumberField(options = {}, renderFn = render) {
     descriptionConfig = {},
     getDescriptionForId = noop,
     container,
-    errors = {}
+    errors = {},
+    tooltip
   } = options;
 
   const errorsContext = {
@@ -514,7 +533,9 @@ function createNumberField(options = {}, renderFn = render) {
           min={ min }
           setValue={ setValue }
           step={ step }
-          validate={ validate } />
+          validate={ validate }
+          tooltip={ tooltip }
+        />
       </DescriptionContext.Provider>
     </ErrorsContext.Provider>
     ,

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -1,7 +1,9 @@
 import { act } from 'preact/test-utils';
 
 import {
-  render
+  render,
+  fireEvent,
+  findByText
 } from '@testing-library/preact/pure';
 
 import TestContainer from 'mocha-test-container-support';
@@ -572,6 +574,22 @@ describe('<TextField>', function() {
   });
 
 
+  describe('tooltip', function() {
+
+    it('should render tooltip', async function() {
+
+      // given
+      const result = createTextField({ container, tooltip: 'tooltip-test' });
+
+      // when
+      fireEvent.mouseEnter(domQuery('.bio-properties-panel-tooltip-wrapper', result.container));
+
+      // then
+      await findByText(result.container, 'tooltip-test');
+    });
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {
@@ -613,6 +631,7 @@ function createTextField(options = {}, renderFn = render) {
     eventBus = new EventBus(),
     onShow = noop,
     errors = {},
+    tooltip,
     ...restProps
   } = options;
 
@@ -649,7 +668,9 @@ function createTextField(options = {}, renderFn = render) {
               setValue={ setValue }
               onBlur={ onBlur }
               debounce={ debounce }
-              validate={ validate } />
+              validate={ validate }
+              tooltip={ tooltip }
+            />
           </DescriptionContext.Provider>
         </PropertiesPanelContext.Provider>
       </EventContext.Provider>


### PR DESCRIPTION
### Proposed Changes

Make tooltips work with number fields.

Related to https://github.com/camunda/camunda-modeler/issues/5102

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
