### PR TITLE
Default element templates fields doesn't have user edited sign

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -15,7 +15,8 @@ import {
 } from 'min-dom';
 
 import {
-  isFunction
+  isFunction,
+  isUndefined
 } from 'min-dash';
 
 import {
@@ -64,7 +65,8 @@ export default function Group(props) {
       const hasOneEditedEntry = entries.find(entry => {
         const {
           id,
-          isEdited
+          isEdited,
+          property
         } = entry;
 
         const entryNode = domQuery(`[data-entry-id="${id}"]`);
@@ -75,7 +77,7 @@ export default function Group(props) {
 
         const inputNode = domQuery('.bio-properties-panel-input', entryNode);
 
-        return isEdited(inputNode);
+        return isEdited(inputNode) && isUndefined(property);
       });
 
       setEdited(hasOneEditedEntry);

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -230,6 +230,27 @@ describe('<Group>', function() {
     });
 
 
+    it('should not show group as edited when default exists', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: (node) => !!node.value,
+        value: 'foo',
+        property: { id: 'default-entry', value: 'foo' }
+      });
+
+      // when
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).to.not.exist;
+    });
+
+
     it('should show error marker', function() {
 
       // given
@@ -327,7 +348,8 @@ function createEntries(options = {}) {
   const {
     component = TestEntry,
     isEdited = noop,
-    value
+    value,
+    property
   } = options;
 
   return [
@@ -335,7 +357,8 @@ function createEntries(options = {}) {
       id: 'entry-1',
       component,
       isEdited,
-      value
+      value,
+      property
     },
     {
       id: 'entry-2'


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-modeler/issues/5170
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 
Default fields coming from Element templates are not indicated as `changed`
<img width="1165" height="666" alt="Screenshot 2025-07-28 at 15 19 42" src="https://github.com/user-attachments/assets/43a31cda-39ea-44e9-a271-ee44ebc89a3a" />



### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
