### PR TITLE
fix: make CSS selector less specific to allow overriding

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -287,7 +287,7 @@
   display: flex;
 }
 
-.bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button {
+.bio-properties-panel-group-header-button {
   display: inline-flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
### Proposed Changes

Makes a CSS selector less specific to make the overrides in bpmn-js-element-templates work:

<img width="1227" height="531" alt="image" src="https://github.com/user-attachments/assets/4e860af1-27c7-469c-a59e-0bb3df161c04" />

CSS selector specificity should always work regarless of what stylesheet is loaded first. You can test this by switching the order of stylesheets in the helper in bpmn-js-element-templates:

<img width="660" height="219" alt="image" src="https://github.com/user-attachments/assets/06371e96-8eee-4527-b637-be3b1e825752" />

Related to https://github.com/camunda/camunda-modeler/issues/5059

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
