### PR TITLE
fix: only show text popup scrollbar when content overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: only show text popup scrollbar when content overflows
+
 ## 3.49.1
 
 * `FIX`: resolve sticky observer scroll container relative to observed element ([#539](https://github.com/bpmn-io/properties-panel/pull/539))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FIX`: only show text popup scrollbar when content overflows
+* `FIX`: only show text popup scrollbar when content overflows ([#542](https://github.com/bpmn-io/properties-panel/issues/542))
 
 ## 3.49.1
 

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1475,6 +1475,15 @@ textarea.bio-properties-panel-input.auto-resize {
   font-size: 14px;
 }
 
+/**
+ * Popups render through a portal outside `.bio-properties-panel`, so re-apply
+ * the global box-sizing reset here.
+ */
+.bio-properties-panel-popup,
+.bio-properties-panel-popup * {
+  box-sizing: border-box;
+}
+
 .bio-properties-panel-popup h1,
 .bio-properties-panel-popup h2,
 .bio-properties-panel-popup h3,

--- a/test/spec/components/TextArea.spec.js
+++ b/test/spec/components/TextArea.spec.js
@@ -27,7 +27,8 @@ import EventBus from 'diagram-js/lib/core/EventBus';
 import {
   changeInput,
   expectNoViolations,
-  insertCoreStyles
+  insertCoreStyles,
+  insertCSS
 } from 'test/TestHelper';
 
 import {
@@ -1168,11 +1169,16 @@ describe('<TextArea>', function() {
     it('should NOT resize on single line input when initially was display: none', function() {
 
       // given
-      const parent = domify('<div style="display: none;"></div>');
+      const parent = domify('<div class="test-textarea-boxsizing-scope" style="display: none;"></div>');
       container.appendChild(parent);
 
-      const style = domify('<style>.bio-properties-panel-input { box-sizing: border-box; }</style>');
-      parent.appendChild(style);
+      // scope the box-sizing override to this test's subtree so it does not
+      // leak `border-box` onto `.bio-properties-panel-input` elements in other
+      // specs (which share the same document)
+      insertCSS(
+        'test-textarea-boxsizing.css',
+        '.test-textarea-boxsizing-scope .bio-properties-panel-input { box-sizing: border-box; }'
+      );
 
       const result = createTextArea({
         container: parent,

--- a/test/spec/features/popup/components/TextPopup.spec.js
+++ b/test/spec/features/popup/components/TextPopup.spec.js
@@ -177,6 +177,63 @@ describe('<TextPopup>', function() {
   });
 
 
+  describe('sizing', function() {
+
+    // The popup is rendered through a portal outside of `.bio-properties-panel`,
+    // so it must not rely on the global `.bio-properties-panel *` box-sizing
+    // reset. Otherwise `height: 100%` + padding overflows and forces a
+    // permanent vertical scrollbar.
+    it('should apply border-box sizing to the textarea', function() {
+
+      // when
+      render(
+        <TextPopup
+          entryId="foo"
+          title="Test Title"
+          value="bar"
+          onInput={ () => {} }
+          onClose={ () => {} }
+          sourceElement={ sourceElement }
+        />, { container }
+      );
+
+      // then
+      const textarea = container.querySelector('textarea.bio-properties-panel-input');
+
+      expect(textarea).to.exist;
+      expect(window.getComputedStyle(textarea).boxSizing).to.equal('border-box');
+    });
+
+
+    it('should not exceed its container height', function() {
+
+      // when
+      render(
+        <TextPopup
+          entryId="foo"
+          title="Test Title"
+          value="bar"
+          onInput={ () => {} }
+          onClose={ () => {} }
+          sourceElement={ sourceElement }
+        />, { container }
+      );
+
+      // then
+      const textarea = container.querySelector('textarea.bio-properties-panel-input');
+
+      expect(textarea).to.exist;
+
+      const body = textarea.closest('.bio-properties-panel-popup__body');
+
+      // with content-box sizing the `height: 100%` + padding would make the
+      // textarea overflow its body by the padding amount, forcing a scrollbar
+      expect(textarea.offsetHeight).to.be.at.most(body.clientHeight);
+    });
+
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {


### PR DESCRIPTION
### Proposed Changes

<img width="1003" height="612" alt="image" src="https://github.com/user-attachments/assets/75bd0af4-e7e2-44ae-9172-b79115f22460" />

Closes #542

The text popup editor is rendered through a portal into a container outside of `.bio-properties-panel`, so the global `.bio-properties-panel *` box-sizing reset never reaches it. The popup textarea fell back to `content-box`, and its `height: 100%` + `padding: 8px 12px` made it 16px taller than its body, forcing a permanent vertical scrollbar even for short content.

This re-applies the box-sizing reset scoped to the whole popup subtree so all popup content (text popup, FEEL popup, future popups) is sized with `border-box` and only overflows when content actually exceeds the editor area:

```css
.bio-properties-panel-popup,
.bio-properties-panel-popup * {
  box-sizing: border-box;
}
```

I chose the subtree reset over patching only the text-popup rule because it fixes the whole class of bug caused by the portal dropping the reset, matches the library's existing `.bio-properties-panel *` convention, and stays tiny. Library-level fix, no theme/app-specific hacks.

I also scoped a leaked global `<style>` in `TextArea.spec.js` that polluted `.bio-properties-panel-input` box-sizing across specs and was masking this regression in the full run.

<!-- Screenshots / short video of before vs. after go here. -->

**Steps to try out**

1. Open a text popup for a textarea entry (e.g. an element's Documentation)
2. Enter a single short line of text
3. Before: a vertical scrollbar is shown; after: no scrollbar until the content actually overflows

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
