### PR TITLE
fix(sticky): resolve scroll container relative to observed element

### DIFF
--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -35,7 +35,8 @@ function getScrollContainer(ref, scrollContainerSelector) {
  */
 export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
 
-  const [ scrollContainer, setScrollContainer ] = useState(getScrollContainer(ref, scrollContainerSelector));
+  // resolved from the observed element after mount (see effect below)
+  const [ scrollContainer, setScrollContainer ] = useState(null);
 
   const updateScrollContainer = useCallback(() => {
     const newScrollContainer = getScrollContainer(ref, scrollContainerSelector);
@@ -60,8 +61,9 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
       return;
     }
 
-    // TODO(@barmac): test this
-    if (!ref.current || !scrollContainer) {
+    const element = ref.current;
+
+    if (!element || !scrollContainer) {
       return;
     }
 
@@ -86,12 +88,12 @@ export function useStickyIntersectionObserver(ref, scrollContainerSelector, setS
       rootMargin: '0px 0px 999999% 0px', // Use bottom margin to avoid stickyness when scrolling out to bottom
       threshold: [ 1 ]
     });
-    observer.observe(ref.current);
+    observer.observe(element);
 
     // Unobserve if unmounted
     return () => {
-      observer.unobserve(ref.current);
+      observer.unobserve(element);
     };
 
-  }, [ ref.current, scrollContainer, setSticky ]);
+  }, [ ref, scrollContainer, setSticky ]);
 }

--- a/src/hooks/useStickyIntersectionObserver.js
+++ b/src/hooks/useStickyIntersectionObserver.js
@@ -5,7 +5,7 @@ import {
 } from 'preact/hooks';
 
 import {
-  query as domQuery
+  closest as domClosest
 } from 'min-dom';
 
 import { useEvent } from './useEvent';
@@ -17,10 +17,17 @@ import { useEvent } from './useEvent';
  */
 
 /**
+ * Resolve scroll container closest to the referenced element.
+ */
+function getScrollContainer(ref, scrollContainerSelector) {
+  return ref.current ? domClosest(ref.current, scrollContainerSelector, true) : null;
+}
+
+/**
  * Use IntersectionObserver to identify when DOM element is in sticky mode.
+ *
  * If sticky is observered setSticky(true) will be called.
  * If sticky mode is left, setSticky(false) will be called.
- *
  *
  * @param {Object} ref
  * @param {string} scrollContainerSelector
@@ -28,15 +35,15 @@ import { useEvent } from './useEvent';
  */
 export function useStickyIntersectionObserver(ref, scrollContainerSelector, setSticky) {
 
-  const [ scrollContainer, setScrollContainer ] = useState(domQuery(scrollContainerSelector));
+  const [ scrollContainer, setScrollContainer ] = useState(getScrollContainer(ref, scrollContainerSelector));
 
   const updateScrollContainer = useCallback(() => {
-    const newScrollContainer = domQuery(scrollContainerSelector);
+    const newScrollContainer = getScrollContainer(ref, scrollContainerSelector);
 
     if (newScrollContainer !== scrollContainer) {
       setScrollContainer(newScrollContainer);
     }
-  }, [ scrollContainerSelector, scrollContainer ]);
+  }, [ ref, scrollContainerSelector, scrollContainer ]);
 
   useEffect(() => {
     updateScrollContainer();

--- a/test/spec/hooks/useStickyIntersectionObserver.spec.js
+++ b/test/spec/hooks/useStickyIntersectionObserver.spec.js
@@ -12,6 +12,9 @@ import TestContainer from 'mocha-test-container-support';
 import { EventContext } from '../../../src/context';
 
 
+const SCROLL_CONTAINER_SELECTOR = 'div.bio-properties-panel-scroll-container';
+
+
 describe('hooks/userStickyIntersectionObserver', function() {
 
   const OriginalIntersectionObserver = global.IntersectionObserver;
@@ -42,13 +45,14 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     mockIntersectionObserver({ observe: observeSpy });
 
-    const domObject = <div></div>;
+    const scrollContainer = createScrollContainer(container);
+    const domObject = createObserved(scrollContainer);
 
     // when
     const ref = { current: domObject };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, 'div', () => {});
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
       return domObject;
     });
@@ -65,13 +69,14 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     const triggerCallback = mockIntersectionObserver({});
 
-    const domObject = <div></div>;
+    const scrollContainer = createScrollContainer(container, { withContent: true });
+    const domObject = createObserved(scrollContainer);
 
     // when
     const ref = { current: domObject };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, 'div', callbackSpy);
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, callbackSpy);
 
       return domObject;
     });
@@ -99,7 +104,7 @@ describe('hooks/userStickyIntersectionObserver', function() {
     const ref = { current: undefined };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, 'div', () => {});
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
       return undefined;
     });
@@ -116,16 +121,13 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     const triggerCallback = mockIntersectionObserver({});
 
-    const domObject = <div></div>;
-
-    const scrollContainer = document.createElement('div');
-    scrollContainer.setAttribute('id', 'scrollContainer');
-    container.appendChild(scrollContainer);
+    const scrollContainer = createScrollContainer(container, { withContent: true });
+    const domObject = createObserved(scrollContainer);
 
     const ref = { current: domObject };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, '#scrollContainer', callbackSpy);
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, callbackSpy);
 
       return domObject;
     });
@@ -148,11 +150,14 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     mockIntersectionObserver({ observe: observeSpy });
 
-    const domObject = <div></div>;
+    const scrollContainer = createScrollContainer(container);
+
+    // observed element not yet inside its scroll container
+    const domObject = document.createElement('div');
     const ref = { current: domObject };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, '#scrollContainer', () => {});
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
       return domObject;
     }, { wrapper: WithEventContext(eventBus) });
@@ -161,9 +166,7 @@ describe('hooks/userStickyIntersectionObserver', function() {
     expect(observeSpy).not.to.have.been.called;
 
     // when
-    const scrollContainer = document.createElement('div');
-    scrollContainer.setAttribute('id', 'scrollContainer');
-    container.appendChild(scrollContainer);
+    scrollContainer.appendChild(domObject);
 
     eventBus.fire('propertiesPanel.attach');
 
@@ -182,12 +185,13 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     mockIntersectionObserver({ unobserve: unobserveSpy });
 
-    const domObject = <div></div>;
+    const scrollContainer = createScrollContainer(container);
+    const domObject = createObserved(scrollContainer);
 
     const ref = { current: domObject };
 
     const { unmount } = await renderHook(() => {
-      useStickyIntersectionObserver(ref, 'div', () => {});
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
       return domObject;
     });
@@ -207,21 +211,19 @@ describe('hooks/userStickyIntersectionObserver', function() {
 
     mockIntersectionObserver({ unobserve: unobserveSpy });
 
-    const scrollContainer = document.createElement('div');
-    scrollContainer.setAttribute('id', 'scrollContainer');
-    container.appendChild(scrollContainer);
+    const scrollContainer = createScrollContainer(container);
+    const domObject = createObserved(scrollContainer);
 
-    const domObject = <div></div>;
     const ref = { current: domObject };
 
     await renderHook(() => {
-      useStickyIntersectionObserver(ref, '#scrollContainer', () => {});
+      useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
       return domObject;
     }, { wrapper: WithEventContext(eventBus) });
 
     // when
-    scrollContainer.remove();
+    domObject.remove();
     eventBus.fire('propertiesPanel.detach');
 
     // then
@@ -232,19 +234,64 @@ describe('hooks/userStickyIntersectionObserver', function() {
   });
 
 
+  it('should resolve scroll container relative to the observed element', async function() {
+
+    // given multiple panels mounted in the same document
+    const triggerCallback = mockIntersectionObserver({});
+
+    const scrollContainerOne = createScrollContainer(container);
+    const scrollContainerTwo = createScrollContainer(container);
+
+    const groupOne = createObserved(scrollContainerOne);
+    const groupTwo = createObserved(scrollContainerTwo);
+
+    const setStickyOne = sinonSpy();
+    const setStickyTwo = sinonSpy();
+
+    const refOne = { current: groupOne };
+    const refTwo = { current: groupTwo };
+
+    // when
+    await renderHook(() => {
+      useStickyIntersectionObserver(refOne, SCROLL_CONTAINER_SELECTOR, setStickyOne);
+
+      return groupOne;
+    });
+
+    await renderHook(() => {
+      useStickyIntersectionObserver(refTwo, SCROLL_CONTAINER_SELECTOR, setStickyTwo);
+
+      return groupTwo;
+    });
+
+    // then
+    // each observer is scoped to its OWN panel's scroll container,
+    // not the first scroll container found in document order
+    const observers = triggerCallback.instances;
+
+    expect(observers).to.have.length(2);
+    expect(observers[0].root).to.equal(scrollContainerOne);
+    expect(observers[1].root).to.equal(scrollContainerTwo);
+
+    expect(observers[0].observed).to.equal(groupOne);
+    expect(observers[1].observed).to.equal(groupTwo);
+  });
+
+
   it('should NOT crash when IntersectionObserver is not available', async function() {
 
     // given
     global.IntersectionObserver = null;
 
-    const domObject = <div></div>;
+    const scrollContainer = createScrollContainer(container);
+    const domObject = createObserved(scrollContainer);
 
     const ref = { current: domObject };
 
     // when
     try {
       await renderHook(() => {
-        useStickyIntersectionObserver(ref, 'div', () => {});
+        useStickyIntersectionObserver(ref, SCROLL_CONTAINER_SELECTOR, () => {});
 
         return domObject;
       });
@@ -262,12 +309,57 @@ describe('hooks/userStickyIntersectionObserver', function() {
 function noop() {}
 
 /**
+ * Create a scroll container inside the given parent.
+ *
+ * @param {Element} parent
+ * @param {Object} [options]
+ * @param {boolean} [options.withContent=false] add overflowing content so the
+ *   container reports a non-zero `scrollHeight`
+ *
+ * @return {Element}
+ */
+function createScrollContainer(parent, options = {}) {
+  const { withContent = false } = options;
+
+  const scrollContainer = document.createElement('div');
+  scrollContainer.classList.add('bio-properties-panel-scroll-container');
+  scrollContainer.style.height = '100px';
+  scrollContainer.style.overflow = 'auto';
+
+  if (withContent) {
+    const content = document.createElement('div');
+    content.style.height = '500px';
+    scrollContainer.appendChild(content);
+  }
+
+  parent.appendChild(scrollContainer);
+
+  return scrollContainer;
+}
+
+/**
+ * Create an observed element inside the given scroll container.
+ *
+ * @param {Element} scrollContainer
+ *
+ * @return {Element}
+ */
+function createObserved(scrollContainer) {
+  const observed = document.createElement('div');
+
+  scrollContainer.appendChild(observed);
+
+  return observed;
+}
+
+/**
  * Overrides the IntersectionObserver global with a mock.
  *
  * @param {Object} props
  * @param {Object} [props.observe]
  * @param {Object} [props.unobserve]
- * @returns {Function} triggers the callback on all created observers
+ * @returns {Function} triggers the callback on all created observers; the
+ *   created observer instances are exposed via the `instances` property
  */
 function mockIntersectionObserver(props) {
   const {
@@ -276,18 +368,25 @@ function mockIntersectionObserver(props) {
   } = props;
 
   const callbacks = [];
+  const instances = [];
 
   function triggerCallbacks(args) {
     callbacks.forEach(callback => callback(args));
   }
 
   class MockObserver {
-    constructor(callback) {
+    constructor(callback, options = {}) {
+      this.root = options.root;
+      this.observed = null;
+
       callbacks.push(callback);
+      instances.push(this);
     }
 
-    observe() {
-      return observe();
+    observe(element) {
+      this.observed = element;
+
+      return observe(element);
     }
 
     unobserve() {
@@ -297,6 +396,8 @@ function mockIntersectionObserver(props) {
   }
 
   global.IntersectionObserver = MockObserver;
+
+  triggerCallbacks.instances = instances;
 
   return triggerCallbacks;
 }


### PR DESCRIPTION
### Proposed Changes

Fixes falsely-sticky group headers when more than one properties panel is mounted in the same document.

`useStickyIntersectionObserver` resolved the `IntersectionObserver` root with a document-global `query('.bio-properties-panel-scroll-container')`, which always returns the first match. Later panels therefore observed the *wrong* scroll container; their fully contained groups reported `intersectionRatio < 1` and were wrongly given the `.sticky` class.

Fix: resolve the container relative to the observed element via `ref.current.closest(selector)`, so each panel uses its own scroll container. Attach/detach re-resolution, early-returns, and observer options are unchanged.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Brief textual description__ of the changes
  * [x] Added a regression test (two panels in one document); full suite green (698 pass), lint clean