### PR TITLE
chore: change open popup icon to carbon maximise

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1467,7 +1467,7 @@ textarea.bio-properties-panel-input {
   top: 0;
   right: 0;
   line-height: 1;
-  padding: 2px 4px;
+  padding: 3px 4px;
   margin: 3px;
   display: none;
   background: none;

--- a/src/components/icons/OpenPopup.svg
+++ b/src/components/icons/OpenPopup.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32"><path fill="currentColor" d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"/><path fill="currentColor" d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
+  <path fill="currentColor" d="M20 2v2h6.586L18 12.582 19.414 14 28 5.414V12h2V2zM14 19.416 12.592 18 4 26.586V20H2v10h10v-2H5.414z"/>
+</svg>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5185

### Proposed Changes

Adjusted the popup icon as it was too similar to the change element one.

We are using the carbon icon called Maximise here, I've also adjusted the padding by one pixel to get perfect centering in single line fields:

<img width="336" height="73" alt="image" src="https://github.com/user-attachments/assets/13a8cddb-7b44-47fd-a323-a9aa5109d824" />


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
