### PR TITLE
feat: do not render `<Header>` if no `headerProvider` is provided

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -105,9 +105,12 @@ const DEFAULT_TOOLTIP = {};
  * A basic properties panel component. Describes *how* content will be rendered, accepts
  * data from implementor to describe *what* will be rendered.
  *
+ * If `headerProvider` is omitted (or `null`), the built-in `<Header>` is not rendered;
+ * consumers can render `<Header>` standalone elsewhere using the same provider shape.
+ *
  * @param {Object} props
  * @param {Object|Array} props.element
- * @param {import('./components/Header').HeaderProvider} props.headerProvider
+ * @param {import('./components/Header').HeaderProvider} [props.headerProvider]
  * @param {PlaceholderProvider} [props.placeholderProvider]
  * @param {Array<GroupDefinition|ListGroupDefinition>} props.groups
  * @param {Object} [props.layoutConfig]
@@ -243,9 +246,11 @@ export default function PropertiesPanel(props) {
             <LayoutContext.Provider value={ layoutContext }>
               <EventContext.Provider value={ eventContext }>
                 <div class="bio-properties-panel">
-                  <Header
-                    element={ element }
-                    headerProvider={ headerProvider } />
+                  { headerProvider ? (
+                    <Header
+                      element={ element }
+                      headerProvider={ headerProvider } />
+                  ) : null }
                   <div class="bio-properties-panel-scroll-container">
                     {
                       groups.map(group => {

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -9,6 +9,8 @@ import {
 
 import PropertiesPanel from 'src/PropertiesPanel';
 
+import Header from 'src/components/Header';
+
 import ListGroup from 'src/components/ListGroup';
 
 import {
@@ -248,15 +250,27 @@ function ExampleApp() {
   ];
 
   return (
-    <PropertiesPanel
-      element={ element }
-      headerProvider={ ExampleHeaderProvider }
-      placeholderProvider={ ExamplePlaceholderProvider }
-      groups={ groups }
-      eventBus={ eventBus }
-      layoutConfig={ layoutConfig }
-      layoutChanged={ noop }
-    />
+    <div class="bio-properties-panel" style="display: flex; flex-direction: column; height: 100%;">
+      <div style="border: 2px dashed #888; margin: 4px;">
+        <div style="font-size: 11px; color: #555; padding: 4px 8px; background: #f5f5f5;">
+          standalone &lt;Header&gt;
+        </div>
+        <Header element={ element } headerProvider={ ExampleHeaderProvider } />
+      </div>
+      <div style="border: 2px dashed #0a7; margin: 4px; flex: 1; min-height: 0;">
+        <div style="font-size: 11px; color: #555; padding: 4px 8px; background: #f5f5f5;">
+          &lt;PropertiesPanel&gt; without built-in header
+        </div>
+        <PropertiesPanel
+          element={ element }
+          placeholderProvider={ ExamplePlaceholderProvider }
+          groups={ groups }
+          eventBus={ eventBus }
+          layoutConfig={ layoutConfig }
+          layoutChanged={ noop }
+        />
+      </div>
+    </div>
   );
 }
 
@@ -437,7 +451,11 @@ class ExampleHeaderProvider {
   }
 
   static getElementIcon() {
-    return () => <span>&#9881;</span>;
+    return ({ width, height }) => (
+      <span style={ `font-size: ${ width || 32 }px; line-height: ${ height || 32 }px;` }>
+        &#9881;
+      </span>
+    );
   }
 
   static getTypeLabel(element) {

--- a/test/spec/PropertiesPanel.spec.js
+++ b/test/spec/PropertiesPanel.spec.js
@@ -120,6 +120,37 @@ describe('<PropertiesPanel>', function() {
   });
 
 
+  it('should not render header - no header provider', function() {
+
+    // when
+    const result = createPropertiesPanel({
+      container,
+      element: noopElement,
+      headerProvider: null
+    });
+
+    // then
+    expect(domQuery('.bio-properties-panel-header', result.container)).to.not.exist;
+    expect(domQuery('.bio-properties-panel-scroll-container', result.container)).to.exist;
+  });
+
+
+  it('should not render header - header provider omitted', function() {
+
+    // when
+    const result = render(
+      <PropertiesPanel
+        element={ noopElement }
+        groups={ [] } />,
+      { container }
+    );
+
+    // then
+    expect(domQuery('.bio-properties-panel-header', result.container)).to.not.exist;
+    expect(domQuery('.bio-properties-panel-scroll-container', result.container)).to.exist;
+  });
+
+
   describe('groups', function() {
 
     it('should render groups', function() {


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1294

### Proposed Changes

Make `<Header>` optional - it is not rendered if no `headerProvider` is provided.

### Try it

`npm start`

<img width="392" height="601" alt="image" src="https://github.com/user-attachments/assets/6359fcf7-afee-41c2-9bf5-bb201bf7eb33" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
