### PR TITLE
Update feel-editor to 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.51.1",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^2.7.0",
+        "@bpmn-io/feel-editor": "^2.7.1",
         "@bpmn-io/feelers-editor": "^1.1.1",
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.10.3",
@@ -445,9 +445,9 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.7.0.tgz",
-      "integrity": "sha512-5Tpkx8zrHrZEQr4TgS7QOwEL2tqv97cHMPoBXq2sd6aQuONS8l6ROZw067i6MLc21XFXOzmrWT5A6333y88vZQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.7.1.tgz",
+      "integrity": "sha512-WY3aUUc3MYwfAz4sL8SgR82stdXvM7cKvqaqZAelZ3fXj6Ve2gqrbPmZJ6Kg+bYtOZA9obsDmVNdP7zMcXwIrQ==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/cm-theme": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/feel-editor": "^2.7.0",
+    "@bpmn-io/feel-editor": "^2.7.1",
     "@bpmn-io/feelers-editor": "^1.1.1",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.10.3",


### PR DESCRIPTION
### Proposed Changes

Update `@bpmn-io/feel-editor` to `^2.7.1` so changing target engine versions refreshes FEEL lint diagnostics.

Related to https://github.com/camunda/camunda-modeler/issues/5735

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes (not applicable; dependency update)
  * [x] __Steps to try out__ (covered by upstream regression test and `npm run all`)