### PR TITLE
fix: add support of external validator for `JsonEditorEntry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: add support of external validator for `JsonEditorEntry` ([#489](https://github.com/bpmn-io/properties-panel/pull/489))
+
 ## 3.41.2
 
-* `FIX`:fix JSON editor entry `isEdited` check from a properties panel group header ([#488](https://github.com/bpmn-io/properties-panel/pull/488))
+* `FIX`: fix JSON editor entry `isEdited` check from a properties panel group header ([#488](https://github.com/bpmn-io/properties-panel/pull/488))
 
 ## 3.41.1
 

--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -656,18 +656,18 @@ export default function FeelEntry(props) {
 
   const onInput = useStaticCallback((newValue) => {
     const value = getValue(element);
-    let newValidationError = null;
 
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
-    }
-
-    // don't create multiple commandStack entries for the same value
+    // don't create multiple commandStack entries and do validation for the same value
     if (newValue !== value) {
-      setValue(newValue, newValidationError);
-    }
+      let newValidationError = null;
 
-    setValidationError(newValidationError);
+      if (isFunction(validate)) {
+        newValidationError = validate(newValue) || null;
+      }
+
+      setValue(newValue, newValidationError);
+      setValidationError(newValidationError);
+    }
   });
 
   const onError = useCallback(err => {

--- a/src/components/entries/JsonEditor.js
+++ b/src/components/entries/JsonEditor.js
@@ -8,7 +8,7 @@ import {
 
 import classnames from 'classnames';
 
-import { isObject } from 'min-dash';
+import { isFunction, isObject } from 'min-dash';
 
 import {
   useDebounce,
@@ -171,6 +171,7 @@ function JsonEditor(props) {
  * @param {boolean} [props.disabled]
  * @param {string} [props.placeholder]
  * @param {string} [props.tooltip]
+ * @param {Function} [props.validate]
  */
 export default function JsonEditorEntry(props) {
   const {
@@ -183,12 +184,16 @@ export default function JsonEditorEntry(props) {
     setValue,
     disabled,
     placeholder,
-    tooltip
+    tooltip,
+    validate
   } = props;
 
   const globalError = useError(id);
 
   let value = getValue(element);
+  const [ localError, setLocalError ] = useState(
+    () => computeError(validate, value)
+  );
   const [ editorValue, setEditorValue ] = useState(value);
 
   useEffect(() => {
@@ -197,7 +202,8 @@ export default function JsonEditorEntry(props) {
     }
 
     setEditorValue(value);
-  }, [ value ]);
+    setLocalError(computeError(validate, value));
+  }, [ value, validate ]);
 
   const onInput = useStaticCallback((newValue) => {
     setEditorValue(newValue);
@@ -205,11 +211,14 @@ export default function JsonEditorEntry(props) {
     const currentValue = getValue(element);
 
     if (newValue !== currentValue) {
-      setValue(newValue);
+      const newValidationError = computeError(validate, newValue);
+
+      setValue(newValue, newValidationError);
+      setLocalError(newValidationError);
     }
   });
 
-  const error = globalError || validateJson(editorValue);
+  const error = globalError || localError;
 
   return (
     <div
@@ -243,6 +252,10 @@ export function isEdited(node) {
 
 // helpers /////////////////
 
+function computeError(validate, value) {
+  return (isFunction(validate) ? validate(value) : null) || validateJson(value);
+}
+
 function validateJson(value) {
   if (!value || !value.trim()) return null;
 
@@ -252,6 +265,3 @@ function validateJson(value) {
     return 'JSON contains errors';
   }
 }
-
-
-

--- a/src/components/entries/NumberField.js
+++ b/src/components/entries/NumberField.js
@@ -139,14 +139,16 @@ export default function NumberFieldEntry(props) {
   }, [ value, validate ]);
 
   const onInput = (newValue) => {
-    let newValidationError = null;
+    if (newValue !== value) {
+      let newValidationError = null;
 
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
+      if (isFunction(validate)) {
+        newValidationError = validate(newValue) || null;
+      }
+
+      setValue(newValue, newValidationError);
+      setLocalError(newValidationError);
     }
-
-    setValue(newValue, newValidationError);
-    setLocalError(newValidationError);
   };
 
   const error = globalError || localError;

--- a/src/components/entries/Select.js
+++ b/src/components/entries/Select.js
@@ -162,14 +162,16 @@ export default function SelectEntry(props) {
 
 
   const onChange = (newValue) => {
-    let newValidationError = null;
+    if (newValue !== value) {
+      let newValidationError = null;
 
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
+      if (isFunction(validate)) {
+        newValidationError = validate(newValue) || null;
+      }
+
+      setValue(newValue, newValidationError);
+      setLocalError(newValidationError);
     }
-
-    setValue(newValue, newValidationError);
-    setLocalError(newValidationError);
   };
 
   const error = globalError || localError;

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -223,17 +223,17 @@ export default function TextAreaEntry(props) {
 
   const onInput = useStaticCallback((newValue) => {
     const value = getValue(element);
-    let newValidationError = null;
-
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
-    }
 
     if (newValue !== value) {
-      setValue(newValue, newValidationError);
-    }
+      let newValidationError = null;
 
-    setLocalError(newValidationError);
+      if (isFunction(validate)) {
+        newValidationError = validate(newValue) || null;
+      }
+
+      setValue(newValue, newValidationError);
+      setLocalError(newValidationError);
+    }
   });
 
 

--- a/src/components/entries/TextField.js
+++ b/src/components/entries/TextField.js
@@ -189,17 +189,17 @@ export default function TextfieldEntry(props) {
 
   const onInput = useStaticCallback((newValue) => {
     const value = getValue(element);
-    let newValidationError = null;
-
-    if (isFunction(validate)) {
-      newValidationError = validate(newValue) || null;
-    }
 
     if (newValue !== value) {
-      setValue(newValue, newValidationError);
-    }
+      let newValidationError = null;
 
-    setLocalError(newValidationError);
+      if (isFunction(validate)) {
+        newValidationError = validate(newValue) || null;
+      }
+
+      setValue(newValue, newValidationError);
+      setLocalError(newValidationError);
+    }
   });
 
 

--- a/test/spec/components/JsonEditor.spec.js
+++ b/test/spec/components/JsonEditor.spec.js
@@ -306,6 +306,34 @@ describe('<JsonEditor>', function() {
     });
 
 
+    it('should not call setValue or validate if value is same', async function() {
+
+      // given
+      const setValueSpy = sinonSpy();
+      const validateSpy = sinonSpy();
+
+      const result = createJsonEditor({
+        container,
+        getValue: () => '{"existing": true}',
+        setValue: setValueSpy,
+        validate: validateSpy
+      });
+
+      await waitFor(() => {
+        expect(getEditorView(result.container)).to.exist;
+      });
+
+      // when
+      validateSpy.resetHistory();
+      setEditorValue(result.container, '{"existing": true}');
+
+      // then
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(setValueSpy).to.not.have.been.called;
+      expect(validateSpy).to.not.have.been.called;
+    });
+
+
     it('should pass validation error to setValue', async function() {
 
       // given

--- a/test/spec/components/JsonEditor.spec.js
+++ b/test/spec/components/JsonEditor.spec.js
@@ -266,6 +266,68 @@ describe('<JsonEditor>', function() {
       expect(editorInlineErrors).to.not.exist;
     });
 
+
+    it('should show error from validate prop', async function() {
+
+      // given
+      const validate = (value) => value === 'invalid' ? 'custom error' : null;
+
+      const result = createJsonEditor({
+        container,
+        getValue: () => 'invalid',
+        validate
+      });
+
+      // then
+      await waitFor(() => {
+        const error = domQuery('.bio-properties-panel-error', result.container);
+        expect(error).to.exist;
+        expect(error.textContent).to.equal('custom error');
+      });
+    });
+
+
+    it('should show no error from validate prop if valid', async function() {
+
+      // given
+      const validate = (value) => value === 'invalid' ? 'custom error' : null;
+
+      const result = createJsonEditor({
+        container,
+        getValue: () => '{"valid": true}',
+        validate
+      });
+
+      // then
+      await waitFor(() => {
+        const error = domQuery('.bio-properties-panel-error', result.container);
+        expect(error).to.not.exist;
+      });
+    });
+
+
+    it('should pass validation error to setValue', async function() {
+
+      // given
+      const validate = () => 'always invalid';
+      const setValue = sinonSpy();
+
+      const result = createJsonEditor({
+        container,
+        getValue: () => '',
+        setValue,
+        validate
+      });
+
+      // when
+      setEditorValue(result.container, 'new value');
+
+      // then
+      await waitFor(() => {
+        expect(setValue).to.have.been.calledWith('new value', 'always invalid');
+      });
+    });
+
   });
 
 
@@ -349,6 +411,7 @@ function createJsonEditor(options = {}, renderFn = render) {
     disabled,
     placeholder,
     tooltip,
+    validate,
     descriptionConfig = {},
     getDescriptionForId = noop,
     container,
@@ -389,7 +452,8 @@ function createJsonEditor(options = {}, renderFn = render) {
               setValue={ setValue }
               disabled={ disabled }
               placeholder={ placeholder }
-              tooltip={ tooltip } />
+              tooltip={ tooltip }
+              validate={ validate } />
           </DescriptionContext.Provider>
         </PropertiesPanelContext.Provider>
       </EventContext.Provider>

--- a/test/spec/components/NumberField.spec.js
+++ b/test/spec/components/NumberField.spec.js
@@ -91,7 +91,7 @@ describe('<NumberField>', function() {
     // given
     const updateSpy = sinonSpy();
 
-    const result = createNumberField({ container, setValue: updateSpy });
+    const result = createNumberField({ container, getValue: () => 42, setValue: updateSpy });
 
     const input = domQuery('.bio-properties-panel-input', result.container);
 
@@ -119,6 +119,31 @@ describe('<NumberField>', function() {
 
     // then
     expect(updateSpy).to.not.have.been.called;
+  });
+
+
+  it('should not call setValue or validate if the value is same', function() {
+
+    // given
+    const setValueSpy = sinonSpy();
+    const validateSpy = sinonSpy();
+
+    const result = createNumberField({
+      container,
+      getValue: () => 20.5,
+      setValue: setValueSpy,
+      validate: validateSpy
+    });
+
+    const input = domQuery('.bio-properties-panel-input', result.container);
+
+    // when
+    validateSpy.resetHistory();
+    changeInput(input, 20.5);
+
+    // then
+    expect(setValueSpy).to.not.have.been.called;
+    expect(validateSpy).to.not.have.been.called;
   });
 
 

--- a/test/spec/components/Select.spec.js
+++ b/test/spec/components/Select.spec.js
@@ -147,6 +147,34 @@ describe('<Select>', function() {
   });
 
 
+  it('should not call setValue or validate if the value is same', function() {
+
+    // given
+    const setValueSpy = sinonSpy();
+    const validateSpy = sinonSpy();
+
+    const getOptions = () => createOptions();
+
+    const result = createSelect({
+      container,
+      getValue: () => 'A',
+      setValue: setValueSpy,
+      validate: validateSpy,
+      getOptions
+    });
+
+    const select = domQuery('.bio-properties-panel-input', result.container);
+
+    // when
+    validateSpy.resetHistory();
+    changeInput(select, 'A');
+
+    // then
+    expect(setValueSpy).to.not.have.been.called;
+    expect(validateSpy).to.not.have.been.called;
+  });
+
+
   it('should use unique input element on element change', function() {
 
     // given

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -336,26 +336,30 @@ describe('<TextArea>', function() {
   });
 
 
-  it('should not call setValue if the value is same', async function() {
+  it('should not call setValue or validate if the value is same', async function() {
 
     // given
     const setValueSpy = sinonSpy();
+    const validateSpy = sinonSpy();
 
     const result = createTextArea({
       container,
       getValue: () => 'a value',
-      setValue: setValueSpy
+      setValue: setValueSpy,
+      validate: validateSpy
     });
 
     const input = domQuery('.bio-properties-panel-input', result.container);
 
     // when
+    validateSpy.resetHistory();
     input.focus();
     changeInput(input, 'a value');
     input.blur();
 
     // then
     expect(setValueSpy).to.not.have.been.called;
+    expect(validateSpy).to.not.have.been.called;
 
   });
 

--- a/test/spec/components/TextField.spec.js
+++ b/test/spec/components/TextField.spec.js
@@ -294,26 +294,30 @@ describe('<TextField>', function() {
   });
 
 
-  it('should not call setValue if the value is same', async function() {
+  it('should not call setValue or validate if the value is same', async function() {
 
     // given
     const setValueSpy = sinonSpy();
+    const validateSpy = sinonSpy();
 
     const result = createTextField({
       container,
       getValue: () => 'a value',
-      setValue: setValueSpy
+      setValue: setValueSpy,
+      validate: validateSpy
     });
 
     const input = domQuery('.bio-properties-panel-input', result.container);
 
     // when
+    validateSpy.resetHistory();
     input.focus();
     changeInput(input, 'a value');
     input.blur();
 
     // then
     expect(setValueSpy).to.not.have.been.called;
+    expect(validateSpy).to.not.have.been.called;
 
   });
 


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/244#discussion_r3138619604

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Add support of external validator for `JsonEditorEntry`. 

This PR also included small refactoring of other input-like components to avoid calling `setValue` and validation if the value hasn't changed(ref [slack](https://camunda.slack.com/archives/GP70M0J6M/p1777459163731909) discussion)

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
