### PR TITLE
Correct `TextArea` to compare popup input against live value

### DIFF
--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -62,6 +62,11 @@ function TextArea(props) {
   const ref = useShowEntryEvent(id);
   const containerRef = useRef();
 
+  // keep a live reference to the current value so callbacks captured by the
+  // popup (frozen at open time) can compare against the latest value
+  const localValueRef = useRef(localValue);
+  localValueRef.current = localValue;
+
   const { eventBus } = useContext(EventContext);
 
   const [ isPopupOpen, setIsPopupOpen ] = useState(false);
@@ -135,7 +140,7 @@ function TextArea(props) {
   };
 
   const handlePopupInput = newValue => {
-    if (newValue === localValue) {
+    if (newValue === localValueRef.current) {
       return;
     }
 

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -745,6 +745,45 @@ describe('<TextArea>', function() {
     });
 
 
+    it('should reflect clearing contents in popup', async function() {
+
+      // given
+      const eventBus = new EventBus();
+      const setValueSpy = sinonSpy();
+
+      let popupInput;
+
+      eventBus.on('propertiesPanel.openPopup', (event, ctx) => {
+        popupInput = ctx.onInput;
+        return true;
+      });
+
+      const result = createTextArea({
+        container,
+        eventBus,
+        id: 'textarea',
+        getValue: () => '',
+        setValue: setValueSpy
+      });
+
+      const button = domQuery('.bio-properties-panel-open-feel-popup', result.container);
+
+      fireEvent.click(button);
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      // type and then clear back to the value present when the popup opened
+      await act(() => popupInput('foo'));
+      await act(() => popupInput(''));
+
+      // then
+      // clearing is reflected, old value is not restored
+      expect(input.value).to.eql('');
+      expect(setValueSpy).to.have.been.calledWith(undefined);
+    });
+
+
     it('should reset open state on <propertiesPanelPopup.close>', async function() {
 
       // given


### PR DESCRIPTION
### Proposed Changes

Popup editor (for text field) was compared against stale values, loosing a future edit.

Using a `ref` we ensure we always compare against the most recent value. As a result the user can now "clear" the contents, via the popup editor:
<img width="1506" height="807" alt="capture ZGg6bc_optimized" src="https://github.com/user-attachments/assets/41c35f34-8468-4b6d-95cf-c23a82ca4027" />

Try out via 

```
npx @bpmn-io/sr -l bpmn-io/properties-panel#text-editor-commit-empty bpmn-io/bpmn-js-properties-panel
```

Related to #523 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
