### PR TITLE
Resolve preact from actual install location

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import path, { parse as parsePath, relative as relativePath } from 'path';
+import { createRequire } from 'module';
 import { replaceInFile } from 'replace-in-file';
 
 import babel from '@rollup/plugin-babel';
@@ -8,6 +9,15 @@ import resolve from '@rollup/plugin-node-resolve';
 
 import pkg from './package.json';
 import babelConfig from './.babelrc.json';
+
+const require = createRequire(import.meta.url);
+
+// resolve preact through Node module resolution rather than assuming it lives
+// in the local `node_modules/preact`. This ensures the build works when preact
+// is hoisted to a parent `node_modules` (mono repositories) or linked in from
+// another location. Path separators are normalized to POSIX so that
+// rollup-plugin-copy's globby can process the path on Windows.
+const preactDir = path.dirname(require.resolve('preact/package.json')).split(path.sep).join('/');
 
 const nonbundledDependencies = Object.keys({ ...pkg.dependencies });
 
@@ -38,7 +48,7 @@ export default [
         // hook name provided to make sure next plugin has files to replace
         hook: 'buildStart',
         targets: [
-          { src: 'node_modules/preact', dest: '.' },
+          { src: preactDir, dest: '.' },
           { src: 'src/assets', dest: 'dist' }
         ]
       }),


### PR DESCRIPTION
### Proposed Changes

The Rollup build copies `preact` into a local `./preact` folder that is shared with extensions (e.g. `bpmn-js-properties-panel`). Until now the copy step assumed `preact` always lived in `./node_modules/preact`:

```js
{ src: 'node_modules/preact', dest: '.' }
```

That assumption breaks whenever `preact` is **not** installed directly next to this package — for example in a mono repository, or when this library is linked into another project, where npm hoists `preact` into a parent `node_modules`. In those setups the build either copied nothing or failed.

This PR resolves `preact` through Node's module resolution instead, so it is picked up from wherever it is actually installed:

```js
const require = createRequire(import.meta.url);
const preactDir = path.dirname(require.resolve('preact/package.json')).split(path.sep).join('/');

// ...
{ src: preactDir, dest: '.' }
```

Notes:

* We use `createRequire(import.meta.url)` rather than the native `import.meta.resolve(...)` because the config is bundled to CommonJS via `rollup -c --bundleConfigAsCjs`, and Rollup only shims `import.meta.url` — `import.meta.resolve` is `undefined` in that context.
* Path separators are normalized to POSIX (`/`) so `rollup-plugin-copy`'s `globby` matching keeps working on Windows.

### Steps to try out

1. `npm install`
2. `npm run build` — verify `./preact` is created and `dist/` builds.
3. To exercise the hoisted case, move `node_modules/preact` into a parent `node_modules` and re-run `npm run build`; it should still resolve, copy `./preact`, and rewire the sub-package imports.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)