### PR TITLE
Clarify dirty marker hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.32.0
+
 * `FEAT`: clarify dirty hint ([#432](https://github.com/bpmn-io/properties-panel/pull/432))
 
 ## 3.31.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: clarify dirty hint ([#432](https://github.com/bpmn-io/properties-panel/pull/432))
+
 ## 3.31.1
 
 * `FIX`: make CSS selector of button in group header less specific to allow overriding ([#436](https://github.com/bpmn-io/properties-panel/pull/436))

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -167,7 +167,7 @@ function DataMarker(props) {
 
   if (edited) {
     return (
-      <div title="Section contains data" class="bio-properties-panel-dot"></div>
+      <div title="Section contains edits" class="bio-properties-panel-dot"></div>
     );
   }
   return null;

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -294,7 +294,7 @@ describe('<Group>', function() {
       const dataMarker = domQuery('.bio-properties-panel-dot', header);
 
       // then
-      expect(domAttr(dataMarker, 'title')).to.eql('Section contains data');
+      expect(domAttr(dataMarker, 'title')).to.eql('Section contains edits');
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Changes the dirty marker text from "Section contains data" to "Section contains edits", to more closely align with the [original intend of the :grey_heart: dot](https://github.com/camunda/camunda-modeler/issues/5126#issuecomment-3102856547):

![capture krCgSH_optimized](https://github.com/user-attachments/assets/03d2de99-a13d-44fc-abf1-588576fb6098)


Steps to try out:

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#user-data
```

Related to https://github.com/camunda/camunda-modeler/issues/5126


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
