### PR TITLE
fix: support snippet placeholder navigation in FEEL popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: support snippet placeholder navigation in FEEL popup ([#524](https://github.com/bpmn-io/properties-panel/pull/524))
+
 ## 3.47.0
 
 * `FEAT`: enhance FEEL syntax highlighting ([bpmn-io/feel-editor#100](https://github.com/bpmn-io/feel-editor/pull/100))

--- a/src/features/feel-popup/components/FeelPopup.js
+++ b/src/features/feel-popup/components/FeelPopup.js
@@ -94,6 +94,7 @@ export function FeelPopup(props) {
       returnFocus={ false }
       closeOnEscape={ false }
       delayInitialFocus={ false }
+      allowFocusMove={ (event) => !isSnippetNavigation(event) }
       onPostDeactivate={ handleSetReturnFocus }
       height={ FEEL_POPUP_HEIGHT }
       width={ FEEL_POPUP_WIDTH }
@@ -171,4 +172,10 @@ function prefixId(id) {
 function autoCompletionOpen(element) {
   const editor = element.closest('.cm-editor');
   return editor ? editor.querySelector('.cm-tooltip-autocomplete') : null;
+}
+
+// while a snippet is active, Tab navigates its placeholders inside the editor
+function isSnippetNavigation(event) {
+  const editor = event.target.closest('.cm-editor');
+  return !!(editor && editor.querySelector('.cm-snippetField'));
 }

--- a/src/features/feel-popup/components/Popup.js
+++ b/src/features/feel-popup/components/Popup.js
@@ -28,6 +28,9 @@ const noop = () => {};
  * @param {Function} [props.onPostDeactivate]
  * @param {boolean} [props.returnFocus]
  * @param {boolean} [props.closeOnEscape]
+ * @param {(event: KeyboardEvent) => boolean} [props.allowFocusMove] -
+ *   Whether a Tab keypress may move focus. Return false to leave the keypress
+ *   to the focused element, e.g. an editor navigating snippet placeholders.
  * @param {string} props.title
  * @param {Ref} [ref]
  */
@@ -43,6 +46,7 @@ function PopupComponent(props, globalRef) {
     onPostDeactivate = noop,
     returnFocus = true,
     closeOnEscape = true,
+    allowFocusMove = () => true,
     title
   } = props;
 
@@ -103,6 +107,8 @@ function PopupComponent(props, globalRef) {
         clickOutsideDeactivates: true,
         delayInitialFocus,
         fallbackFocus: popupRef.current,
+        isKeyForward: (event) => isTab(event) && !event.shiftKey && allowFocusMove(event),
+        isKeyBackward: (event) => isTab(event) && event.shiftKey && allowFocusMove(event),
         onPostActivate,
         onPostDeactivate,
         returnFocusOnDeactivate: returnFocus,
@@ -269,6 +275,10 @@ function Footer(props) {
 }
 
 // helpers //////////////////////
+
+function isTab(event) {
+  return event.key === 'Tab';
+}
 
 function getPopupParent(node) {
   return node.closest('.bio-properties-panel-popup');

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -35,6 +35,9 @@ import {
 
 import EventBus from 'diagram-js/lib/core/EventBus';
 
+import { FeelPopup } from 'src/features/feel-popup/FeelPopup';
+import { FeelPopupRenderer } from 'src/features/feel-popup/FeelPopupRenderer';
+
 insertCoreStyles();
 
 const singleStart = window.__env__?.SINGLE_START;
@@ -91,6 +94,10 @@ const element = {
 const eventBus = new EventBus();
 const layoutConfig = {};
 const noop = () => {};
+
+// wire the FEEL popup feature
+new FeelPopup(eventBus);
+new FeelPopupRenderer(eventBus);
 
 function ExampleApp() {
   const [ , forceUpdate ] = useReducer(x => x + 1, 0);
@@ -230,11 +237,13 @@ function ExampleApp() {
         entries: [
           {
             id: `${param.id}-name`,
-            component: createParameterNameEntry(param),
+            component: ParameterNameEntry,
+            param
           },
           {
             id: `${param.id}-value`,
-            component: createParameterValueEntry(param),
+            component: ParameterValueEntry,
+            param
           }
         ]
       }))
@@ -429,40 +438,36 @@ function FeelTemplatingComponent(props) {
   });
 }
 
-function createParameterNameEntry(param) {
-  return function ParameterNameEntry(props) {
-    const { element } = props;
+function ParameterNameEntry(props) {
+  const { element, param } = props;
 
-    return TextFieldEntry({
-      id: `${param.id}-name`,
-      element,
-      label: 'Name',
-      debounce: fn => fn,
-      getValue: () => param.name,
-      setValue: (val) => { param.name = val; }
-    });
-  };
+  return TextFieldEntry({
+    id: `${param.id}-name`,
+    element,
+    label: 'Name',
+    debounce: fn => fn,
+    getValue: () => param.name,
+    setValue: (val) => { param.name = val; }
+  });
 }
 
-function createParameterValueEntry(param) {
-  return function ParameterValueEntry(props) {
-    const { element } = props;
+function ParameterValueEntry(props) {
+  const { element, param } = props;
 
-    return FeelEntry({
-      id: `${param.id}-value`,
-      element,
-      label: 'Value',
-      feel: 'optional',
-      debounce: fn => fn,
-      getValue: () => param.value,
-      setValue: (val) => { param.value = val; },
-      variables: [
-        { name: 'customer', info: 'Customer context object' },
-        { name: 'order', info: 'Current order data' },
-        { name: 'response', info: 'Response from service call' }
-      ]
-    });
-  };
+  return FeelEntry({
+    id: `${param.id}-value`,
+    element,
+    label: 'Value',
+    feel: 'optional',
+    debounce: fn => fn,
+    getValue: () => param.value,
+    setValue: (val) => { param.value = val; },
+    variables: [
+      { name: 'customer', info: 'Customer context object' },
+      { name: 'order', info: 'Current order data' },
+      { name: 'response', info: 'Response from service call' }
+    ]
+  });
 }
 
 function createInputParameter(element, forceUpdate) {

--- a/test/spec/features/feel-popup/components/FeelPopup.spec.js
+++ b/test/spec/features/feel-popup/components/FeelPopup.spec.js
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import { spy as sinonSpy } from 'sinon';
 
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact/pure';
+import { snippet } from '@codemirror/autocomplete';
+import { EditorView } from '@codemirror/view';
 import { expectNoViolations, insertCoreStyles } from 'test/TestHelper';
 import { FeelPopup, FEEL_POPUP_WIDTH, FEEL_POPUP_HEIGHT } from 'src/features/feel-popup/components/FeelPopup';
 
@@ -234,6 +236,40 @@ describe('<FeelPopup>', function() {
       expect(sourceElement.focus).to.have.been.called;
     });
   });
+
+  it('should keep focus in editor when Tab navigates snippet placeholders', async function() {
+
+    // given
+    render(
+      <FeelPopup
+        entryId="foo"
+        title="Feel"
+        type="feel"
+        value=""
+        onInput={ () => {} }
+        onClose={ () => {} }
+        sourceElement={ sourceElement }
+      />, { container }
+    );
+
+    const cmContent = container.querySelector('.cm-content');
+
+    await waitFor(() => {
+      expect(document.activeElement === cmContent, 'expected editor to be focused').to.be.true;
+    });
+
+    const view = EditorView.findFromDOM(container.querySelector('.cm-editor'));
+
+    snippet('append(${list}, ${item})')(view, null, 0, 0);
+
+    // when
+    fireEvent.keyDown(cmContent, { key: 'Tab' });
+
+    // then
+    expect(document.activeElement === cmContent, 'expected focus to stay on editor content').to.be.true;
+    expect(view.state.sliceDoc(view.state.selection.main.from, view.state.selection.main.to)).to.equal('item');
+  });
+
 
   describe('accessibility', function() {
 

--- a/test/spec/features/feel-popup/components/Popup.spec.js
+++ b/test/spec/features/feel-popup/components/Popup.spec.js
@@ -118,6 +118,58 @@ describe('<Popup>', function() {
   });
 
 
+  it('should move focus within popup on Tab', async function() {
+
+    // given
+    await act(() => {
+      render(
+        <Popup>
+          <input name="foo"></input>
+          <input name="bar"></input>
+        </Popup>,
+        { container }
+      );
+    });
+
+    const popup = domQuery('.bio-properties-panel-popup', container);
+    const [ firstInput, lastInput ] = popup.querySelectorAll('input');
+
+    lastInput.focus();
+
+    // when
+    fireEvent.keyDown(lastInput, { key: 'Tab' });
+
+    // then
+    expect(document.activeElement).to.eql(firstInput);
+  });
+
+
+  it('should NOT move focus on Tab (allowFocusMove=false)', async function() {
+
+    // given
+    await act(() => {
+      render(
+        <Popup allowFocusMove={ () => false }>
+          <input name="foo"></input>
+          <input name="bar"></input>
+        </Popup>,
+        { container }
+      );
+    });
+
+    const popup = domQuery('.bio-properties-panel-popup', container);
+    const lastInput = popup.querySelectorAll('input')[1];
+
+    lastInput.focus();
+
+    // when
+    fireEvent.keyDown(lastInput, { key: 'Tab' });
+
+    // then
+    expect(document.activeElement).to.eql(lastInput);
+  });
+
+
   it('should close on ESC', async function() {
 
     // given


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/5055

Previously in the FEEL popup, pressing `Tab` after applying a completion like `append(list, item)` moved focus out of the editor instead of jumping to the next placeholder.

The popup's focus trap intercepts `Tab` on document capture, before the editor's snippet keymap runs. `<Popup>` now accepts an `allowFocusMove(event)` predicate, and the FEEL popup returns `false` while a snippet is active (`.cm-snippetField` present), leaving the keypress to the editor. Behavior now matches the inline FEEL editor.

Also wires the FEEL popup feature in the interactive example (`npm start`), which was previously not set up.

https://github.com/user-attachments/assets/748492b8-913d-418c-8577-30f739fb14d9


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
