### PR TITLE
fix: allow tooltip navigation inside group tooltips

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -108,7 +108,7 @@ export default function Group(props) {
       <div
         class="bio-properties-panel-group-header-title"
       >
-        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element } parent={ groupRef }>
+        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element }>
           { label }
         </Tooltip>
       </div>

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -127,7 +127,7 @@ export default function ListGroup(props) {
       <div
         class="bio-properties-panel-group-header-title"
       >
-        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element } parent={ groupRef }>
+        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element }>
           { label }
         </Tooltip>
       </div>

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -34,7 +34,7 @@ import {
   PropertiesPanelContext,
   ErrorsContext
 } from 'src/context';
-import { fireEvent } from '@testing-library/preact';
+import { fireEvent, waitFor } from '@testing-library/preact';
 import { act } from 'preact/test-utils';
 
 insertCoreStyles();
@@ -302,6 +302,57 @@ describe('<Group>', function() {
 
       // then
       expect(domAttr(dataMarker, 'title')).to.eql('Section contains edits');
+    });
+
+  });
+
+
+  describe('tooltip keyboard navigation', function() {
+
+    it('should allow tab navigation to focusable tooltip content', async function() {
+
+      // given
+      const tooltip = <div><a id="tooltip-link" href="#">link</a></div>;
+      const result = createGroup({ container, label: 'Group', tooltip });
+
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', result.container);
+
+      // when - open tooltip via keyboard focus
+      wrapper.focus();
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-tooltip', result.container)).to.exist;
+      });
+
+      // then - focusable tooltip content should be inside the wrapper
+      const link = domQuery('#tooltip-link', result.container);
+      expect(wrapper.contains(link)).to.be.true;
+    });
+
+
+    it('should keep tooltip open when focusing link inside tooltip', async function() {
+
+      // given
+      const tooltip = <div><a id="tooltip-link" href="#">link</a></div>;
+      const result = createGroup({ container, label: 'Group', tooltip });
+
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', result.container);
+
+      // when - open tooltip via keyboard focus and focus the link
+      wrapper.focus();
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-tooltip', result.container)).to.exist;
+      });
+
+      const link = domQuery('#tooltip-link', result.container);
+      link.focus();
+
+      // then - tooltip should remain visible after state updates flush
+      await waitFor(() => {
+        expect(document.activeElement).to.equal(link);
+        expect(domQuery('.bio-properties-panel-tooltip', result.container)).to.exist;
+      });
     });
 
   });

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -895,6 +895,57 @@ describe('<ListGroup>', function() {
   });
 
 
+  describe('tooltip keyboard navigation', function() {
+
+    it('should allow tab navigation to focusable tooltip content', async function() {
+
+      // given
+      const tooltip = <div><a id="tooltip-link" href="#">link</a></div>;
+      const { container } = createListGroup({ container: parentContainer, tooltip });
+
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when - open tooltip via keyboard focus
+      wrapper.focus();
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-tooltip', container)).to.exist;
+      });
+
+      // then - focusable tooltip content should be inside the wrapper
+      const link = domQuery('#tooltip-link', container);
+      expect(wrapper.contains(link)).to.be.true;
+    });
+
+
+    it('should keep tooltip open when focusing link inside tooltip', async function() {
+
+      // given
+      const tooltip = <div><a id="tooltip-link" href="#">link</a></div>;
+      const { container } = createListGroup({ container: parentContainer, tooltip });
+
+      const wrapper = domQuery('.bio-properties-panel-tooltip-wrapper', container);
+
+      // when - open tooltip via keyboard focus and focus the link
+      wrapper.focus();
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-tooltip', container)).to.exist;
+      });
+
+      const link = domQuery('#tooltip-link', container);
+      link.focus();
+
+      // then - tooltip should remain visible after state updates flush
+      await waitFor(() => {
+        expect(document.activeElement).to.equal(link);
+        expect(domQuery('.bio-properties-panel-tooltip', container)).to.exist;
+      });
+    });
+
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Do not render tooltip in a portal, which prevented tab navigation from working correctly.

On macOS Firefox 151.0, this fix does not reopen https://github.com/bpmn-io/properties-panel/issues/266 . But the reviewer should check this to verify.

Closes https://github.com/bpmn-io/properties-panel/issues/493

https://github.com/user-attachments/assets/47b69aa5-b735-40a5-92f7-348175ca233d


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
