### PR TITLE
fix: `blur` should emit boolean value for checkboxes

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -154,10 +154,12 @@ function FeelTextfield(props) {
   };
 
   const handleOnBlur = (e) => {
-    const trimmedValue = e.target.value.trim();
-
-    // trim and commit on blur
-    onInput(trimmedValue);
+    if (e.target.type === 'checkbox') {
+      onInput(e.target.checked);
+    } else {
+      const trimmedValue = e.target.value.trim();
+      onInput(trimmedValue);
+    }
 
     if (onBlur) {
       onBlur(e);

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -1821,9 +1821,28 @@ describe('<FeelEntry>', function() {
       clickInput(input);
 
       // then
-      expect(updateSpy).to.have.been.calledWith(true);
+      expect(updateSpy).to.have.been.calledOnceWith(true);
     });
 
+
+    it('should update on blur', async function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const result = createFeelCheckbox({ container, setValue: updateSpy, getValue: () => false });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      input.focus();
+      clickInput(input);
+      input.blur();
+
+      // then
+      expect(updateSpy).to.have.been.calledTwice;
+      expect(updateSpy).to.have.always.been.calledWith(true);
+    });
 
     describe('#isEdited', function() {
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/properties-panel/issues/430

### Proposed Changes

Make sure `Feel#handleOnBlur` emits correct value type for checkbox field.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
