### PR TITLE
feat: add `JsonEditor` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+`FEAT`: add `JsonEditor` component ([#485](https://github.com/bpmn-io/properties-panel/pull/485))
+
 ## 3.40.6
 
 * `FIX`: make FeelEditor read-only based on the `disabled` prop ([#484](https://github.com/bpmn-io/properties-panel/pull/484))

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,12 @@
       "dependencies": {
         "@bpmn-io/feel-editor": "^2.5.2",
         "@carbon/icons": "^11.69.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.5.1",
         "feelers": "^1.5.1",
@@ -534,15 +540,25 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -560,9 +576,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
-      "integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -571,9 +587,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -1047,6 +1063,17 @@
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "dependencies": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -11000,14 +11027,23 @@
       }
     },
     "@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
       "requires": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "@codemirror/language": {
@@ -11024,9 +11060,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
-      "integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -11034,9 +11070,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "requires": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -11368,6 +11404,16 @@
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "requires": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "requires": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/lr": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,15 @@
   "dependencies": {
     "@bpmn-io/feel-editor": "^2.5.2",
     "@carbon/icons": "^11.69.0",
+    "@codemirror/autocomplete": "^6.18.6",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/language": "^6.11.0",
+    "@codemirror/lint": "^6.9.5",
+    "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.28.1",
     "classnames": "^2.5.1",
+
     "feelers": "^1.5.1",
     "focus-trap": "^8.0.0",
     "min-dash": "^5.0.0",

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -569,6 +569,42 @@ textarea.bio-properties-panel-input {
   resize: vertical;
 }
 
+/**
+ * JSON Editor (CodeMirror)
+ */
+
+.bio-properties-panel-json-editor .cm-editor {
+  border: 1px solid var(--input-border-color);
+  border-radius: 2px;
+  background-color: var(--input-background-color);
+  font-size: var(--text-size-base);
+  font-family: var(--font-family-monospace);
+}
+
+.bio-properties-panel-json-editor .cm-editor.cm-focused {
+  outline: none;
+  background-color: var(--input-focus-background-color);
+  border-color: var(--input-focus-border-color);
+}
+
+.bio-properties-panel-json-editor .cm-scroller {
+  overflow: auto;
+  max-height: 215px;
+}
+
+.bio-properties-panel-json-editor .cm-content {
+  padding-right: 18px;
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-json-editor .cm-editor {
+  border-color: var(--input-error-border-color);
+  background-color: var(--input-error-background-color);
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-json-editor .cm-editor.cm-focused {
+  border-color: var(--input-error-focus-border-color);
+}
+
 .bio-properties-panel-entry.has-error .bio-properties-panel-input,
 .bio-properties-panel-entry.has-error .bio-properties-panel-feel-editor__open-popup-placeholder {
   border-color: var(--input-error-border-color);

--- a/src/components/entries/JsonEditor.js
+++ b/src/components/entries/JsonEditor.js
@@ -1,0 +1,253 @@
+import Description from './Description';
+
+import {
+  useEffect,
+  useRef,
+  useState
+} from 'preact/hooks';
+
+import classnames from 'classnames';
+
+import { isObject } from 'min-dash';
+
+import {
+  useDebounce,
+  useError,
+  useShowEntryEvent,
+  useStaticCallback
+} from '../../hooks';
+
+import Tooltip from './Tooltip';
+
+import { EditorView, drawSelection, highlightSpecialChars, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
+import { Annotation, EditorState } from '@codemirror/state';
+import { bracketMatching, defaultHighlightStyle, foldGutter, foldKeymap, syntaxHighlighting } from '@codemirror/language';
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { json, jsonParseLinter } from '@codemirror/lang-json';
+import { linter } from '@codemirror/lint';
+
+{ /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
+
+const ExternalChange = Annotation.define();
+
+/**
+ * A CodeMirror based JSON editor for the properties panel.
+ *
+ * @param {object} props
+ * @param {string} props.id
+ * @param {string} props.label
+ * @param {string} [props.value]
+ * @param {Function} props.onInput
+ * @param {boolean} [props.disabled]
+ * @param {string} [props.placeholder]
+ * @param {string} [props.tooltip]
+ * @param {object} [props.element]
+ */
+function JsonEditor(props) {
+
+  const {
+    id,
+    label,
+    debounce,
+    value = '',
+    onInput: commitValue,
+    disabled,
+    placeholder,
+    tooltip,
+    element
+  } = props;
+
+  const containerRef = useRef(null);
+  const viewRef = useRef(null);
+  const editorRef = useShowEntryEvent(id);
+
+  const onInput = useStaticCallback((newValue) => {
+    commitValue(newValue === '' ? undefined : newValue);
+  });
+
+  const handleChange = useDebounce(onInput, debounce);
+
+  useEffect(() => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          highlightSpecialChars(),
+          history(),
+          drawSelection(),
+          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+          foldGutter(),
+          bracketMatching(),
+          closeBrackets(),
+          keymap.of([
+            ...defaultKeymap,
+            ...historyKeymap,
+            ...closeBracketsKeymap,
+            ...foldKeymap
+          ]),
+          EditorState.tabSize.of(2),
+          EditorView.lineWrapping,
+          EditorState.readOnly.of(!!disabled),
+          ...(placeholder ? [ cmPlaceholder(placeholder) ] : []),
+          EditorView.updateListener.of(update => {
+            const isExternal = update.transactions.some(
+              tr => tr.annotation(ExternalChange)
+            );
+            if (update.docChanged && !isExternal) {
+              handleChange(update.state.doc.toString());
+            }
+          }),
+          json(),
+          linter(jsonParseLinter(), { delay: 300 })
+        ]
+      }),
+      parent: containerRef.current
+    });
+
+    viewRef.current = view;
+
+    // Allow useShowEntryEvent to focus the editor
+    editorRef.current = view.contentDOM;
+
+    const prefixedId = `bio-properties-panel-${ id }`;
+    view.contentDOM.setAttribute('id', prefixedId);
+    view.contentDOM.setAttribute('aria-label', label);
+
+    return () => {
+      view.destroy();
+    };
+  }, []);
+
+  // Sync external value changes into the editor
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const currentValue = view.state.doc.toString();
+    if (value === currentValue) return;
+
+    view.dispatch({
+      changes: { from: 0, to: currentValue.length, insert: value || '' },
+      annotations: ExternalChange.of(true)
+    });
+  }, [ value ]);
+
+  // Focus editor on label click manually, as the native `for`
+  // attribute does not work with contenteditable elements
+  const focusEditor = () => {
+    viewRef.current && viewRef.current.focus();
+  };
+
+  return (
+    <div class="bio-properties-panel-json-editor">
+      <label class="bio-properties-panel-label" onClick={ focusEditor }>
+        <Tooltip value={ tooltip } forId={ id } element={ element }>
+          { label }
+        </Tooltip>
+      </label>
+      <div ref={ containerRef } />
+    </div>
+  );
+}
+
+
+/**
+ * Entry wrapper for JsonEditor, handles getValue/setValue, built-in JSON validation, error display, and description.
+ *
+ * @param {object} props
+ * @param {object} props.element
+ * @param {string} props.id
+ * @param {string} [props.description]
+ * @param {string} props.label
+ * @param {Function} props.debounce
+ * @param {Function} props.getValue
+ * @param {Function} props.setValue
+ * @param {boolean} [props.disabled]
+ * @param {string} [props.placeholder]
+ * @param {string} [props.tooltip]
+ */
+export default function JsonEditorEntry(props) {
+  const {
+    element,
+    id,
+    description,
+    debounce,
+    label,
+    getValue,
+    setValue,
+    disabled,
+    placeholder,
+    tooltip
+  } = props;
+
+  const globalError = useError(id);
+
+  let value = getValue(element);
+  const [ editorValue, setEditorValue ] = useState(value);
+
+  useEffect(() => {
+    if (value === editorValue) {
+      return;
+    }
+
+    setEditorValue(value);
+  }, [ value ]);
+
+  const onInput = useStaticCallback((newValue) => {
+    setEditorValue(newValue);
+
+    const currentValue = getValue(element);
+
+    if (newValue !== currentValue) {
+      setValue(newValue);
+    }
+  });
+
+  const error = globalError || validateJson(editorValue);
+
+  return (
+    <div
+      class={ classnames('bio-properties-panel-entry', error && 'has-error') }
+      data-entry-id={ id }>
+      <JsonEditor
+        id={ id }
+        key={ element }
+        label={ label }
+        debounce={ debounce }
+        value={ value }
+        onInput={ onInput }
+        disabled={ disabled }
+        placeholder={ placeholder }
+        tooltip={ tooltip }
+        element={ element }
+      />
+      { error && <div class="bio-properties-panel-error">{ error }</div> }
+      <Description forId={ id } element={ element } value={ description } />
+    </div>
+  );
+}
+
+/**
+ * Check if the JSON editor entry has been edited.
+ */
+export function isEdited(node) {
+  const cmContent = node && node.querySelector('.cm-content');
+  return cmContent ? cmContent.textContent.trim().length > 0 : false;
+}
+
+
+// helpers /////////////////
+
+function validateJson(value) {
+  if (!value) return null;
+
+  try {
+    return isObject(JSON.parse(value)) ? null : 'JSON contains errors';
+  } catch (e) {
+    return 'JSON contains errors';
+  }
+}
+
+
+

--- a/src/components/entries/index.js
+++ b/src/components/entries/index.js
@@ -1,5 +1,6 @@
 export { default as CheckboxEntry, isEdited as isCheckboxEntryEdited } from './Checkbox';
 export { default as CheckboxGroup } from './CheckboxGroup';
+export { default as JsonEditorEntry, isEdited as isJsonEditorEntryEdited } from './JsonEditor';
 export { default as CollapsibleEntry } from './Collapsible';
 export { default as DescriptionEntry } from './Description';
 export {

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -14,6 +14,7 @@ import {
   TextFieldEntry,
   TextAreaEntry,
   CheckboxEntry,
+  JsonEditorEntry,
   NumberFieldEntry,
   SelectEntry,
   ToggleSwitchEntry,
@@ -35,6 +36,7 @@ describe('Example', function() {
   beforeEach(function() {
     container = document.createElement('div');
     container.style.width = '350px';
+    container.style.marginLeft = 'auto';
 
     TestContainer.get(this).appendChild(container);
   });
@@ -51,6 +53,7 @@ describe('Example', function() {
       implementation: 'java',
       className: 'com.example.MyDelegate',
       documentation: '',
+      exampleData: '{\n  "orderId": "12345",\n  "customer": {\n    "name": "Jane Doe",\n    "email": "jane@example.com"\n  },\n  "items": [\n    { "id": 1, "price": 29.99 },\n    { "id": 2, "price": 49.99 }\n  ]\n}',
       retryCount: 3,
       async: false,
       expression: '=myVariable + 10',
@@ -138,6 +141,19 @@ describe('Example', function() {
             component: NumberFieldComponent,
             label: 'Retry Count',
             description: 'Number of retries on failure.',
+            element
+          }
+        ]
+      },
+      {
+        id: 'code',
+        label: 'Example Data',
+        entries: [
+          {
+            id: 'exampleData',
+            component: JsonEditorComponent,
+            label: 'Example Data (JSON)',
+            description: 'Provide example output data as a JSON object.',
             element
           }
         ]
@@ -349,6 +365,22 @@ function createInputParameter(element) {
       value: ''
     });
   };
+}
+
+function JsonEditorComponent(props) {
+  const { id, element, label, description } = props;
+
+  return JsonEditorEntry({
+    id,
+    element,
+    label,
+    description,
+    debounce: fn => fn,
+    tooltip: 'Enter a JSON object representing example output data for this element.',
+    placeholder: '{ }',
+    getValue: () => element[id] ?? '',
+    setValue: (val) => { element[id] = val; }
+  });
 }
 
 class ExampleHeaderProvider {

--- a/test/spec/components/JsonEditor.spec.js
+++ b/test/spec/components/JsonEditor.spec.js
@@ -1,0 +1,375 @@
+import { expect } from 'chai';
+
+import {
+  spy as sinonSpy
+} from 'sinon';
+
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import { waitFor } from '@testing-library/preact';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  classes as domClasses,
+  query as domQuery
+} from 'min-dom';
+
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import {
+  insertCoreStyles
+} from 'test/TestHelper';
+
+import {
+  DescriptionContext,
+  ErrorsContext,
+  EventContext,
+  PropertiesPanelContext
+} from 'src/context';
+
+import JsonEditor, { isEdited } from 'src/components/entries/JsonEditor';
+
+import { EditorView } from '@codemirror/view';
+
+import { debounce } from 'min-dash';
+
+insertCoreStyles();
+
+const noop = () => {};
+
+describe('<JsonEditor>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  it('should render', async function() {
+
+    // given
+    const result = createJsonEditor({ container });
+
+    // then
+    await waitFor(() => {
+      expect(domQuery('.bio-properties-panel-json-editor', result.container)).to.exist;
+      expect(domQuery('.cm-editor', result.container)).to.exist;
+    });
+  });
+
+
+  it('should render with label', async function() {
+
+    // given
+    const result = createJsonEditor({ container, label: 'My Label' });
+
+    // then
+    const label = domQuery('.bio-properties-panel-label', result.container);
+    expect(label).to.exist;
+    expect(label.textContent).to.equal('My Label');
+  });
+
+
+  it('should render with value', async function() {
+
+    // given
+    const result = createJsonEditor({ container, getValue: () => '{"foo": 1}' });
+
+    // then
+    await waitFor(() => {
+      expect(getEditorValue(result.container)).to.equal('{"foo": 1}');
+    });
+  });
+
+
+  it('should render with placeholder', async function() {
+
+    // given
+    const result = createJsonEditor({ container, placeholder: 'Enter JSON' });
+
+    // then
+    await waitFor(() => {
+      const placeholder = domQuery('.cm-placeholder', result.container);
+      expect(placeholder).to.exist;
+      expect(placeholder.textContent).to.equal('Enter JSON');
+    });
+  });
+
+
+  it('should call setValue on user input', async function() {
+
+    // given
+    const setValueSpy = sinonSpy();
+
+    const result = createJsonEditor({
+      container,
+      setValue: setValueSpy
+    });
+
+    // when
+    await waitFor(() => {
+      expect(getEditorView(result.container)).to.exist;
+    });
+
+    setEditorValue(result.container, '{"test": true}');
+
+    // then
+    await waitFor(() => {
+      expect(setValueSpy).to.have.been.calledWith('{"test": true}');
+    });
+  });
+
+
+  it('should debounce setValue', async function() {
+
+    // given
+    const setValueSpy = sinonSpy();
+
+    const result = createJsonEditor({
+      container,
+      setValue: setValueSpy,
+      debounce: fn => debounce(fn, 50)
+    });
+
+    await waitFor(() => {
+      expect(getEditorView(result.container)).to.exist;
+    });
+
+    // when
+    setEditorValue(result.container, '{"debounced": true}');
+
+    // then - should NOT have called setValue yet
+    expect(setValueSpy).to.not.have.been.called;
+
+    // when - wait for debounce to flush
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    // then - should have called setValue after debounce
+    expect(setValueSpy).to.have.been.calledWith('{"debounced": true}');
+  });
+
+
+  it('should call setValue with undefined for empty value', async function() {
+
+    // given
+    const setValueSpy = sinonSpy();
+
+    const result = createJsonEditor({
+      container,
+      getValue: () => '{"old": 1}',
+      setValue: setValueSpy
+    });
+
+    await waitFor(() => {
+      expect(getEditorView(result.container)).to.exist;
+    });
+
+    // when
+    setEditorValue(result.container, '');
+
+    // then
+    await waitFor(() => {
+      expect(setValueSpy).to.have.been.calledWith(undefined);
+    });
+  });
+
+
+  it('should sync external value changes', async function() {
+
+    // given
+    let currentValue = '{"a": 1}';
+
+    const result = createJsonEditor({
+      container,
+      getValue: () => currentValue
+    });
+
+    await waitFor(() => {
+      expect(getEditorValue(result.container)).to.equal('{"a": 1}');
+    });
+
+    // when
+    currentValue = '{"b": 2}';
+    createJsonEditor({
+      container,
+      getValue: () => currentValue
+    }, result.render);
+
+    // then
+    await waitFor(() => {
+      expect(getEditorValue(result.container)).to.equal('{"b": 2}');
+    });
+  });
+
+
+  describe('validation', function() {
+
+    it('should show error for invalid value', async function() {
+
+      // given
+      const result = createJsonEditor({
+        container,
+        getValue: () => '{invalid: json}'
+      });
+
+      // then
+      await waitFor(() => {
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        expect(domClasses(entry).has('has-error')).to.be.true;
+
+        const error = domQuery('.bio-properties-panel-error', result.container);
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('JSON contains errors');
+      });
+    });
+
+
+    it('should show no error for valid value', async function() {
+
+      // given
+      const result = createJsonEditor({
+        container,
+        getValue: () => '{"valid": true}'
+      });
+
+      // then
+      await waitFor(() => {
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        expect(domClasses(entry).has('has-error')).to.be.false;
+      });
+    });
+
+  });
+
+
+  describe('isEdited', function() {
+
+    it('should return true when editor has content', async function() {
+
+      // given
+      const result = createJsonEditor({
+        container,
+        getValue: () => '{"foo": 1}'
+      });
+
+      // then
+      await waitFor(() => {
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        expect(isEdited(entry)).to.be.true;
+      });
+    });
+
+
+    it('should return false when editor is empty', async function() {
+
+      // given
+      const result = createJsonEditor({
+        container,
+        getValue: () => ''
+      });
+
+      // then
+      await waitFor(() => {
+        const entry = domQuery('.bio-properties-panel-entry', result.container);
+        expect(isEdited(entry)).to.be.false;
+      });
+    });
+
+  });
+});
+
+
+// factory ////////////////////
+
+function createJsonEditor(options = {}, renderFn = render) {
+  const {
+    element,
+    id = 'testJsonEditor',
+    description,
+    debounce = fn => fn,
+    label = 'JSON Editor',
+    getValue = noop,
+    setValue = noop,
+    disabled,
+    placeholder,
+    tooltip,
+    descriptionConfig = {},
+    getDescriptionForId = noop,
+    container,
+    eventBus = new EventBus(),
+    onShow = noop,
+    errors = {}
+  } = options;
+
+  const errorsContext = {
+    errors
+  };
+
+  const eventContext = {
+    eventBus
+  };
+
+  const propertiesPanelContext = {
+    onShow
+  };
+
+  const descriptionContext = {
+    description: descriptionConfig,
+    getDescriptionForId
+  };
+
+  return renderFn(
+    <ErrorsContext.Provider value={ errorsContext }>
+      <EventContext.Provider value={ eventContext }>
+        <PropertiesPanelContext.Provider value={ propertiesPanelContext }>
+          <DescriptionContext.Provider value={ descriptionContext }>
+            <JsonEditor
+              element={ element }
+              id={ id }
+              label={ label }
+              debounce={ debounce }
+              description={ description }
+              getValue={ getValue }
+              setValue={ setValue }
+              disabled={ disabled }
+              placeholder={ placeholder }
+              tooltip={ tooltip } />
+          </DescriptionContext.Provider>
+        </PropertiesPanelContext.Provider>
+      </EventContext.Provider>
+    </ErrorsContext.Provider>,
+    { container }
+  );
+}
+
+// helpers /////////////////
+
+/**
+ * Get the CodeMirror EditorView instance from a container.
+ */
+function getEditorView(container) {
+  const cmElement = domQuery('.cm-editor', container);
+  return cmElement && EditorView.findFromDOM(cmElement);
+}
+
+/**
+ * Get the current document text from the CodeMirror editor.
+ */
+function getEditorValue(container) {
+  const view = getEditorView(container);
+  return view ? view.state.doc.toString() : '';
+}
+
+/**
+ * Set the text of the CodeMirror editor, simulating user input.
+ */
+function setEditorValue(container, value) {
+  const view = getEditorView(container);
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: value }
+  });
+}


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5855

### Proposed Changes

Added a new `JsonEditor` properties panel component with built-in JSON validation. This will be used for example data input and integrated into the [example-data-properties-provider](https://github.com/camunda/example-data-properties-provider), replacing the simple textarea currently in use.

This component can also be reused for any future properties panel inputs that require JSON formatting.

<img width="783" height="370" alt="image" src="https://github.com/user-attachments/assets/378daf96-98bc-4b40-93cd-92bd265e6296" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
