### PR TITLE
fix: do not render toggle when entry has no children

### DIFF
--- a/src/components/entries/Collapsible.js
+++ b/src/components/entries/Collapsible.js
@@ -51,6 +51,8 @@ export default function CollapsibleEntry(props) {
 
   const placeholderLabel = translate('<empty>');
 
+  const hasEntries = entries.length > 0;
+
   return (
     <div
       data-entry-id={ id }
@@ -58,7 +60,7 @@ export default function CollapsibleEntry(props) {
         'bio-properties-panel-collapsible-entry',
         open ? 'open' : ''
       ) }>
-      <div class="bio-properties-panel-collapsible-entry-header" onClick={ toggleOpen }>
+      <div class="bio-properties-panel-collapsible-entry-header" onClick={ hasEntries ? toggleOpen : null }>
         <div
           class={ classnames(
             'bio-properties-panel-collapsible-entry-header-title',
@@ -66,13 +68,15 @@ export default function CollapsibleEntry(props) {
           ) }>
           { label || placeholderLabel }
         </div>
-        <button
-          type="button"
-          title={ translate('Toggle list item') }
-          class="bio-properties-panel-arrow  bio-properties-panel-collapsible-entry-arrow"
-        >
-          <ArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
-        </button>
+        { hasEntries && (
+          <button
+            type="button"
+            title={ translate('Toggle list item') }
+            class="bio-properties-panel-arrow  bio-properties-panel-collapsible-entry-arrow"
+          >
+            <ArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
+          </button>
+        ) }
         {
           remove
             ?

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -104,7 +104,15 @@ describe('<Collapsible>', function() {
   it('should toggle open', async function() {
 
     // given
-    const { container } = createCollapsible({ container: parentContainer });
+    const { container } = createCollapsible({
+      container: parentContainer,
+      entries: [
+        {
+          id: 'entry-1',
+          component: TestEntry
+        }
+      ]
+    });
 
     const entry = domQuery('.bio-properties-panel-collapsible-entry', container);
 
@@ -122,6 +130,42 @@ describe('<Collapsible>', function() {
 
     // then
     expect(domClasses(entries).has('open')).to.be.true;
+  });
+
+
+  it('should NOT render toggle button when entry has no children', function() {
+
+    // when
+    const { container } = createCollapsible({ container: parentContainer });
+
+    const toggleButton = domQuery('.bio-properties-panel-collapsible-entry-arrow', container);
+
+    // then
+    expect(toggleButton).to.not.exist;
+  });
+
+
+  it('should NOT toggle on header click when entry has no children', async function() {
+
+    // given
+    const { container } = createCollapsible({ container: parentContainer });
+
+    const entry = domQuery('.bio-properties-panel-collapsible-entry', container);
+
+    const header = domQuery('.bio-properties-panel-collapsible-entry-header', entry);
+
+    const entries = domQuery('.bio-properties-panel-collapsible-entry-entries', entry);
+
+    // assume
+    expect(domClasses(entries).has('open')).to.be.false;
+
+    // when
+    await act(() => {
+      header.click();
+    });
+
+    // then
+    expect(domClasses(entries).has('open')).to.be.false;
   });
 
 
@@ -234,7 +278,16 @@ describe('<Collapsible>', function() {
     it('should render translated toggle button title', function() {
 
       // given
-      const { container } = createCollapsible({ container: parentContainer, translate });
+      const { container } = createCollapsible({
+        container: parentContainer,
+        translate,
+        entries: [
+          {
+            id: 'entry-1',
+            component: TestEntry
+          }
+        ]
+      });
 
       const toggleButton = domQuery('.bio-properties-panel-collapsible-entry-arrow', container);
 

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -157,7 +157,7 @@ describe('<Collapsible>', function() {
     const entries = domQuery('.bio-properties-panel-collapsible-entry-entries', entry);
 
     // assume
-    expect(domClasses(entries).has('open')).to.be.false;
+expect(domClasses(entries).has('open')).to.be.false;
 
     // when
     await act(() => {

--- a/test/spec/components/Collapsible.spec.js
+++ b/test/spec/components/Collapsible.spec.js
@@ -157,7 +157,7 @@ describe('<Collapsible>', function() {
     const entries = domQuery('.bio-properties-panel-collapsible-entry-entries', entry);
 
     // assume
-expect(domClasses(entries).has('open')).to.be.false;
+    expect(domClasses(entries).has('open')).to.be.false;
 
     // when
     await act(() => {


### PR DESCRIPTION
### Proposed Changes

`CollapsibleEntry` previously rendered an always-on toggle arrow and a clickable header, even when the entry had no nested entries (`entries.length === 0`).

Clicking the arrow or the header flipped the internal `open` state but nothing visibly expanded or collapsed, because the entries container was empty. Screen readers also announced the entry as expandable while there was nothing to expand.

This PR makes `CollapsibleEntry` only render the toggle button and react to header clicks when there is at least one nested entry to show:

- `src/components/entries/Collapsible.js`
  - introduces a local `hasEntries = entries.length > 0` flag;
  - gates the toggle arrow `<button>` rendering on `hasEntries`;
  - gates the header `onClick={ toggleOpen }` on `hasEntries` (falls back to `null`).
- `test/spec/components/Collapsible.spec.js`
  - updates the two existing tests that relied on the toggle being present to pass an `entries` array;
  - adds two new specs covering the empty-entries behaviour:
    - `should NOT render toggle button when entry has no children`
    - `should NOT toggle on header click when entry has no children`.

No public API change; the `entries` prop already defaults to `[]`, so existing call sites are unaffected.

### Checklist

- [x] Contribution meets the project's [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)
- [x] Pull request establishes context
  - Link to related issue(s): Closes #508
  - Brief textual description of the changes: see above
  - Screenshots / steps to reproduce: see *Notes for reviewers* below
- [x] `npm run all` passes locally (lint + 672 tests, 1 skipped — matches `main`)

### Notes for reviewers

**Reproduction in the existing dev demo:**

1. `npm install && npm run dev`
2. In `demo/`, render a `CollapsibleEntry` with `entries: []`, e.g.:
   ```js
   {
     id: 'empty-item',
     component: CollapsibleEntry,
     label: 'My item',
     entries: []
   }
   ```
3. **Before this PR:** the arrow rotates on every header/arrow click but nothing expands or collapses.
   **After this PR:** no toggle arrow is rendered and the header is not interactive.

**Design note:** when an entry has no children the arrow is simply omitted. If you would prefer a visual placeholder (e.g. a dash/dot) to keep horizontal alignment consistent across a list of mixed entries, I'm happy to follow up — but the upstream CSS has no class for that today, so I kept the change minimal.
