### PR TITLE
feat: use CSS for textarea auto-resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ## Unreleased
 
+___Note:__ Yet to be released changes appear here._
+
 * `FEAT`: use CSS for textarea auto-resize ([#540](https://github.com/bpmn-io/properties-panel/pull/540))
 
 ## 3.49.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ## Unreleased
 
-___Note:__ Yet to be released changes appear here._
+* `FEAT`: use CSS for textarea auto-resize ([#540](https://github.com/bpmn-io/properties-panel/pull/540))
 
 ## 3.49.1
 

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -676,9 +676,10 @@ textarea.bio-properties-panel-input {
   resize: vertical;
 }
 
-/* auto-resizing textareas grow with their content, so manual resizing is pointless */
 textarea.bio-properties-panel-input.auto-resize {
+  /* auto-resizing textareas grow with their content, so manual resizing is pointless */
   resize: none;
+  field-sizing: content;
 }
 
 .bio-properties-panel-entry.has-error .bio-properties-panel-input,

--- a/src/components/entries/TextArea.js
+++ b/src/components/entries/TextArea.js
@@ -4,7 +4,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState
 } from 'preact/hooks';
@@ -13,7 +12,6 @@ import classnames from 'classnames';
 
 import {
   useDebounce,
-  useElementVisible,
   useError,
   useShowEntryEvent,
   useStaticCallback
@@ -27,14 +25,6 @@ import { isCmdWithChar } from '../util/keyboardUtils';
 import translateFallback from '../util/translateFallback';
 
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
-
-function resizeToContents(element) {
-  element.style.height = 'auto';
-
-  // a 2px pixel offset is required to prevent scrollbar from
-  // appearing on OS with a full length scroll bar (Windows/Linux)
-  element.style.height = `${ element.scrollHeight + 2 }px`;
-}
 
 function TextArea(props) {
 
@@ -75,8 +65,6 @@ function TextArea(props) {
     const newModelValue = newValue === '' ? undefined : newValue;
     commitValue(newModelValue);
   }, [ commitValue ]);
-
-  const visible = useElementVisible(ref.current);
 
   /**
    * @type { import('min-dash').DebouncedFunction }
@@ -171,15 +159,6 @@ function TextArea(props) {
       eventBus && eventBus.fire('propertiesPanel.closePopup');
     };
   }, []);
-
-  // auto-resize on any value change (typing, popup edits, external updates)
-  useLayoutEffect(() => {
-    autoResize && resizeToContents(ref.current);
-  }, [ localValue ]);
-
-  useLayoutEffect(() => {
-    visible && autoResize && resizeToContents(ref.current);
-  }, [ visible ]);
 
   useEffect(() => {
     if (value === localValue) {


### PR DESCRIPTION
### Proposed Changes

This PR makes use of [`field-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/field-sizing) property which is newly baseline, and allows to remove a bunch of code.

Note: I left the `useElementVisible` hook in the code base as it's part of the exports, but it's not used anywhere. We could remove it but that will be a BC.

https://github.com/user-attachments/assets/8e448ffd-5026-42c1-b3a4-a6cea2471eda

`npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel -l bpmn-io/properties-panel#use-field-sizing-for-text-area`

To verify: Windows/Linux behavior where we had an annotation about scrollbars appearing.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
