### PR TITLE
fix: resolve preact via module resolution

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,11 @@
 import path, { parse as parsePath, relative as relativePath } from 'path';
+import { createRequire } from 'module';
 import { replaceInFile } from 'replace-in-file';
+
+// Resolve preact via Node module resolution so the build works regardless
+// of whether preact is installed locally or hoisted to a parent node_modules.
+const require = createRequire(import.meta.url);
+const preactDir = path.dirname(require.resolve('preact/package.json'));
 
 import babel from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
@@ -38,7 +44,7 @@ export default [
         // hook name provided to make sure next plugin has files to replace
         hook: 'buildStart',
         targets: [
-          { src: 'node_modules/preact', dest: '.' },
+          { src: preactDir, dest: '.' },
           { src: 'src/assets', dest: 'dist' }
         ]
       }),


### PR DESCRIPTION
## What

Replace the hardcoded `node_modules/preact` path in `rollup.config.js` with a `require.resolve` lookup.

## Why

The build currently assumes preact lives at `./node_modules/preact` relative to the package root. When the package is consumed as a `file:` dependency (e.g. in a fork/experiment setup), npm may hoist preact to a parent `node_modules`. The hardcoded path then resolves to nothing, `rollup-plugin-copy` silently skips the copy, and the subsequent `buildEnd` patch step fails with _"No files match the pattern: `./preact/**/*.{js,mjs,js.map}`"_.

Using `createRequire` + `require.resolve('preact/package.json')` lets Node's own module resolution find preact wherever it is installed.

## Change

```js
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
const preactDir = path.dirname(require.resolve('preact/package.json'));

// inside rollup-plugin-copy targets:
{ src: preactDir, dest: '.' }
```