### PR TITLE
feat(styles): add themeable, reusable focus ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add themable focus ring to inputs/controls ([#535](https://github.com/bpmn-io/properties-panel/pull/535))
 * `FEAT`: pass engine versions to editor for FEEL compatibility linting ([#533](https://github.com/bpmn-io/properties-panel/pull/533))
 * `FEAT`: unify single line input height ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
 * `FIX`: do not show vertical resizer for auto resizing `Text` fields ([#537](https://github.com/bpmn-io/properties-panel/pull/537))

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -23,11 +23,13 @@
   --color-blue-218-100-74: hsl(218, 100%, 74%);
   --color-blue-205-100-85: hsl(205, 100%, 85%);
   --color-blue-205-100-95: hsl(205, 100%, 95%);
+  --color-blue-205-100-50-a35: hsla(205, 100%, 50%, 0.35);
 
   --color-red-360-100-40: hsl(360, 100%, 40%);
   --color-red-360-100-45: hsl(360, 100%, 45%);
   --color-red-360-100-92: hsl(360, 100%, 92%);
   --color-red-360-100-97: hsl(360, 100%, 97%);
+  --color-red-360-100-45-a35: hsla(360, 100%, 45%, 0.35);
   --color-white: white;
   --color-black: black;
   --color-transparent: transparent;
@@ -78,10 +80,29 @@
 
   --input-background-color: var(--color-grey-225-10-97);
   --input-border-color: var(--color-grey-225-10-75);
+  --input-border-radius: 2px;
+
+  --checkbox-size: 14px;
+  --checkbox-border-radius: 4px;
+  --checkbox-border-color: var(--input-border-color);
+  --checkbox-background-color: var(--input-background-color);
+  --checkbox-checked-background-color: var(--color-blue-205-100-50);
+  --checkbox-checked-border-color: var(--color-blue-205-100-50);
 
   --input-focus-background-color: var(--color-blue-205-100-95);
   --input-focus-border-color: var(--color-blue-205-100-50);
+
   --focus-outline-color: var(--color-blue-205-100-40);
+
+  /**
+   * Focus ring — reusable, themeable primitive shared by inputs, checkboxes,
+   * toggles and any control with the `bio-properties-panel-focus-ring` class.
+   */
+  --focus-ring-color: var(--color-blue-205-100-50-a35);
+  --focus-ring-error-color: var(--color-red-360-100-45-a35);
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 0px;
+  --focus-ring-offset-color: var(--group-background-color);
 
   --input-error-background-color: var(--color-red-360-100-97);
   --input-error-border-color: var(--color-red-360-100-45);
@@ -511,7 +532,7 @@
 .bio-properties-panel-input {
   padding: 3px 6px 2px;
   border: 1px solid var(--input-border-color);
-  border-radius: 2px;
+  border-radius: var(--input-border-radius);
   background-color: var(--input-background-color);
   font-size: var(--text-size-base);
   font-family: inherit;
@@ -526,9 +547,49 @@ textarea.bio-properties-panel-input,
   min-height: var(--input-height);
 }
 
+/**
+ * Focus ring
+ *
+ * A themeable, reusable focus indicator shared by all controls — inputs,
+ * checkboxes (rendered as custom `appearance: none` controls so the ring
+ * paints and follows their corners) and toggles. To reuse it in a custom
+ * component, add the `bio-properties-panel-focus-ring` class to the focusable
+ * element; when placed inside an entry with `has-error` it switches to the
+ * error color. Tune the look via the `--focus-ring-*` variables (and
+ * `--input-border-radius` / `--checkbox-border-radius` for corners).
+ */
 .bio-properties-panel-input:focus,
-.bio-properties-panel-input:focus-within {
+.bio-properties-panel-input:focus-within,
+.bio-properties-panel-toggle-switch__switcher:focus-within,
+.bio-properties-panel-focus-ring:focus,
+.bio-properties-panel-focus-ring:focus-within {
   outline: none;
+  box-shadow:
+    0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color),
+    0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width)) var(--focus-ring-color);
+}
+
+/* keep focus visible where box-shadow is dropped (e.g. Windows High Contrast) */
+@media (forced-colors: active) {
+  .bio-properties-panel-input:focus,
+  .bio-properties-panel-input:focus-within,
+  .bio-properties-panel-toggle-switch__switcher:focus-within,
+  .bio-properties-panel-focus-ring:focus,
+  .bio-properties-panel-focus-ring:focus-within {
+    outline: 2px solid Highlight;
+    outline-offset: var(--focus-ring-offset);
+  }
+
+  /* the custom checkmark (SVG background) is not recolored by the OS; fall back
+     to the native checkbox so the checked state stays visible */
+  .bio-properties-panel-input[type="checkbox"] {
+    appearance: auto;
+    -webkit-appearance: auto;
+  }
+}
+
+.bio-properties-panel-input:focus:not([type="checkbox"]),
+.bio-properties-panel-input:focus-within {
   background-color: var(--input-focus-background-color);
   border: 1px solid var(--input-focus-border-color);
 }
@@ -548,15 +609,51 @@ select.bio-properties-panel-input {
   font-family: var(--font-family-monospace);
 }
 
-.bio-properties-panel-input[type="checkbox"], .bio-properties-panel-input[type="radio"] {
+.bio-properties-panel-input[type="radio"] {
   margin: 0;
   vertical-align: middle;
 }
 
-.bio-properties-panel-input[type="checkbox"]:focus {
-  outline: auto;
-  outline-color: var(--focus-outline-color);
-  outline-offset: 2px;
+/* native radios drop `box-shadow`; keep a visible outline-based focus ring */
+.bio-properties-panel-input[type="radio"]:focus {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+/**
+ * Checkbox
+ *
+ * Rendered as a custom control (`appearance: none`) following shadcn/ui: native
+ * checkboxes drop `box-shadow`, so the shared focus ring could never paint on
+ * them and fell back to the browser's square outline. As a custom element the
+ * box-shadow ring renders and follows `border-radius`, giving a properly rounded
+ * ring — no checkbox-specific focus rule needed. Themeable via `--checkbox-*`.
+ */
+.bio-properties-panel-input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  margin: 0;
+  padding: 0;
+  vertical-align: middle;
+  border: 1px solid var(--checkbox-border-color);
+  border-radius: var(--checkbox-border-radius);
+  background: var(--checkbox-background-color) center / contain no-repeat;
+  cursor: pointer;
+}
+
+.bio-properties-panel-input[type="checkbox"]:checked {
+  border-color: var(--checkbox-checked-border-color);
+  background-color: var(--checkbox-checked-background-color);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23fff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 4.5 6.5 11.5 3 8'/%3E%3C/svg%3E");
+}
+
+.bio-properties-panel-input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+  border-color: var(--input-disabled-border-color);
+  background-color: var(--input-disabled-background-color);
 }
 
 .bio-properties-panel-checkbox > .bio-properties-panel-label {
@@ -595,8 +692,17 @@ textarea.bio-properties-panel-input.auto-resize {
 }
 
 .bio-properties-panel-entry.has-error .bio-properties-panel-input:focus,
+.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus-within,
 .bio-properties-panel-entry.has-error .bio-properties-panel-feel-indicator:focus {
   border-color: var(--input-error-focus-border-color);
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus,
+.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus-within,
+.bio-properties-panel-entry.has-error .bio-properties-panel-toggle-switch__switcher:focus-within,
+.bio-properties-panel-entry.has-error .bio-properties-panel-focus-ring:focus,
+.bio-properties-panel-entry.has-error .bio-properties-panel-focus-ring:focus-within {
+  --focus-ring-color: var(--focus-ring-error-color);
 }
 
 .bio-properties-panel-entry .bio-properties-panel-error {
@@ -680,11 +786,7 @@ textarea.bio-properties-panel-input.auto-resize {
   position: relative;
   width: 32px;
   height: 16px;
-}
-
-.bio-properties-panel-toggle-switch .bio-properties-panel-toggle-switch__switcher:focus-within {
-  outline: 2px solid var(--input-focus-border-color);
-  outline-offset: 1px;
+  border-radius: 34px;
 }
 
 .bio-properties-panel-toggle-switch .bio-properties-panel-toggle-switch__switcher input[type='checkbox'] {
@@ -1138,7 +1240,7 @@ textarea.bio-properties-panel-input.auto-resize {
   border: 1px solid var(--input-border-color);
   background-color: var(--feel-indicator-background-color);
   border-right: 0px;
-  border-radius: 2px 0 0 2px;
+  border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
   z-index: 1;
   height: 100%;
   width: 2em;
@@ -1319,7 +1421,7 @@ textarea.bio-properties-panel-input.auto-resize {
   color: hsla(0, 0%, 9%, 0.25);
   padding: 3px 6px 2px;
   border: 1px solid var(--input-border-color);
-  border-radius: 2px;
+  border-radius: var(--input-border-radius);
   background-color: var(--input-background-color);
   font-size: var(--text-size-base);
   font-family: inherit;


### PR DESCRIPTION
### Proposed Changes

Fixes a defect where an **invalid** and an **invalid + focused** input looked identical (focus was invisible in the error state):

<img width="420" height="539" alt="capture Zry0I6_optimized" src="https://github.com/user-attachments/assets/cd02b79c-f9e8-4ac3-a125-233532e7a56c" />

With this PR we adopt what established UI frameworks (shadcn/ui, bootstrap) do: Validity remains on the border and focus is now a themeable `box-shadow` ring present in every focus state, turning red when invalid:

<img width="420" height="539" alt="capture zVBavo_optimized" src="https://github.com/user-attachments/assets/9fac7e24-d2b3-4f23-9992-6c582424c3bf" />

It's a single reusable primitive shared by inputs, checkboxes and toggles, tunable via `--focus-ring-*` tokens and opt-in for custom components through the `bio-properties-panel-focus-ring` class. 

CSS only (`src/assets/properties-panel.css`).


### Try out

```
npm start
```

Focus/blur the inputs, checkbox and toggle in both valid and invalid (required) states.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)