### PR TITLE
Add error state to playground + fix vertical sizing (assume available height for panel body)

### DIFF
--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -1,5 +1,5 @@
 import { render } from 'preact';
-import { useReducer, useCallback } from 'preact/hooks';
+import { useReducer, useCallback, useState } from 'preact/hooks';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -97,11 +97,29 @@ const eventBus = new EventBus();
 const layoutConfig = {};
 const noop = () => {};
 
+/**
+ * Collect the ids of all entries across groups (including nested list items).
+ */
+function collectEntryIds(groups) {
+  const ids = [];
+
+  groups.forEach(group => {
+    (group.entries || []).forEach(entry => ids.push(entry.id));
+    (group.items || []).forEach(item => {
+      (item.entries || []).forEach(entry => ids.push(entry.id));
+    });
+  });
+
+  return ids;
+}
+
 new Popup(eventBus, {});
 new PopupRenderer(eventBus);
 
 function ExampleApp() {
   const [ , forceUpdate ] = useReducer(x => x + 1, 0);
+
+  const [ showErrors, setShowErrors ] = useState(false);
 
   const updateElement = useCallback((key, value) => {
     element[key] = value;
@@ -275,8 +293,28 @@ function ExampleApp() {
     }
   ];
 
+  const toggleErrors = event => {
+    const active = event.target.checked;
+
+    setShowErrors(active);
+
+    const errors = active ? collectEntryIds(groups).reduce((acc, id) => {
+      acc[id] = 'This field is invalid.';
+
+      return acc;
+    }, {}) : {};
+
+    eventBus.fire('propertiesPanel.setErrors', { errors });
+  };
+
   return (
     <div class="bio-properties-panel" style="display: flex; flex-direction: column; height: 100%;">
+      <div style="padding: 6px 8px; border-bottom: 1px solid #ccc;">
+        <label style="font-size: 12px; display: flex; align-items: center; gap: 6px;">
+          <input type="checkbox" checked={ showErrors } onChange={ toggleErrors } />
+          Show errors on all controls
+        </label>
+      </div>
       <div style="border: 2px dashed #888; margin: 4px;">
         <div style="font-size: 11px; color: #555; padding: 4px 8px; background: #f5f5f5;">
           standalone &lt;Header&gt;

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -4,7 +4,8 @@ import { useReducer, useCallback, useState } from 'preact/hooks';
 import TestContainer from 'mocha-test-container-support';
 
 import {
-  insertCoreStyles
+  insertCoreStyles,
+  insertCSS
 } from 'test/TestHelper';
 
 import PropertiesPanel from 'src/PropertiesPanel';
@@ -42,6 +43,50 @@ import { PopupRenderer } from 'src/features/popup/PopupRenderer';
 
 insertCoreStyles();
 
+insertCSS('example.css', `
+  body:has(.bio-properties-panel-example) {
+    box-sizing: border-box;
+    height: calc(100vh - 16px);
+    margin: 8px;
+  }
+
+  .test-container:has(.bio-properties-panel-example) {
+    box-sizing: border-box;
+    height: 100% !important;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .test-content-container:has(.bio-properties-panel-example) {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .bio-properties-panel-example {
+    display: flex;
+    flex-direction: column;
+    width: 350px;
+    height: 100%;
+    margin-left: auto;
+    border-left: solid 2px #CCC;
+  }
+
+  .bio-properties-panel-example__panel {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .bio-properties-panel-example__panel > .bio-properties-panel {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+`);
+
 const singleStart = window.__env__?.SINGLE_START;
 
 describe('Example', function() {
@@ -50,8 +95,7 @@ describe('Example', function() {
 
   beforeEach(function() {
     container = document.createElement('div');
-    container.style.width = '350px';
-    container.style.marginLeft = 'auto';
+    container.classList.add('bio-properties-panel-example');
 
     TestContainer.get(this).appendChild(container);
   });
@@ -321,7 +365,7 @@ function ExampleApp() {
         </div>
         <Header element={ element } headerProvider={ ExampleHeaderProvider } />
       </div>
-      <div style="border: 2px dashed #0a7; margin: 4px; flex: 1; min-height: 0;">
+      <div class="bio-properties-panel-example__panel" style="border: 2px dashed #0a7; margin: 4px; flex: 1; min-height: 0;">
         <div style="font-size: 11px; color: #555; padding: 4px 8px; background: #f5f5f5;">
           &lt;PropertiesPanel&gt; without built-in header
         </div>


### PR DESCRIPTION
### Proposed Changes

Playground allows to toggle error state + is assumes full height:

<img width="1420" height="1024" alt="capture ZsZ9sv_optimized" src="https://github.com/user-attachments/assets/5ceaa931-7742-4cb4-8b38-0c967ff69961" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
