### PR TITLE
fix(feel-editor): react to `engines` change

### DIFF
--- a/src/components/entries/FEEL/FeelEditor.js
+++ b/src/components/entries/FEEL/FeelEditor.js
@@ -176,6 +176,14 @@ const FeelEditor = forwardRef((props, ref) => {
     editor.setPlaceholder(placeholder);
   }, [ placeholder ]);
 
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setEngines(engines);
+  }, [ engines ]);
+
   const handleClick = () => {
     ref.current.focus();
   };

--- a/test/spec/components/FeelEditor.spec.js
+++ b/test/spec/components/FeelEditor.spec.js
@@ -20,15 +20,21 @@ import { useEffect, useRef } from 'preact/hooks';
 import { fireEvent, waitFor } from '@testing-library/preact';
 
 import FeelComponent from 'src/components/entries/FEEL/FeelEditor';
+import FeelEditor from '@bpmn-io/feel-editor';
 
 insertCoreStyles();
 
 describe('<FeelEditor>', function() {
 
   let container;
+  let setEnginesSpy;
 
   beforeEach(function() {
     container = TestContainer.get(this);
+  });
+
+  afterEach(function() {
+    setEnginesSpy?.restore();
   });
 
   it('should supply variables to editor', async function() {
@@ -192,6 +198,25 @@ describe('<FeelEditor>', function() {
     const editor = domQuery('[role="textbox"]', container);
 
     expect(editor.textContent).to.eql('bar');
+  });
+
+
+  it('should update engines when changed', function() {
+
+    // given
+    const engines = {
+      camunda: '8.8'
+    };
+
+    setEnginesSpy = sinonSpy(FeelEditor.prototype, 'setEngines');
+
+    const component = render(<Wrapper />, { container });
+
+    // when
+    component.rerender(<Wrapper feelLanguageContext={ { engines } } />);
+
+    // then
+    expect(setEnginesSpy).to.have.been.calledWith(engines);
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Allows consumers to reset `engines`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
