### PR TITLE
fix: `TemplatingEditor` paste action override current content

### DIFF
--- a/src/components/entries/FEEL/Feel.js
+++ b/src/components/entries/FEEL/Feel.js
@@ -279,9 +279,15 @@ function FeelTextfield(props) {
         return;
       }
 
-      const input = event.target;
-      const isFieldEmpty = !input.value;
-      const isAllSelected = input.selectionStart === 0 && input.selectionEnd === input.value.length;
+      const target = event.target;
+
+      // Skip for non-input/textArea elements (e.g. CodeMirror contenteditable)
+      if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLTextAreaElement)) {
+        return;
+      }
+
+      const isFieldEmpty = !target.value;
+      const isAllSelected = target.selectionStart === 0 && target.selectionEnd === target.value.length;
 
       if (isFieldEmpty || isAllSelected) {
         const textData = event.clipboardData.getData('text');

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -29,6 +29,7 @@ import {
   ToggleSwitchEntry,
   isToggleSwitchEntryEdited,
   FeelEntry,
+  FeelTemplatingEntry,
   isFeelEntryEdited
 } from 'src/components/entries';
 
@@ -72,6 +73,7 @@ const element = {
   implementation: 'java',
   className: 'com.example.MyDelegate',
   documentation: '',
+  templateLabel: 'Hello {{name}}, welcome!',
   exampleData: '{\n  "orderId": "12345",\n  "customer": {\n    "name": "Jane Doe",\n    "email": "jane@example.com"\n  },\n  "items": [\n    { "id": 1, "price": 29.99 },\n    { "id": 2, "price": 49.99 }\n  ]\n}',
   retryCount: 3,
   async: false,
@@ -118,6 +120,20 @@ function ExampleApp() {
           isEdited: isTextAreaEntryEdited,
           label: 'Documentation',
           description: 'Documentation for this element.',
+          updateElement,
+          element
+        }
+      ]
+    },
+    {
+      id: 'templating',
+      label: 'Templating',
+      entries: [
+        {
+          id: 'templateLabel',
+          component: FeelTemplatingComponent,
+          isEdited: isFeelEntryEdited,
+          label: 'Template Label',
           updateElement,
           element
         }
@@ -392,6 +408,24 @@ function JsonEditorComponent(props) {
     placeholder: '{ }',
     getValue: () => element[id] ?? '',
     setValue: (val) => updateElement(id, val)
+  });
+}
+
+function FeelTemplatingComponent(props) {
+  const { id, element, label, updateElement } = props;
+
+  return FeelTemplatingEntry({
+    id,
+    element,
+    label,
+    singleLine: true,
+    debounce: fn => fn,
+    getValue: () => element[id] ?? '',
+    setValue: (val) => updateElement(id, val),
+    variables: [
+      { name: 'name', info: 'User name' },
+      { name: 'orderId', info: 'Order identifier' }
+    ]
   });
 }
 

--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -42,6 +42,7 @@ import {
 import FeelField, {
   FeelCheckboxEntry,
   FeelNumberEntry,
+  FeelTemplatingEntry,
   FeelTextAreaEntry,
   FeelToggleSwitchEntry,
   isEdited
@@ -1120,6 +1121,47 @@ describe('<FeelEntry>', function() {
 
       // then
       expect(setValueSpy).to.have.been.calledWith('hello');
+    });
+
+  });
+
+
+  describe('FEEL disabled (FeelTemplatingEntry)', function() {
+
+    describe('paste', function() {
+
+      it('should not override content on paste for templating editor', async function() {
+
+        // given
+        const updateSpy = sinonSpy();
+
+        const result = createFeelField({
+          container,
+          feel: 'optional',
+          getValue: () => 'bar',
+          setValue: updateSpy,
+          Component: FeelTemplatingEntry
+        });
+
+        const editor = await waitFor(() => {
+          const el = domQuery('.cm-content', result.container);
+          expect(el).to.exist;
+          return el;
+        });
+
+        updateSpy.resetHistory();
+
+        // when - paste 'foo' into editor containing 'bar'
+        editor.dispatchEvent(createFeelPasteEvent('foo'));
+
+        // then - value should contain both original and pasted text
+        await waitFor(() => {
+          expect(updateSpy).to.have.been.called;
+          const calledValue = updateSpy.lastCall.args[0];
+          expect(calledValue).to.equal('foobar');
+        });
+      });
+
     });
 
   });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5948

### Proposed Changes

The bug was cause by wrong paste behavior in `FeelTemplatingEntry`. The `pasteHandler` in `Feel.js` is registered on a container `<div>` and catches paste events from all child elements via event bubbling. It accesses `event.target.value` and `event.target.selectionStart` — properties that only exist on `<input>` elements.

When `FeelTemplatingEntry` renders a CodeMirror editor (contenteditable `<div>`), `event.target.value` is undefined. Since `!undefined` evaluates to true, the handler always treats the field as empty, replaces the entire content with the pasted text, and calls `preventDefault()` — blocking CodeMirror's native paste.

**Before:**

https://github.com/user-attachments/assets/5dff179a-6f9b-47dc-9133-e4221a5ee80f

**After:**


https://github.com/user-attachments/assets/7e32e3e8-5040-4314-ae56-acd5833dbf60


Try out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#fix-FeelTemplatingEntry-paste
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
