### PR TITLE
Default element templates to not have user edited sign

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -38,6 +38,7 @@ export default function Group(props) {
     entries = [],
     id,
     label,
+    isDefault,
     shouldOpen = false,
   } = props;
 
@@ -115,6 +116,7 @@ export default function Group(props) {
       <div class="bio-properties-panel-group-header-buttons">
         {
           <DataMarker
+            isDefault={ isDefault }
             edited={ edited }
             hasErrors={ hasErrors }
           />
@@ -156,7 +158,8 @@ export default function Group(props) {
 function DataMarker(props) {
   const {
     edited,
-    hasErrors
+    hasErrors,
+    isDefault
   } = props;
 
   if (hasErrors) {
@@ -165,7 +168,7 @@ function DataMarker(props) {
     );
   }
 
-  if (edited) {
+  if (edited && !isDefault) {
     return (
       <div title="Section contains data" class="bio-properties-panel-dot"></div>
     );

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -247,6 +247,27 @@ describe('<Group>', function() {
       expect(errorMarker).to.exist;
     });
 
+
+    it('should not show group as edited when default exists', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: (node) => !!node.value,
+        value: 'foo',
+      });
+
+      // when
+      // this will be the case when element templates are used
+      const result = createGroup({ container, label: 'Group', entries, isDefault: true });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).to.not.exist;
+    });
+
   });
 
 


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-modeler/issues/5170, https://github.com/bpmn-io/bpmn-js-element-templates/pull/170
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

-->

Element templates now provides `isDefault` for default properties and it will not be marked as user edited.

![Aug-04-2025 13-01-50](https://github.com/user-attachments/assets/a45c7c7c-6854-4adb-8552-eebb4962e504)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
