### PR TITLE
Only visualize active state on actual input focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: pass engine versions to editor for FEEL compatibility linting ([#533](https://github.com/bpmn-io/properties-panel/pull/533))
+* `FIX`: show input active state on actual focus only ([#538](https://github.com/bpmn-io/properties-panel/pull/538))
 * `FIX`: restore FEEL syntax highlighting with `@bpmn-io/cm-theme@0.2.1+` ([bpmn-io/feelers#117](https://github.com/bpmn-io/feelers/pull/117))
 * `DEPS`: update to `@bpmn-io/feel-editor@2.7.0`
 * `DEPS`: update to `@bpmn-io/feelers-editor@1.1.1`

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -520,12 +520,6 @@ textarea.bio-properties-panel-input {
   border: 1px solid var(--input-focus-border-color);
 }
 
-.bio-properties-panel-textfield:focus-within,
-.bio-properties-panel-feel-entry:focus-within {
-  --input-background-color: var(--input-focus-background-color);
-  --input-border-color: var(--input-focus-border-color);
-}
-
 .bio-properties-panel-input:disabled {
   border-color: var(--input-disabled-border-color);
   background-color: var(--input-disabled-background-color);
@@ -1131,6 +1125,22 @@ textarea.bio-properties-panel-input {
   width: 2em;
   text-align: center;
   padding: 2px 6px;
+}
+
+/**
+ * `:has()` so the indicator tracks real editor focus only — a plain
+ * `:focus-within` would also match the sibling pop-out button. Degrades to a
+ * neutral border where `:has()` is unsupported.
+ */
+.bio-properties-panel-feel-container:has(.bio-properties-panel-input:focus-within)
+  .bio-properties-panel-feel-indicator {
+  border-color: var(--input-focus-border-color);
+}
+
+.bio-properties-panel-entry.has-error
+  .bio-properties-panel-feel-container:has(.bio-properties-panel-input:focus-within)
+  .bio-properties-panel-feel-indicator {
+  border-color: var(--input-error-focus-border-color);
 }
 
 .bio-properties-panel-feel-editor-container .cm-scroller {


### PR DESCRIPTION
### Proposed Changes

Focus a field's secondary control (the `fx` FEEL toggle or the pop-out editor button) and the whole entry got the blue active look — but only for FEEL and text fields, not for others. The active styling was driven by an entry-level `:focus-within` rule, so it leaked onto sibling controls that own their own focus indicator:

<img width="419" height="426" alt="capture BvZ75W_optimized" src="https://github.com/user-attachments/assets/22feb2d9-0720-469e-b2e5-f1d1bc7a5542" />

This drops that rule so the active state follows real input focus consistently across String, Text, and FEEL. A scoped `:has()` rule keeps the FEEL `=` indicator border tracking editor focus. CSS-only:

<img width="419" height="426" alt="capture n10cR1_optimized" src="https://github.com/user-attachments/assets/e16464e6-b3dd-4797-9540-e2fa700004dd" />


### Try out

Via the playground, `npm start`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)