### PR TITLE
De-emphasize tooltiped element underlines

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1182,14 +1182,16 @@ textarea.bio-properties-panel-input {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;
-  text-decoration-color: #888;
+  text-decoration-color: var(--color-grey-225-10-55);
   font: inherit;
   display: flex;
   justify-content: center;
   width: fit-content;
 }
 
-.bio-properties-panel-tooltip-wrapper:hover {
+.bio-properties-panel-tooltip-wrapper:hover,
+.bio-properties-panel-tooltip-wrapper:focus,
+.bio-properties-panel-tooltip-wrapper:focus-visible {
   text-decoration-color: currentColor;
 }
 

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1182,10 +1182,15 @@ textarea.bio-properties-panel-input {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;
+  text-decoration-color: #888;
   font: inherit;
   display: flex;
   justify-content: center;
   width: fit-content;
+}
+
+.bio-properties-panel-tooltip-wrapper:hover {
+  text-decoration-color: currentColor;
 }
 
 .bio-properties-panel-tooltip {


### PR DESCRIPTION
### Proposed Changes

As per our guidelines we should assume that in more complicated scenarios most of the primary sections are documented via tooltips - however not all of them, at all times. In addition, entries may have tooltips, bringing additional details across.

This PR slightly de-prioritizes tooltiped elements underlines, so folks can focus more on the actual contents - it reduces the visual noise. At the same time, we still bring the core message across: This element offers a helpful tooltip.

<img width="1148" height="989" alt="image" src="https://github.com/user-attachments/assets/f5a6f0fa-2e4d-4776-841b-7b5b305a9ca4" />

For comparison, the before version:

<img width="1032" height="987" alt="image" src="https://github.com/user-attachments/assets/338af942-f33c-4336-8110-9ad179edb3ae" />

### Try out via

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#tooltip-reworks -l bpmn-io/properties-panel#tt-underline
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
