### PR TITLE
fix: reserve space for open pop-up button in FEEL editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: reserve space for open pop-up button in FEEL editor ([#525](https://github.com/bpmn-io/properties-panel/pull/525))
+
 ## 3.52.0
 
 * `FEAT`: add `--warning-badge-*` and `--error-badge-*` theming tokens ([#547](https://github.com/bpmn-io/properties-panel/pull/547))

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1120,6 +1120,16 @@ textarea.bio-properties-panel-input {
   min-height: 28px;
 }
 
+/* reserve space on the first line for the open pop-up button, only while the input is focused */
+.bio-properties-panel-feel-container:focus-within .bio-properties-panel-feel-editor-container .cm-line:first-child::before,
+.bio-properties-panel-feelers-input .bio-properties-panel-feelers-editor-container:focus-within .cm-line:first-child::before,
+.bio-properties-panel-feel-container .bio-properties-panel-feelers-editor-container:focus-within .cm-line:first-child::before {
+  content: "";
+  float: right;
+  width: 1.7em;
+  height: 1.5em;
+}
+
 .bio-properties-panel-feel-indicator {
   position: absolute;
   border: 1px solid var(--input-border-color);
@@ -1494,16 +1504,29 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup,
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup {
   position: absolute;
-  top: 0;
+  top: 4px;
   right: 0;
   line-height: 1;
-  padding: 3px 4px;
-  margin: 3px;
+  padding: 2px 4px;
+  margin: 0 3px;
   display: none;
-  background: none;
+  background-color: var(--input-background-color);
   border: none;
   color: var(--feel-open-popup-color);
   cursor: pointer;
+}
+
+/* fade the text out beneath the feel popup button */
+.bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup::before,
+.bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 100%;
+  width: 0.5em;
+  background: linear-gradient(to right, transparent, var(--input-background-color));
+  pointer-events: none;
 }
 
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup svg,

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1302,6 +1302,16 @@ textarea.bio-properties-panel-input.auto-resize {
   min-height: var(--input-height);
 }
 
+/* reserve space on the first line for the open pop-up button, only while the input is focused or hovered */
+.bio-properties-panel-feel-container .bio-properties-panel-feel-editor-container:is(:hover, :focus-within) .cm-line:first-child::before,
+.bio-properties-panel-feelers-input .bio-properties-panel-feelers-editor-container:is(:hover, :focus-within) .cm-line:first-child::before,
+.bio-properties-panel-feel-container .bio-properties-panel-feelers-editor-container:is(:hover, :focus-within) .cm-line:first-child::before {
+  content: "";
+  float: right;
+  width: 1.7em;
+  height: 1.5em;
+}
+
 .bio-properties-panel-feel-indicator {
   position: absolute;
   border: 1px solid var(--input-border-color);
@@ -1720,16 +1730,29 @@ textarea.bio-properties-panel-input.auto-resize {
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup,
 .bio-properties-panel-textarea-container .bio-properties-panel-open-feel-popup {
   position: absolute;
-  top: 0;
+  top: 4px;
   right: 0;
   line-height: 1;
-  padding: 3px 4px;
-  margin: 3px;
+  padding: 2px 4px;
+  margin: 0 3px;
   display: none;
-  background: none;
+  background-color: var(--input-background-color);
   border: none;
   color: var(--feel-open-popup-color);
   cursor: pointer;
+}
+
+/* fade the text out beneath the feel popup button */
+.bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup::before,
+.bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 100%;
+  width: 0.5em;
+  background: linear-gradient(to right, transparent, var(--input-background-color));
+  pointer-events: none;
 }
 
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup svg,


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/5863

Reserve space for open pop-up button in FEEL editor. Long expressions no longer render under the open pop-up button.

<img width="416" height="809" alt="image" src="https://github.com/user-attachments/assets/9d1a2046-4a82-4569-bbd5-b5ffc40defa4" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
