### PR TITLE
Unify input height + fix expand button aligment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: pass engine versions to editor for FEEL compatibility linting ([#533](https://github.com/bpmn-io/properties-panel/pull/533))
 * `FEAT`: unify single line input height ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
+* `FIX`: center popup button vertically ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
 * `FIX`: show input active state on actual focus only ([#538](https://github.com/bpmn-io/properties-panel/pull/538))
 * `FIX`: restore FEEL syntax highlighting with `@bpmn-io/cm-theme@0.2.1+` ([bpmn-io/feelers#117](https://github.com/bpmn-io/feelers/pull/117))
 * `DEPS`: update to `@bpmn-io/feel-editor@2.7.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: pass engine versions to editor for FEEL compatibility linting ([#533](https://github.com/bpmn-io/properties-panel/pull/533))
 * `FEAT`: unify single line input height ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
+* `FIX`: do not show vertical resizer for auto resizing `Text` fields ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
 * `FIX`: center popup button vertically ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
 * `FIX`: show input active state on actual focus only ([#538](https://github.com/bpmn-io/properties-panel/pull/538))
 * `FIX`: restore FEEL syntax highlighting with `@bpmn-io/cm-theme@0.2.1+` ([bpmn-io/feelers#117](https://github.com/bpmn-io/feelers/pull/117))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: pass engine versions to editor for FEEL compatibility linting ([#533](https://github.com/bpmn-io/properties-panel/pull/533))
+* `FEAT`: unify single line input height ([#537](https://github.com/bpmn-io/properties-panel/pull/537))
 * `FIX`: show input active state on actual focus only ([#538](https://github.com/bpmn-io/properties-panel/pull/538))
 * `FIX`: restore FEEL syntax highlighting with `@bpmn-io/cm-theme@0.2.1+` ([bpmn-io/feelers#117](https://github.com/bpmn-io/feelers/pull/117))
 * `DEPS`: update to `@bpmn-io/feel-editor@2.7.0`

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -131,6 +131,8 @@
   --text-line-height: 21px;
   --line-height-condensed: 17px;
 
+  --input-height: 28px;
+
   --font-family: sans-serif;
   --font-family-monospace: monospace;
 
@@ -478,11 +480,25 @@
 
 .bio-properties-panel-feelers-editor.bio-properties-panel-input {
   padding: 0;
+  min-height: var(--input-height);
+}
+
+/**
+ * Normalize the vertical rhythm of the feelers and JSON editors so single-line
+ * editors line up with plain inputs. CodeMirror's default `.cm-content` padding
+ * of `4px 0` would otherwise render them a few pixels taller than the
+ * surrounding controls. (The FEEL editor already zeroes its own content padding
+ * and sizes to the shared baseline, so it is intentionally left untouched.)
+ */
+.bio-properties-panel-feelers-editor .cm-content,
+.bio-properties-panel-json-editor .cm-content {
+  padding-top: 3px;
+  padding-bottom: 2px;
 }
 
 .bio-properties-panel-feelers-input .cm-editor
 {
-  min-height: 32px;
+  min-height: var(--input-height);
   max-height: 215px;
   background-color: transparent;
 }
@@ -507,10 +523,7 @@ textarea.bio-properties-panel-input,
 .bio-properties-panel-input[type=text] {
   display: block;
   width: 100%;
-}
-
-textarea.bio-properties-panel-input {
-  min-height: 28px;
+  min-height: var(--input-height);
 }
 
 .bio-properties-panel-input:focus,
@@ -602,6 +615,7 @@ textarea.bio-properties-panel-input {
 
 .bio-properties-panel-json-editor .bio-properties-panel-input {
   padding: 0;
+  min-height: var(--input-height);
 }
 
 .bio-properties-panel-json-editor .cm-editor {
@@ -1111,7 +1125,7 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-feel-container .bio-properties-panel-feel-editor-container>div {
   position: static;
   padding-left: 2.4em !important;
-  min-height: 28px;
+  min-height: var(--input-height);
 }
 
 .bio-properties-panel-feel-indicator {

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1546,6 +1546,7 @@ textarea.bio-properties-panel-input {
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup svg,
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup svg,
 .bio-properties-panel-textarea-container .bio-properties-panel-open-feel-popup svg {
+  display: block;
   width: 16px;
   height: 16px;
 }

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -579,6 +579,11 @@ textarea.bio-properties-panel-input {
   resize: vertical;
 }
 
+/* auto-resizing textareas grow with their content, so manual resizing is pointless */
+textarea.bio-properties-panel-input.auto-resize {
+  resize: none;
+}
+
 .bio-properties-panel-entry.has-error .bio-properties-panel-input,
 .bio-properties-panel-entry.has-error .bio-properties-panel-feel-editor__open-popup-placeholder {
   border-color: var(--input-error-border-color);


### PR DESCRIPTION
### Proposed Changes

Adjusts inputs / controls so they have the same size - which would (depending on the editor) otherwise vary from 26 to 31 pixels.

<img width="1915" height="1022" alt="image" src="https://github.com/user-attachments/assets/6fa15fca-8b8e-4bda-b746-e98e4f61093a" />

Adjusts the popup toggle accordingly (fit clearly into the 28px height).

As a bonus, remove resize vertical handle from auto-resize text areas - modeling the behavior of FEEL inputs.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
