### PR TITLE
test: suppress fake timer native clearTimeout warning

### DIFF
--- a/test/spec/components/Feel.spec.js
+++ b/test/spec/components/Feel.spec.js
@@ -2936,7 +2936,7 @@ describe('<FeelEntry>', function() {
       it('should show syntax error', async function() {
 
         // given
-        const clock = useFakeTimers();
+        const clock = useFakeTimers({ shouldClearNativeTimers: true });
         const result = createFeelField({ container, getValue: () => '= ...syntax error...', feel: 'required' });
 
         // when
@@ -2956,7 +2956,7 @@ describe('<FeelEntry>', function() {
       it('should not indicate field error on non-syntax errors', async function() {
 
         // given
-        const clock = useFakeTimers();
+        const clock = useFakeTimers({ shouldClearNativeTimers: true });
         const result = createFeelField({ container, getValue: () => '= friend[0]', feel: 'required' });
 
         // when
@@ -2976,7 +2976,7 @@ describe('<FeelEntry>', function() {
       it('should show global error over local error', async function() {
 
         // given
-        const clock = useFakeTimers();
+        const clock = useFakeTimers({ shouldClearNativeTimers: true });
         const errors = {
           foo: 'bar'
         };

--- a/test/spec/components/Templating.spec.js
+++ b/test/spec/components/Templating.spec.js
@@ -46,7 +46,7 @@ describe('<Templating>', function() {
 
   beforeEach(function() {
     container = TestContainer.get(this);
-    clock = useFakeTimers();
+    clock = useFakeTimers({ shouldClearNativeTimers: true });
   });
 
   afterEach(function() {


### PR DESCRIPTION
## Summary

- Passes `shouldClearNativeTimers: true` to all `sinon.useFakeTimers()` calls in the test suite
- Eliminates the console warning `FakeTimers: clearTimeout was invoked to clear a native timer instead of one created by this library` that appeared during test runs, caused by `@codemirror/lint` creating a native timer before sinon's fake timers take over

## Why not remove fake timers entirely?

The tests use fake timers to control when codemirror's lint debounce fires (750 ms default delay). Removing them is viable for positive-assertion tests (`waitFor` with a long timeout), but the **negative-assertion test** ("should not show syntax warnings") would pass immediately before linting fires — giving false confidence. `shouldClearNativeTimers: true` is exactly the sinon API designed for this scenario: minimal, correct, and keeps tests fast.

---

Alternative considered: `expectEventually` (slow), `lintDelay` configuration in `*Editor` - larger change but would be consistent with JSON editor.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)