### PR TITLE
fix: make FeelEditor read-only based on the `disabled` prop

### DIFF
--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -116,6 +116,7 @@ const FeelEditor = forwardRef((props, ref) => {
       onKeyDown: onKeyDown,
       onLint: onLint,
       placeholder: placeholder,
+      readOnly: disabled,
       tooltipContainer: tooltipContainer,
       value: localValue,
       variables,

--- a/test/spec/components/FeelEditor.spec.js
+++ b/test/spec/components/FeelEditor.spec.js
@@ -226,6 +226,28 @@ describe('<FeelEditor>', function() {
     expect(onBlurSpy).to.have.been.calledOnce;
   });
 
+
+  it('should be read-only when disabled', function() {
+
+    // given
+    render(<Wrapper disabled={ true } />, { container });
+
+    // then
+    const editor = domQuery('[role="textbox"]', container);
+    expect(editor.getAttribute('contenteditable')).to.equal('false');
+  });
+
+
+  it('should be editable when not disabled', function() {
+
+    // given
+    render(<Wrapper />, { container });
+
+    // then
+    const editor = domQuery('[role="textbox"]', container);
+    expect(editor.getAttribute('contenteditable')).to.equal('true');
+  });
+
 });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5819

### Proposed Changes

Make a FEEL editor read-only based on the `disabled` prop.

### Try it

Use the `Example.spec.js` to create a disabled FEEL field.

![disabled-feel-entry](https://github.com/user-attachments/assets/7058ed08-8155-4e65-aca1-60b1b9206d25)

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
