### PR TITLE
fix: theme tooltip underline via semantic color name

### DIFF
--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -44,6 +44,8 @@
   --description-code-border-color: var(--color-grey-225-10-85);
   --description-list-item-color: var(--color-grey-225-10-35);
 
+  --tooltip-underline-color: var(--color-grey-225-10-55);
+
   --placeholder-color: var(--color-grey-225-10-35);
   --placeholder-background-color: var(--color-grey-225-10-95);
 
@@ -1182,7 +1184,7 @@ textarea.bio-properties-panel-input {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;
-  text-decoration-color: var(--color-grey-225-10-55);
+  text-decoration-color: var(--tooltip-underline-color);
   font: inherit;
   display: flex;
   justify-content: center;
@@ -1196,7 +1198,6 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-tooltip {
-  --tooltip-underline-color: var(--color-blue-219-99-53);
   --tooltip-background-color: var(--color-grey-0-0-22);
   --tooltip-link: var(--color-blue-218-100-74);
   --tooltip-code-background-color: var(--color-grey-225-10-97);


### PR DESCRIPTION
### Proposed Changes

Follow-up to https://github.com/bpmn-io/properties-panel/pull/499, theming tooltip underline color via a semantic variable name.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
