### PR TITLE
Style `<code />` as monospace, following theming

### DIFF
--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -51,7 +51,7 @@ const DEFAULT_TOOLTIP = {};
  *    autoOpen?: Boolean,
  *    entries: Array<EntryDefinition>,
  *    id: String,
- *    label: String,
+ *    label: String|import('preact').ComponentChildren,
  *    remove: (event: MouseEvent) => void
  * } } ListItemDefinition
  *

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -534,6 +534,7 @@ select.bio-properties-panel-input {
   padding: 4px 6px;
 }
 
+.bio-properties-panel code,
 .bio-properties-panel-input-monospace {
   font-family: var(--font-family-monospace);
 }

--- a/src/components/entries/List.js
+++ b/src/components/entries/List.js
@@ -35,7 +35,7 @@ import {
  * @param {*} props.element
  * @param {Function} props.onAdd
  * @param {import('preact').Component} props.component
- * @param {string} [props.label='<empty>']
+ * @param {string|import('preact').ComponentChildren} [props.label='<empty>']
  * @param {Function} [props.onRemove]
  * @param {Item[]} [props.items]
  * @param {boolean} [props.open]


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1222, ensures that properties panel components can be styled as `<code />`, and the font is picked up as per our variables:

<img width="1110" height="991" alt="image" src="https://github.com/user-attachments/assets/f0023bcb-640f-4984-aa48-823bb1224002" />


```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#variables-monospace -l bpmn-io/properties-panel#code
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
