### PR TITLE
fix: autofocus first focusable element in the tooltip body in case of keyboard navigation

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -98,6 +98,8 @@ export default function Group(props) {
     onShow
   };
 
+  const tooltipContainerRef = useRef(null);
+
   return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id } ref={ groupRef }>
     <div class={ classnames(
       'bio-properties-panel-group-header',
@@ -108,10 +110,11 @@ export default function Group(props) {
       <div
         class="bio-properties-panel-group-header-title"
       >
-        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element }>
+        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element } parent={ tooltipContainerRef }>
           { label }
         </Tooltip>
       </div>
+      <div ref={ tooltipContainerRef } />
       <div class="bio-properties-panel-group-header-buttons">
         {
           <DataMarker

--- a/src/components/ListGroup.js
+++ b/src/components/ListGroup.js
@@ -114,6 +114,8 @@ export default function ListGroup(props) {
     return item.entries.some(entry => allErrors[entry.id]);
   });
 
+  const tooltipContainerRef = useRef(null);
+
 
   return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id } ref={ groupRef }>
     <div
@@ -127,10 +129,11 @@ export default function ListGroup(props) {
       <div
         class="bio-properties-panel-group-header-title"
       >
-        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element }>
+        <Tooltip value={ props.tooltip } forId={ 'group-' + id } element={ element } parent={ tooltipContainerRef }>
           { label }
         </Tooltip>
       </div>
+      <div ref={ tooltipContainerRef } />
       <div class="bio-properties-panel-group-header-buttons">
         {
           add

--- a/src/components/entries/Tooltip.js
+++ b/src/components/entries/Tooltip.js
@@ -68,6 +68,7 @@ function Tooltip(props) {
   const [ visible, setVisible ] = useState(false);
   const [ tooltipPosition, setTooltipPosition ] = useState(null);
   const [ arrowOffset, setArrowOffset ] = useState(null);
+  const [ openedViaKeyboard, setOpenedViaKeyboard ] = useState(false);
 
   const showTimeoutRef = useRef(null);
   const hideTimeoutRef = useRef(null);
@@ -90,7 +91,13 @@ function Tooltip(props) {
     }
   };
 
+  const handleWrapperFocus = (e) => {
+    setOpenedViaKeyboard(true);
+    show(e, false);
+  };
+
   const handleWrapperMouseEnter = (e) => {
+    setOpenedViaKeyboard(false);
     show(e, true);
   };
 
@@ -186,8 +193,23 @@ function Tooltip(props) {
     hide(false);
   };
 
+  // Auto-focus first focusable element in tooltip when opened via keyboard
+  useEffect(() => {
+    if (!visible || !openedViaKeyboard || !tooltipRef.current) return;
+
+    const focusable = tooltipRef.current.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    }
+  }, [ visible, openedViaKeyboard ]);
+
   const hideTooltipViaEscape = (e) => {
-    e.code === 'Escape' && hide(false);
+    if (e.code === 'Escape') {
+      hide(false);
+      wrapperRef.current?.focus();
+    }
   };
 
   const renderTooltip = () => {
@@ -205,6 +227,8 @@ function Tooltip(props) {
         onClick={ (e)=> e.stopPropagation() }
         onMouseEnter={ handleTooltipMouseEnter }
         onMouseLeave={ handleMouseLeave }
+        onKeyDown={ hideTooltipViaEscape }
+        onBlur={ handleFocusOut }
       >
         <div class="bio-properties-panel-tooltip-content">
           {value}
@@ -219,7 +243,7 @@ function Tooltip(props) {
       ref={ wrapperRef }
       onMouseEnter={ handleWrapperMouseEnter }
       onMouseLeave={ handleMouseLeave }
-      onFocus={ show }
+      onFocus={ handleWrapperFocus }
       onBlur={ handleFocusOut }
       onKeyDown={ hideTooltipViaEscape }
     >

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -102,6 +102,7 @@ function ExampleApp() {
     {
       id: 'general',
       label: 'General',
+      tooltip: <div>Configure general properties of this element. <a href="https://docs.camunda.io">Learn more</a> or see <a href="https://forum.camunda.io">Community Forum</a>.</div>,
       entries: [
         {
           id: 'name',
@@ -152,6 +153,7 @@ function ExampleApp() {
     {
       id: 'details',
       label: 'Details',
+      tooltip: 'Implementation details for selected task.',
       entries: [
         {
           id: 'implementation',
@@ -206,6 +208,7 @@ function ExampleApp() {
     {
       id: 'inputs',
       label: 'Input Parameters',
+      tooltip: <div>Map process variables to task input parameters. <a href="https://docs.camunda.io">Documentation</a>.</div>,
       component: ListGroup,
       add: createInputParameter(element, forceUpdate),
       items: element.inputParameters.map(param => ({

--- a/test/spec/components/Group.spec.js
+++ b/test/spec/components/Group.spec.js
@@ -320,13 +320,12 @@ describe('<Group>', function() {
       // when - open tooltip via keyboard focus
       wrapper.focus();
 
+      // then - focus should auto-move to first focusable element in tooltip
       await waitFor(() => {
         expect(domQuery('.bio-properties-panel-tooltip', result.container)).to.exist;
+        const link = domQuery('#tooltip-link', result.container);
+        expect(document.activeElement).to.equal(link);
       });
-
-      // then - focusable tooltip content should be inside the wrapper
-      const link = domQuery('#tooltip-link', result.container);
-      expect(wrapper.contains(link)).to.be.true;
     });
 
 

--- a/test/spec/components/ListGroup.spec.js
+++ b/test/spec/components/ListGroup.spec.js
@@ -908,13 +908,12 @@ describe('<ListGroup>', function() {
       // when - open tooltip via keyboard focus
       wrapper.focus();
 
+      // then - focus should auto-move to first focusable element in tooltip
       await waitFor(() => {
         expect(domQuery('.bio-properties-panel-tooltip', container)).to.exist;
+        const link = domQuery('#tooltip-link', container);
+        expect(document.activeElement).to.equal(link);
       });
-
-      // then - focusable tooltip content should be inside the wrapper
-      const link = domQuery('#tooltip-link', container);
-      expect(wrapper.contains(link)).to.be.true;
     });
 
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/properties-panel/issues/493

### Proposed Changes

Autofocus first focusable element in the tooltip body in case of keyboard navigation. Additionally change the portal root node, to be placed outside the title container([ref](https://github.com/bpmn-io/properties-panel/issues/493#issuecomment-4543800913)) and before group actions to allow to focus them after the tooltip content.


https://github.com/user-attachments/assets/ad48f594-0458-478c-95b3-e2c84d7e5605


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
