### PR TITLE
Trim feel expressions

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -194,7 +194,7 @@ function FeelTextfield(props) {
     if (e.target.type === 'checkbox') {
       onInput(e.target.checked);
     } else {
-      let trimmedValue = e.target.value.trim();
+      let trimmedValue = trimValue(feel, e.target.value);
 
       if (!trimmedValue && isString(localValueRef.current) && localValueRef.current.startsWith('=')) {
         trimmedValue = localValueRef.current;
@@ -325,7 +325,7 @@ function FeelTextfield(props) {
 
       if (isFieldEmpty || isAllSelected) {
         const textData = event.clipboardData.getData('text');
-        const trimmedValue = textData.trim();
+        const trimmedValue = trimValue(feel, textData);
 
         handleLocalInput(trimmedValue, false);
 
@@ -958,4 +958,17 @@ function getInitialFeelLocalValue(feelType, value) {
   }
 
   return value;
+}
+
+/*
+* trim value and also feel expression after the `=`
+ *   '  =  test  ' -> '=test'
+ *   '  hello  '   -> 'hello'
+*/
+function trimValue(feelType, value) {
+  const trimmedValue = value.trim();
+  if (isFeelActive(feelType, trimmedValue)) {
+    return '=' + getFeelValue(trimmedValue).trim();
+  }
+  return value.trim();
 }

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState
 } from 'preact/hooks';
@@ -84,6 +85,7 @@ function FeelTextfield(props) {
   } = props;
 
   const [ localValue, setLocalValue ] = useState(getInitialFeelLocalValue(feel, value));
+  const localValueRef = useRef(localValue);
 
   const editorRef = useShowEntryEvent(id);
   const containerRef = useRef();
@@ -99,6 +101,12 @@ function FeelTextfield(props) {
   const feelActive = isFeelActive(feel, localValue);
   const feelOnlyValue = getFeelValue(localValue);
   const feelLanguageContext = useContext(FeelLanguageContext);
+
+  // keep state between rerenders
+  const isUnmountingRef = useRef(false);
+  const feelActiveRef = useRef(feelActive);
+  feelActiveRef.current = feelActive;
+
 
   const [ focus, _setFocus ] = useState(undefined);
 
@@ -121,6 +129,12 @@ function FeelTextfield(props) {
    * @type { import('min-dash').DebouncedFunction }
    */
   const handleInput = useDebounce(onInput, debounce);
+  const previousElementRef = useRef(element);
+
+  if (previousElementRef.current !== element) {
+    handleInput.flush?.();
+    previousElementRef.current = element;
+  }
 
   const handleFeelToggle = useStaticCallback(() => {
     if (feel === 'required') {
@@ -129,22 +143,38 @@ function FeelTextfield(props) {
 
     if (!feelActive) {
       setLocalValue('=' + localValue);
-      handleInput('=' + localValue);
+      handleInput.cancel?.();
+      onInput('=' + localValue);
     } else {
       setLocalValue(feelOnlyValue);
-      handleInput(feelOnlyValue);
+      handleInput.cancel?.();
+      onInput(feelOnlyValue);
     }
+
+    // Prevent the FeelEditor unmount cleanup from double-committing
+    editorRef.current?.clearDirty?.();
   });
 
   const handleLocalInput = (newValue, useDebounce = true) => {
+
+    const currentLocalValue = localValueRef.current;
+
+    if (!useDebounce) {
+      handleInput.cancel?.();
+    }
+
     if (feelActive) {
       newValue = '=' + newValue;
     }
 
-    if (newValue === localValue) {
+    if (newValue === currentLocalValue) {
+      if (!useDebounce) {
+        onInput(newValue);
+      }
       return;
     }
 
+    localValueRef.current = newValue;
     setLocalValue(newValue);
     if (useDebounce) {
       handleInput(newValue);
@@ -164,7 +194,12 @@ function FeelTextfield(props) {
     if (e.target.type === 'checkbox') {
       onInput(e.target.checked);
     } else {
-      const trimmedValue = e.target.value.trim();
+      let trimmedValue = e.target.value.trim();
+
+      if (!trimmedValue && isString(localValueRef.current) && localValueRef.current.startsWith('=')) {
+        trimmedValue = localValueRef.current;
+      }
+
       handleLocalInput(trimmedValue, false);
     }
 
@@ -237,10 +272,29 @@ function FeelTextfield(props) {
   }, [ value ]);
 
   useEffect(() => {
+    localValueRef.current = localValue;
+  }, [ localValue ]);
+
+  // ensure values are committed during element switch
+  useEffect(() => {
+    return () => { isUnmountingRef.current = true; };
+  }, []);
+
+  useLayoutEffect(() => {
     return () => {
+      if (!isUnmountingRef.current && feelActiveRef.current) {
+        handleInput.flush?.();
+        editorRef.current?.commit?.();
+      }
+    };
+  }, [ element, handleInput ]);
+
+  useEffect(() => {
+    return () => {
+      handleInput.flush?.();
       eventBus.fire('propertiesPanel.closePopup');
     };
-  }, []);
+  }, [ eventBus, handleInput ]);
 
   // copy-paste integration
   useEffect(() => {
@@ -273,8 +327,7 @@ function FeelTextfield(props) {
         const textData = event.clipboardData.getData('text');
         const trimmedValue = textData.trim();
 
-        setLocalValue(trimmedValue);
-        handleInput(trimmedValue);
+        handleLocalInput(trimmedValue, false);
 
         if (!feelActive && isString(trimmedValue) && trimmedValue.startsWith('=')) {
           setFocus(trimmedValue.length - 1);

--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -22,18 +22,23 @@ const useBufferedFocus = function(editor, ref) {
 
   const [ buffer, setBuffer ] = useState(undefined);
 
-  ref.current = useMemo(() => ({
-    focus: (offset) => {
-      if (editor) {
-        editor.focus(offset);
-      } else {
-        if (typeof offset === 'undefined') {
-          offset = Infinity;
+  ref.current = useMemo(() => {
+    const current = ref.current || {};
+
+    return {
+      ...current,
+      focus: (offset) => {
+        if (editor) {
+          editor.focus(offset);
+        } else {
+          if (typeof offset === 'undefined') {
+            offset = Infinity;
+          }
+          setBuffer(offset);
         }
-        setBuffer(offset);
       }
-    }
-  }), [ editor ]);
+    };
+  }, [ editor ]);
 
   useEffect(() => {
     if (typeof buffer !== 'undefined' && editor) {
@@ -49,7 +54,7 @@ const FeelEditor = forwardRef((props, ref) => {
     contentAttributes,
     enableGutters,
     value,
-    onInput,
+    onInput = noop,
     onKeyDown: onKeyDownProp = noop,
     onFeelToggle = noop,
     onLint = noop,
@@ -64,7 +69,13 @@ const FeelEditor = forwardRef((props, ref) => {
 
   const inputRef = useRef();
   const [ editor, setEditor ] = useState();
+
   const [ localValue, setLocalValue ] = useState(value || '');
+  const isDirtyRef = useRef(false);
+
+  const ignoreProgrammaticChangeRef = useRef(false);
+  const editorRef = useRef(null);
+  const blurHasCommittedRef = useRef(false);
 
   const {
     builtins,
@@ -74,9 +85,56 @@ const FeelEditor = forwardRef((props, ref) => {
 
   useBufferedFocus(editor, ref);
 
-  const handleInput = useStaticCallback(newValue => {
-    onInput(newValue);
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    ref.current.commit = () => {
+      if (blurHasCommittedRef.current) {
+        blurHasCommittedRef.current = false;
+        return;
+      }
+
+      const stateValue = editor?._cmEditor?.state?.doc?.toString?.();
+      const domValue = editor?._cmEditor?.contentDOM?.textContent;
+      const currentValue = stateValue === '' && typeof domValue === 'string'
+        ? domValue
+        : (stateValue || '');
+      isDirtyRef.current = false;
+      handleInput(currentValue, false);
+    };
+
+    ref.current.clearDirty = () => {
+      isDirtyRef.current = false;
+    };
+  }, [ editor ]);
+
+  const handleInput = useStaticCallback((newValue, useDebounce = true) => {
+    if (!ignoreProgrammaticChangeRef.current) {
+      isDirtyRef.current = useDebounce;
+    }
+
+    onInput(newValue, useDebounce);
     setLocalValue(newValue);
+  });
+
+  // Commit immediately on blur
+  const handleBlur = useStaticCallback(() => {
+    if (!isDirtyRef.current) {
+      return;
+    }
+
+    const currentEditor = editorRef.current;
+    const stateValue = currentEditor?._cmEditor?.state?.doc?.toString?.();
+    const domValue = currentEditor?._cmEditor?.contentDOM?.textContent;
+    const currentValue = stateValue === '' && typeof domValue === 'string'
+      ? domValue
+      : (stateValue || '');
+
+    blurHasCommittedRef.current = true;
+    isDirtyRef.current = false;
+    handleInput(currentValue, false);
   });
 
   useEffect(() => {
@@ -119,16 +177,29 @@ const FeelEditor = forwardRef((props, ref) => {
       parserDialect,
       extensions: [
         ...enableGutters ? [ lineNumbers() ] : [],
-        EditorView.lineWrapping
+        EditorView.lineWrapping,
+        EditorView.domEventHandlers({ blur: handleBlur })
       ],
       contentAttributes
     });
 
+    editorRef.current = editor;
     setEditor(
       editor
     );
 
     return () => {
+      editorRef.current = null;
+      const stateValue = editor?._cmEditor?.state?.doc?.toString?.();
+      const domValue = editor?._cmEditor?.contentDOM?.textContent;
+
+      const currentValue = stateValue === '' && typeof domValue === 'string'
+        ? domValue
+        : (stateValue || '');
+
+      if (isDirtyRef.current) {
+        handleInput(currentValue, false);
+      }
       onLint([]);
       inputRef.current.innerHTML = '';
       setEditor(null);
@@ -144,7 +215,9 @@ const FeelEditor = forwardRef((props, ref) => {
       return;
     }
 
+    ignoreProgrammaticChangeRef.current = true;
     editor.setValue(value);
+    ignoreProgrammaticChangeRef.current = false;
     setLocalValue(value);
   }, [ value ]);
 

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -974,6 +974,58 @@ describe('<FeelEntry>', function() {
 
     });
 
+    it('should trim whitespace after = when pasting FEEL expression', function() {
+
+      // given
+      const updateSpy = sinonSpy();
+
+      const result = createFeelField({
+        container,
+        feel: 'optional',
+        setValue: updateSpy
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      input.dispatchEvent(createFeelPasteEvent('  =  test  '));
+
+      // then
+      expect(updateSpy).to.have.been.calledWith('=test');
+
+      // Should also toggle to FEEL mode
+      return waitFor(() => {
+        expect(getEditor(result.container)).to.exist;
+      });
+    });
+
+
+    it('should trim whitespace after = when blurring with FEEL expression', async function() {
+
+      // given
+      const updateSpy = sinonSpy();
+
+      const result = createFeelField({
+        container,
+        feel: 'optional',
+        setValue: updateSpy
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      await act(() => {
+        input.focus();
+        changeInput(input, '  =  test  ');
+        input.blur();
+      });
+
+      // then
+      expect(updateSpy).to.have.been.calledWith('=test');
+    });
+
+
+
   });
 
 

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -916,7 +916,7 @@ describe('<FeelEntry>', function() {
       });
 
 
-      it('should preserve FEEL toggle when pasting FEEL expression and then blurring', async function() {
+      it('should commit pasted FEEL expression immediately on paste from non-FEEL text state', function() {
 
         // given
         const setValueSpy = sinonSpy();
@@ -925,7 +925,8 @@ describe('<FeelEntry>', function() {
           container,
           feel: 'optional',
           getValue: () => '',
-          setValue: setValueSpy
+          setValue: setValueSpy,
+          debounce: fn => debounce(fn, 50)
         });
 
         const input = domQuery('.bio-properties-panel-input', result.container);
@@ -935,15 +936,40 @@ describe('<FeelEntry>', function() {
         // when
         input.dispatchEvent(createFeelPasteEvent('=test'));
 
-        await waitFor(() => {
-          expect(getEditor(result.container)).to.exist;
+        // then
+        expect(setValueSpy).to.have.been.calledOnceWith('=test');
+      });
+
+
+      it('should not overwrite pasted FEEL expression when blurring immediately', async function() {
+
+        // given
+        const setValueSpy = sinonSpy();
+
+        const result = createFeelField({
+          container,
+          feel: 'optional',
+          getValue: () => '',
+          setValue: setValueSpy,
+          debounce: fn => debounce(fn, 50)
         });
 
-        input.blur();
+        const input = domQuery('.bio-properties-panel-input', result.container);
+
+        expect(getEditor(result.container)).to.not.exist;
+
+        // when
+        await act(() => {
+          input.dispatchEvent(createFeelPasteEvent('=test'));
+          input.blur();
+        });
 
         // then
-        expect(getEditor(result.container)).to.exist;
-        expect(setValueSpy).to.have.been.calledWith('=test');
+        return waitFor(() => {
+          expect(getEditor(result.container)).to.exist;
+          expect(setValueSpy).to.have.been.calledWith('=test');
+          expect(setValueSpy).not.to.have.been.calledWith(undefined);
+        });
       });
 
     });
@@ -2430,6 +2456,45 @@ describe('<FeelEntry>', function() {
       // then
       return waitFor(() => {
         expect(updateSpy).to.have.been.calledWith('=foo');
+      });
+    });
+
+
+    it('should persist value when leaving FEEL editor immediately after input', async function() {
+
+      // given
+      const updateSpy = sinonSpy();
+
+      const firstElement = { id: 'first' };
+      const secondElement = { id: 'second' };
+
+      const result = createFeelField({
+        container,
+        element: firstElement,
+        setValue: updateSpy,
+        feel: 'required',
+        debounce: fn => debounce(fn, 50)
+      });
+
+      const input = getEditor(result.container);
+
+      // when
+      await act(() => {
+        input.textContent = 'foo';
+
+        createFeelField({
+          container,
+          element: secondElement,
+          setValue: updateSpy,
+          feel: 'required',
+          debounce: fn => debounce(fn, 50)
+        }, result.rerender);
+      });
+
+      // then
+      await waitFor(() => {
+        expect(updateSpy).to.have.been.calledWith('=foo');
+        expect(updateSpy).to.have.been.calledOnce;
       });
     });
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4352#issuecomment-3703835165

### Proposed Changes


- feel expressions are now double trimmed on paste. Eg.: `  =  test  ` becomes `=test` 

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
