### PR TITLE
Resize text component on any interaction

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -79,8 +79,6 @@ function TextArea(props) {
   const handleInput = useDebounce(onInput, debounce);
 
   const handleLocalInput = e => {
-    autoResize && resizeToContents(e.target);
-
     if (e.target.value === localValue) {
       return;
     }
@@ -169,9 +167,10 @@ function TextArea(props) {
     };
   }, []);
 
+  // auto-resize on any value change (typing, popup edits, external updates)
   useLayoutEffect(() => {
     autoResize && resizeToContents(ref.current);
-  }, []);
+  }, [ localValue ]);
 
   useLayoutEffect(() => {
     visible && autoResize && resizeToContents(ref.current);

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -1184,6 +1184,46 @@ describe('<TextArea>', function() {
       });
     });
 
+
+    it('should resize on value edited in popup', async function() {
+
+      // given
+      const eventBus = new EventBus();
+
+      let popupInput;
+
+      eventBus.on('propertiesPanel.openPopup', (event, ctx) => {
+        popupInput = ctx.onInput;
+        return true;
+      });
+
+      const result = createTextArea({
+        container,
+        eventBus,
+        id: 'textarea',
+        autoResize: true,
+        getValue: () => 'foo'
+      });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      const button = domQuery('.bio-properties-panel-open-feel-popup', result.container);
+
+      await act(() => {
+        fireEvent.click(button);
+      });
+
+      const initialHeight = input.clientHeight;
+
+      // when
+      await act(() => {
+        popupInput('foo\nbar\nbaz\nqux');
+      });
+
+      // then
+      expect(input.clientHeight).to.be.greaterThan(initialHeight);
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Resize did not properly trigger for plain text fields after closing the popup editor.

This PR ensures it now happens consistently, for all cases - and in the process it may eradicate some quirks ("opening of documentation section keeps documentation one line"), too.

<img width="1450" height="797" alt="capture KWNT9c_optimized" src="https://github.com/user-attachments/assets/c062b1aa-72cd-4254-816f-0f2af3587072" />

Try out via

```
npx @bpmn-io/sr -l bpmn-io/properties-panel#resize-fix bpmn-io/bpmn-js-properties-panel
```

Related to #523 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
