### PR TITLE
fix: don't show inline JSON editor error for empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+## 3.41.1
+
+* `FIX`: prevent inline error in JSON editor with empty value ([#487](https://github.com/bpmn-io/properties-panel/pull/487))
+
 ## 3.41.0
 
 `FEAT`: add `JsonEditor` component ([#485](https://github.com/bpmn-io/properties-panel/pull/485))

--- a/src/components/entries/JsonEditor.js
+++ b/src/components/entries/JsonEditor.js
@@ -30,6 +30,7 @@ import { linter } from '@codemirror/lint';
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 const ExternalChange = Annotation.define();
+const parseJsonLinter = jsonParseLinter();
 
 /**
  * A CodeMirror based JSON editor for the properties panel.
@@ -99,7 +100,11 @@ function JsonEditor(props) {
             }
           }),
           json(),
-          linter(jsonParseLinter(), { delay: 300 })
+          linter((view) => {
+            const content = view.state.doc.toString();
+            if (!content.trim()) return [];
+            return parseJsonLinter(view);
+          }, { delay: 300 })
         ]
       }),
       parent: containerRef.current
@@ -240,7 +245,7 @@ export function isEdited(node) {
 // helpers /////////////////
 
 function validateJson(value) {
-  if (!value) return null;
+  if (!value || !value.trim()) return null;
 
   try {
     return isObject(JSON.parse(value)) ? null : 'JSON contains errors';

--- a/test/spec/components/JsonEditor.spec.js
+++ b/test/spec/components/JsonEditor.spec.js
@@ -243,6 +243,29 @@ describe('<JsonEditor>', function() {
       });
     });
 
+
+    it('should show no error for empty value', async function() {
+
+      // given
+      const result = createJsonEditor({
+        container,
+        getValue: () => ''
+      });
+
+      // wait linter delay to ensure no errors appear
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // then
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      expect(domClasses(entry).has('has-error')).to.be.false;
+
+      const error = domQuery('.bio-properties-panel-error', result.container);
+      expect(error).to.not.exist;
+
+      const editorInlineErrors = domQuery('.cm-lintPoint-error', result.container);
+      expect(editorInlineErrors).to.not.exist;
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Small follow-up tweak for [PR #485](https://github.com/bpmn-io/properties-panel/pull/485) to prevent inline editor errors from being shown for empty values.

Before:

<img width="412" height="171" alt="image" src="https://github.com/user-attachments/assets/554e2b2a-61e5-4386-8e62-d0d37ae65526" />

After:

<img width="378" height="80" alt="image" src="https://github.com/user-attachments/assets/7d1b3102-fb94-4c93-9648-28c516d298d6" />



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
