### PR TITLE
feat: add warning / error badge theming tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add `--warning-badge-*` and `--error-badge-*` theming tokens ([#547](https://github.com/bpmn-io/properties-panel/pull/547))
+* `FIX`: use accessible foreground color for warning list badge ([#547](https://github.com/bpmn-io/properties-panel/pull/547))
 
 ## 3.51.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add `--warning-badge-*` and `--error-badge-*` theming tokens ([#547](https://github.com/bpmn-io/properties-panel/pull/547))
+
 ## 3.51.2
 
 * `FIX`: force linting after engines change ([bpmn-io/feel-editor#114](https://github.com/bpmn-io/feel-editor/pull/114))

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -33,6 +33,7 @@
 
   --color-amber-39-100-33: hsl(39, 100%, 33%);
   --color-amber-35-84-62: hsl(35, 84%, 62%);
+  --color-amber-35-84-57: hsl(35, 84%, 57%);
   --color-amber-38-100-96: hsl(38, 100%, 96%);
   --color-amber-35-84-62-a35: hsla(35, 84%, 62%, 0.35);
 
@@ -79,9 +80,16 @@
   --arrow-fill-color: var(--color-grey-225-10-35);
   --arrow-hover-background-color: var(--color-grey-225-10-95);
 
+  --warning-badge-background-color: var(--color-amber-35-84-62);
+  --warning-badge-color: var(--color-grey-225-10-15);
+  --warning-badge-hover-background-color: var(--color-amber-35-84-57);
+  --error-badge-background-color: var(--color-red-360-100-45);
+  --error-badge-color: var(--color-white);
+  --error-badge-hover-background-color: var(--color-red-360-100-40);
+
   --dot-color: var(--color-grey-225-10-35);
-  --dot-color-error: var(--color-red-360-100-45);
-  --dot-color-warning: var(--color-amber-35-84-62);
+  --dot-color-error: var(--error-badge-background-color);
+  --dot-color-warning: var(--warning-badge-background-color);
 
   --list-badge-color: var(--color-white);
   --list-badge-background-color: var(--color-grey-225-10-35);
@@ -451,11 +459,11 @@
 }
 
 .bio-properties-panel-list-badge--warning {
-  --list-badge-background-color: var(--dot-color-warning);
+  --list-badge-background-color: var(--warning-badge-background-color);
 }
 
 .bio-properties-panel-list-badge--error {
-  --list-badge-background-color: var(--dot-color-error);
+  --list-badge-background-color: var(--error-badge-background-color);
 }
 
 /**

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -460,10 +460,12 @@
 
 .bio-properties-panel-list-badge--warning {
   --list-badge-background-color: var(--warning-badge-background-color);
+  --list-badge-color: var(--warning-badge-color);
 }
 
 .bio-properties-panel-list-badge--error {
   --list-badge-background-color: var(--error-badge-background-color);
+  --list-badge-color: var(--error-badge-color);
 }
 
 /**

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -12,41 +12,62 @@ describe('styling (CSS)', function() {
   beforeEach(function() {
     container = document.createElement('div');
     container.classList.add('bio-properties-panel');
-    container.style.width = '250px';
+    container.style.width = '280px';
     container.style.padding = '10px';
 
     TestContainer.get(this).appendChild(container);
   });
 
-  it.skip('warning states', async function() {
 
-    // when
+  // visual playground for manual review (un-skip and open the Karma debug page)
+  it.skip('severity states (visual)', function() {
     container.innerHTML = `
-      <div class="bio-properties-panel-entry has-warning" style="margin-bottom: 20px">
+      <div class="bio-properties-panel-entry has-warning" style="margin-bottom: 16px">
         <label class="bio-properties-panel-label">has-warning input</label>
         <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
         <div class="bio-properties-panel-warning">warning message</div>
       </div>
 
-      <div class="bio-properties-panel-entry has-error" style="margin-bottom: 20px">
+      <div class="bio-properties-panel-entry has-error" style="margin-bottom: 16px">
         <label class="bio-properties-panel-label">has-error input</label>
         <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
         <div class="bio-properties-panel-error">error message</div>
       </div>
 
-      <div class="bio-properties-panel-entry has-warning has-error" style="margin-bottom: 20px">
-        <label class="bio-properties-panel-label">has-warning and has-error input - error wins</label>
+      <div class="bio-properties-panel-entry has-warning has-error" style="margin-bottom: 16px">
+        <label class="bio-properties-panel-label">has-warning + has-error (error wins)</label>
         <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
         <div class="bio-properties-panel-warning">warning message</div>
         <div class="bio-properties-panel-error">error message</div>
       </div>
 
-      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 4px">
-        <label class="bio-properties-panel-label">dot + badge</label>
+      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px; margin-bottom: 16px">
+        <label class="bio-properties-panel-label">dots</label>
+        <span class="bio-properties-panel-dot"></span>
         <span class="bio-properties-panel-dot bio-properties-panel-dot--warning"></span>
         <span class="bio-properties-panel-dot bio-properties-panel-dot--error"></span>
+      </div>
+
+      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px; margin-bottom: 16px">
+        <label class="bio-properties-panel-label">list badges</label>
+        <span class="bio-properties-panel-list-badge">3</span>
         <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning">3</span>
         <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error">3</span>
+        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning">99</span>
+        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error">99</span>
+      </div>
+
+      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px">
+        <label class="bio-properties-panel-label">badge token swatches (on-surface text)</label>
+        <span style="padding: 2px 8px; border-radius: 11px; background: var(--warning-badge-background-color); color: var(--warning-badge-color)">Aa 3</span>
+        <span style="padding: 2px 8px; border-radius: 11px; background: var(--error-badge-background-color); color: var(--error-badge-color)">Aa 3</span>
+        <span style="padding: 2px 8px; border-radius: 11px; background: var(--list-badge-background-color); color: var(--list-badge-color)">Aa 3</span>
+      </div>
+
+      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px">
+        <label class="bio-properties-panel-label">badge hover swatches</label>
+        <span style="padding: 2px 8px; border-radius: 11px; background: var(--warning-badge-hover-background-color); color: var(--warning-badge-color)">Aa 3</span>
+        <span style="padding: 2px 8px; border-radius: 11px; background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">Aa 3</span>
       </div>
     `;
   });

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 import TestContainer from 'mocha-test-container-support';
 
 import { insertCoreStyles } from 'test/TestHelper';
@@ -72,4 +74,70 @@ describe('styling (CSS)', function() {
     `;
   });
 
+
+  // enforce WCAG AA text contrast so a regression (e.g. white-on-amber) fails CI
+  it('list badges meet WCAG AA text contrast', function() {
+
+    // given
+    container.innerHTML = `
+      <span class="bio-properties-panel-list-badge" data-variant="neutral">3</span>
+      <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning" data-variant="warning">3</span>
+      <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error" data-variant="error">3</span>
+
+      <span data-variant="warning-hover" style="background: var(--warning-badge-hover-background-color); color: var(--warning-badge-color)">3</span>
+      <span data-variant="error-hover" style="background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">3</span>
+    `;
+
+    // then
+    [
+      'neutral',
+      'warning',
+      'error',
+      'warning-hover',
+      'error-hover'
+    ].forEach(function(variant) {
+      const badge = container.querySelector(`[data-variant="${variant}"]`);
+      const style = getComputedStyle(badge);
+
+      const ratio = contrastRatio(style.color, style.backgroundColor);
+
+      expect(ratio, `${variant} list-badge contrast`).to.be.at.least(4.5);
+    });
+  });
+
 });
+
+
+// helpers /////////////////////////////
+
+function parseRgb(value) {
+  const match = value.match(/rgba?\(([^)]+)\)/);
+
+  if (!match) {
+    throw new Error('unexpected color value: ' + value);
+  }
+
+  return match[1].split(',').slice(0, 3).map(function(part) {
+    return parseFloat(part.trim());
+  });
+}
+
+function relativeLuminance(rgb) {
+  const [ r, g, b ] = rgb.map(function(channel) {
+    const c = channel / 255;
+
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foreground, background) {
+  const l1 = relativeLuminance(parseRgb(foreground));
+  const l2 = relativeLuminance(parseRgb(background));
+
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 
 import TestContainer from 'mocha-test-container-support';
 
+import axe from 'axe-core';
+
 import { insertCoreStyles } from 'test/TestHelper';
 
 insertCoreStyles();
@@ -76,9 +78,11 @@ describe('styling (CSS)', function() {
 
 
   // enforce WCAG AA text contrast so a regression (e.g. white-on-amber) fails CI
-  it('list badges meet WCAG AA text contrast', function() {
+  it('list badges meet WCAG AA text contrast', async function() {
 
     // given
+    this.timeout(5000);
+
     container.innerHTML = `
       <span class="bio-properties-panel-list-badge" data-variant="neutral">3</span>
       <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning" data-variant="warning">3</span>
@@ -88,56 +92,16 @@ describe('styling (CSS)', function() {
       <span data-variant="error-hover" style="background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">3</span>
     `;
 
-    // then
-    [
-      'neutral',
-      'warning',
-      'error',
-      'warning-hover',
-      'error-hover'
-    ].forEach(function(variant) {
-      const badge = container.querySelector(`[data-variant="${variant}"]`);
-      const style = getComputedStyle(badge);
-
-      const ratio = contrastRatio(style.color, style.backgroundColor);
-
-      expect(ratio, `${variant} list-badge contrast`).to.be.at.least(4.5);
+    // when
+    const results = await axe.run(container, {
+      runOnly: {
+        type: 'rule',
+        values: [ 'color-contrast' ]
+      }
     });
+
+    // then
+    expect(results.violations).to.be.empty;
   });
 
 });
-
-
-// helpers /////////////////////////////
-
-function parseRgb(value) {
-  const match = value.match(/rgba?\(([^)]+)\)/);
-
-  if (!match) {
-    throw new Error('unexpected color value: ' + value);
-  }
-
-  return match[1].split(',').slice(0, 3).map(function(part) {
-    return parseFloat(part.trim());
-  });
-}
-
-function relativeLuminance(rgb) {
-  const [ r, g, b ] = rgb.map(function(channel) {
-    const c = channel / 255;
-
-    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-  });
-
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
-
-function contrastRatio(foreground, background) {
-  const l1 = relativeLuminance(parseRgb(foreground));
-  const l2 = relativeLuminance(parseRgb(background));
-
-  const lighter = Math.max(l1, l2);
-  const darker = Math.min(l1, l2);
-
-  return (lighter + 0.05) / (darker + 0.05);
-}


### PR DESCRIPTION
### Proposed Changes

Add reusable severity **badge** theming tokens (surface / foreground / hover) for `warning` and `error`, mirroring the existing `--list-badge-*` naming:

```css
--warning-badge-background-color / --warning-badge-color / --warning-badge-hover-background-color
--error-badge-background-color   / --error-badge-color   / --error-badge-hover-background-color
```

The existing severity dots and list-badge surfaces are rerouted to these, so there is a single source of truth (dots resolve to the same colors — no visual change).

This also **fixes** a latent contrast bug: the warning list badge rendered white-on-amber (`1.97:1`, WCAG fail) and now uses dark text (`7.85:1`). The on-surface foreground flips per severity (dark on amber, white on red) and is not derivable from the surface; hover surfaces follow the ecosystem's `-5%` lightness convention (not `color-mix`).

### Screenshots

<img width="621" height="265" alt="image" src="https://github.com/user-attachments/assets/49ed4293-ba7a-46c7-a3a3-329531b690a7" />

### Try it out

* Contrast is enforced in CI: `npm test` runs `list badges meet WCAG AA text contrast` (base + hover, `>= 4.5:1`).
* To view every state visually: un-skip `severity states (visual)` in `test/spec/styling.spec.js` and open the Karma debug page.


Related to bpmn-io/bpmn-js-element-templates#288
Builds on bpmn-io/properties-panel#544

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] Linked to related issues 
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__