### PR TITLE
feat: add accent theming tokens and use WCAG AA compliant accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: reserve space for open pop-up button in FEEL editor ([#525](https://github.com/bpmn-io/properties-panel/pull/525))
+* `FEAT`: add `--accent-*` theming tokens and `--accent` list badge ([#549](https://github.com/bpmn-io/properties-panel/pull/549))
+* `FIX`: use WCAG AA compliant accent color ([#549](https://github.com/bpmn-io/properties-panel/pull/549))
 
 ## 3.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FIX`: reserve space for open pop-up button in FEEL editor ([#525](https://github.com/bpmn-io/properties-panel/pull/525))
 * `FEAT`: add `--accent-*` theming tokens and `--accent` list badge ([#549](https://github.com/bpmn-io/properties-panel/pull/549))
+* `FIX`: reserve space for open pop-up button in FEEL editor ([#525](https://github.com/bpmn-io/properties-panel/pull/525))
 * `FIX`: use WCAG AA compliant accent color ([#549](https://github.com/bpmn-io/properties-panel/pull/549))
 
 ## 3.52.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "chai": "^6.2.2",
         "cross-env": "^10.1.0",
         "del-cli": "^7.0.0",
-        "diagram-js": "^15.24.0",
+        "diagram-js": "^15.25.0",
         "eslint": "^9.39.5",
         "eslint-plugin-bpmn-io": "^2.3.1",
         "eslint-plugin-import": "^2.32.0",
@@ -3855,9 +3855,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.24.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.24.0.tgz",
-      "integrity": "sha512-RVSeGHVNAWQHM7reWAP0geb245GMVPMeDlsYsilNUrQwR/t+rp8ov0agZArCfV7hUaj8VqIQCMROo50L5MLbbg==",
+      "version": "15.25.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.25.0.tgz",
+      "integrity": "sha512-2TKn4hBy1rHf5/6jVubiLdq09BivmhPq3QexH40YXIOnszYGVx0HKP4bW03bTQzrh7GIqMFbNYDkSXlFREWgmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:watch": "npm run build -- --watch",
     "lint": "eslint .",
     "start": "cross-env SINGLE_START=example npm run dev",
+    "start:styles": "cross-env SINGLE_START=styles npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
     "test": "karma start karma.config.js",
     "test:distro": "karma start test/distro/karma.config.js",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "chai": "^6.2.2",
     "cross-env": "^10.1.0",
     "del-cli": "^7.0.0",
-    "diagram-js": "^15.24.0",
+    "diagram-js": "^15.25.0",
     "eslint": "^9.39.5",
     "eslint-plugin-bpmn-io": "^2.3.1",
     "eslint-plugin-import": "^2.32.0",

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -23,6 +23,7 @@
   --color-blue-218-100-74: hsl(218, 100%, 74%);
   --color-blue-205-100-85: hsl(205, 100%, 85%);
   --color-blue-205-100-95: hsl(205, 100%, 95%);
+  --color-blue-205-100-40-a35: hsla(205, 100%, 40%, 0.35);
   --color-blue-205-100-50-a35: hsla(205, 100%, 50%, 0.35);
 
   --color-red-360-100-40: hsl(360, 100%, 40%);
@@ -47,7 +48,11 @@
   --text-base-color: var(--color-grey-225-10-15);
   --text-error-color: var(--color-red-360-100-45);
   --text-warning-color: var(--color-amber-39-100-33);
-  --link-color: var(--color-blue-205-100-50);
+
+  --accent-color: var(--color-blue-205-100-40);
+  --accent-hover-color: var(--color-blue-205-100-35);
+
+  --link-color: var(--accent-color);
 
   --description-color: var(--color-grey-225-10-35);
   --description-code-background-color: var(--color-grey-225-10-97);
@@ -71,7 +76,7 @@
 
   --add-entry-fill-color: var(--color-grey-225-10-35);
   --add-entry-hover-fill-color: var(--color-white);
-  --add-entry-hover-background-color: var(--color-blue-205-100-50);
+  --add-entry-hover-background-color: var(--accent-color);
   --add-entry-label-color: var(--color-white);
 
   --remove-entry-fill-color: var(--color-red-360-100-45);
@@ -86,6 +91,11 @@
   --error-badge-background-color: var(--color-red-360-100-45);
   --error-badge-color: var(--color-white);
   --error-badge-hover-background-color: var(--color-red-360-100-40);
+
+  --accent-badge-background-color: var(--accent-color);
+  --accent-badge-color: var(--color-white);
+  --accent-badge-fill-color: var(--color-white);
+  --accent-badge-hover-background-color: var(--accent-hover-color);
 
   --dot-color: var(--color-grey-225-10-35);
   --dot-color-error: var(--error-badge-background-color);
@@ -102,11 +112,11 @@
   --checkbox-border-radius: 4px;
   --checkbox-border-color: var(--input-border-color);
   --checkbox-background-color: var(--input-background-color);
-  --checkbox-checked-background-color: var(--color-blue-205-100-50);
-  --checkbox-checked-border-color: var(--color-blue-205-100-50);
+  --checkbox-checked-background-color: var(--accent-color);
+  --checkbox-checked-border-color: var(--accent-color);
 
   --input-focus-background-color: var(--color-blue-205-100-95);
-  --input-focus-border-color: var(--color-blue-205-100-50);
+  --input-focus-border-color: var(--accent-color);
 
   --focus-outline-color: var(--color-blue-205-100-40);
 
@@ -114,7 +124,7 @@
    * Focus ring — reusable, themeable primitive shared by inputs, checkboxes,
    * toggles and any control with the `bio-properties-panel-focus-ring` class.
    */
-  --focus-ring-color: var(--color-blue-205-100-50-a35);
+  --focus-ring-color: var(--color-blue-205-100-40-a35);
   --focus-ring-error-color: var(--color-red-360-100-45-a35);
   --focus-ring-warning-color: var(--color-amber-35-84-62-a35);
   --focus-ring-width: 2px;
@@ -133,7 +143,7 @@
   --input-disabled-background-color: var(--color-grey-225-10-97);
   --input-disabled-border-color: var(--color-grey-225-10-90);
 
-  --toggle-switch-on-background-color: var(--color-blue-205-100-50);
+  --toggle-switch-on-background-color: var(--accent-color);
   --toggle-switch-off-background-color: var(--color-grey-225-10-75);
   --toggle-switch-switcher-background-color: var(--color-white);
 
@@ -142,10 +152,10 @@
 
   --list-entry-dot-background-color: var(--color-grey-225-10-35);
   --list-entry-header-button-fill-color: var(--color-grey-225-10-35);
-  --list-entry-add-entry-empty-background-color: var(--color-blue-205-100-50);
-  --list-entry-add-entry-empty-hover-background-color: var(--color-blue-205-100-45);
+  --list-entry-add-entry-empty-background-color: var(--accent-color);
+  --list-entry-add-entry-empty-hover-background-color: var(--accent-hover-color);
   --list-entry-add-entry-label-color: var(--color-white);
-  --list-entry-add-entry-background-color: var(--color-blue-205-100-50);
+  --list-entry-add-entry-background-color: var(--accent-color);
   --list-entry-add-entry-fill-color: var(--color-white);
 
   --dropdown-item-background-color: var(--color-white);
@@ -153,7 +163,7 @@
   --dropdown-separator-background-color: var(--color-grey-225-10-75);
 
   --feel-background-color: transparent;
-  --feel-active-color: var(--color-blue-205-100-45);
+  --feel-active-color: var(--accent-color);
   --feel-inactive-color: var(--color-grey-225-10-35);
   --feel-hover-color: var(--color-grey-225-10-15);
   --feel-hover-background-color: var(--color-grey-225-10-97);
@@ -466,6 +476,11 @@
 .bio-properties-panel-list-badge--error {
   --list-badge-background-color: var(--error-badge-background-color);
   --list-badge-color: var(--error-badge-color);
+}
+
+.bio-properties-panel-list-badge--accent {
+  --list-badge-background-color: var(--accent-badge-background-color);
+  --list-badge-color: var(--accent-badge-color);
 }
 
 /**

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -87,7 +87,7 @@ insertCSS('example.css', `
   }
 `);
 
-const singleStart = window.__env__?.SINGLE_START;
+const singleStart = window.__env__?.SINGLE_START === 'example';
 
 describe('Example', function() {
 

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -51,7 +51,7 @@ insertCSS('styling.spec.css', `
   }
 `);
 
-const singleStart = window.__env__?.SINGLE_START;
+const singleStart = window.__env__?.SINGLE_START === 'styles';
 
 
 describe('styling (CSS)', function() {
@@ -68,8 +68,7 @@ describe('styling (CSS)', function() {
   });
 
 
-  // visual playground for manual review (un-skip and open the Karma debug page)
-  it.skip('severity states (visual)', function() {
+  (singleStart ? it.only : it.skip)('severity states (visual)', function() {
     container.innerHTML = `
       <div class="bio-properties-panel-styles">
         <section class="bio-properties-panel-styles-section">

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -4,9 +4,54 @@ import TestContainer from 'mocha-test-container-support';
 
 import axe from 'axe-core';
 
-import { insertCoreStyles } from 'test/TestHelper';
+import {
+  insertCoreStyles,
+  insertCSS
+} from 'test/TestHelper';
 
 insertCoreStyles();
+
+insertCSS('styling.spec.css', `
+  .bio-properties-panel-styles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 16px;
+    align-items: start;
+  }
+
+  .bio-properties-panel-styles-section {
+    display: grid;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .bio-properties-panel-styles-section-title {
+    margin: 0 0 4px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--group-bottom-border-color);
+    font-size: var(--text-size-base);
+    font-weight: 500;
+  }
+
+  .bio-properties-panel-styles-field {
+    display: grid;
+    gap: 4px;
+  }
+
+  .bio-properties-panel-styles-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 22px;
+  }
+
+  .bio-properties-panel-styles-swatch {
+    padding: 2px 8px;
+    border-radius: 11px;
+  }
+`);
+
+const singleStart = window.__env__?.SINGLE_START;
 
 
 describe('styling (CSS)', function() {
@@ -16,7 +61,7 @@ describe('styling (CSS)', function() {
   beforeEach(function() {
     container = document.createElement('div');
     container.classList.add('bio-properties-panel');
-    container.style.width = '280px';
+    container.style.width = '100%';
     container.style.padding = '10px';
 
     TestContainer.get(this).appendChild(container);
@@ -26,70 +71,132 @@ describe('styling (CSS)', function() {
   // visual playground for manual review (un-skip and open the Karma debug page)
   it.skip('severity states (visual)', function() {
     container.innerHTML = `
-      <div class="bio-properties-panel-entry has-warning" style="margin-bottom: 16px">
-        <label class="bio-properties-panel-label">has-warning input</label>
-        <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
-        <div class="bio-properties-panel-warning">warning message</div>
-      </div>
+      <div class="bio-properties-panel-styles">
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Inputs</h2>
+          <div class="bio-properties-panel-entry">
+            <label class="bio-properties-panel-label">Text</label>
+            <input class="bio-properties-panel-input" type="text" value="Text input" />
+          </div>
+          <div class="bio-properties-panel-entry">
+            <label class="bio-properties-panel-label">Select</label>
+            <select class="bio-properties-panel-input"><option>Select input</option></select>
+          </div>
+          <div class="bio-properties-panel-entry">
+            <label class="bio-properties-panel-label">Text area</label>
+            <textarea class="bio-properties-panel-input">Text area</textarea>
+          </div>
+          <div class="bio-properties-panel-entry bio-properties-panel-checkbox-entry">
+            <label class="bio-properties-panel-checkbox">
+              <input class="bio-properties-panel-input" type="checkbox" checked />
+              <span class="bio-properties-panel-label">Checkbox</span>
+            </label>
+          </div>
+        </section>
 
-      <div class="bio-properties-panel-entry has-error" style="margin-bottom: 16px">
-        <label class="bio-properties-panel-label">has-error input</label>
-        <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
-        <div class="bio-properties-panel-error">error message</div>
-      </div>
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Validation</h2>
+          <div class="bio-properties-panel-entry has-warning">
+            <label class="bio-properties-panel-label">Warning</label>
+            <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="Focus me" />
+            <div class="bio-properties-panel-warning">Warning message</div>
+          </div>
+          <div class="bio-properties-panel-entry has-error">
+            <label class="bio-properties-panel-label">Error</label>
+            <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="Focus me" />
+            <div class="bio-properties-panel-error">Error message</div>
+          </div>
+          <div class="bio-properties-panel-entry has-warning has-error">
+            <label class="bio-properties-panel-label">Warning + error</label>
+            <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="Focus me" />
+            <div class="bio-properties-panel-warning">Warning message</div>
+            <div class="bio-properties-panel-error">Error message</div>
+          </div>
+        </section>
 
-      <div class="bio-properties-panel-entry has-warning has-error" style="margin-bottom: 16px">
-        <label class="bio-properties-panel-label">has-warning + has-error (error wins)</label>
-        <input class="bio-properties-panel-input bio-properties-panel-focus-ring" type="text" value="focus me" />
-        <div class="bio-properties-panel-warning">warning message</div>
-        <div class="bio-properties-panel-error">error message</div>
-      </div>
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Status</h2>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">Dots</span>
+            <div class="bio-properties-panel-styles-row">
+              <span class="bio-properties-panel-dot"></span>
+              <span class="bio-properties-panel-dot bio-properties-panel-dot--warning"></span>
+              <span class="bio-properties-panel-dot bio-properties-panel-dot--error"></span>
+            </div>
+          </div>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">List badges</span>
+            <div class="bio-properties-panel-styles-row">
+              <span class="bio-properties-panel-list-badge">3</span>
+              <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning">3</span>
+              <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error">3</span>
+              <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--accent">Applied</span>
+            </div>
+          </div>
+        </section>
 
-      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px; margin-bottom: 16px">
-        <label class="bio-properties-panel-label">dots</label>
-        <span class="bio-properties-panel-dot"></span>
-        <span class="bio-properties-panel-dot bio-properties-panel-dot--warning"></span>
-        <span class="bio-properties-panel-dot bio-properties-panel-dot--error"></span>
-      </div>
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Actions</h2>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">Create item</span>
+            <div class="bio-properties-panel-styles-row">
+              <button class="bio-properties-panel-group-header-button bio-properties-panel-add-entry" type="button" title="Create new list item">
+                <svg viewBox="0 0 16 16" width="16" height="16"><path d="M7 2h2v5h5v2H9v5H7V9H2V7h5z" /></svg>
+              </button>
+              <span class="bio-properties-panel-list-badge">2</span>
+            </div>
+          </div>
+        </section>
 
-      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px; margin-bottom: 16px">
-        <label class="bio-properties-panel-label">list badges</label>
-        <span class="bio-properties-panel-list-badge">3</span>
-        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning">3</span>
-        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error">3</span>
-        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning">99</span>
-        <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error">99</span>
-      </div>
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Badge colors</h2>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">Default</span>
+            <div class="bio-properties-panel-styles-row">
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--warning-badge-background-color); color: var(--warning-badge-color)">Warning</span>
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--error-badge-background-color); color: var(--error-badge-color)">Error</span>
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--accent-badge-background-color); color: var(--accent-badge-color)">Accent</span>
+            </div>
+          </div>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">Hover</span>
+            <div class="bio-properties-panel-styles-row">
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--warning-badge-hover-background-color); color: var(--warning-badge-color)">Warning</span>
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">Error</span>
+              <span class="bio-properties-panel-styles-swatch" style="background: var(--accent-badge-hover-background-color); color: var(--accent-badge-color)">Accent</span>
+            </div>
+          </div>
+        </section>
 
-      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px">
-        <label class="bio-properties-panel-label">badge token swatches (on-surface text)</label>
-        <span style="padding: 2px 8px; border-radius: 11px; background: var(--warning-badge-background-color); color: var(--warning-badge-color)">Aa 3</span>
-        <span style="padding: 2px 8px; border-radius: 11px; background: var(--error-badge-background-color); color: var(--error-badge-color)">Aa 3</span>
-        <span style="padding: 2px 8px; border-radius: 11px; background: var(--list-badge-background-color); color: var(--list-badge-color)">Aa 3</span>
-      </div>
-
-      <div class="bio-properties-panel-entry" style="display: flex; align-items: center; gap: 6px">
-        <label class="bio-properties-panel-label">badge hover swatches</label>
-        <span style="padding: 2px 8px; border-radius: 11px; background: var(--warning-badge-hover-background-color); color: var(--warning-badge-color)">Aa 3</span>
-        <span style="padding: 2px 8px; border-radius: 11px; background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">Aa 3</span>
+        <section class="bio-properties-panel-styles-section">
+          <h2 class="bio-properties-panel-styles-section-title">Links</h2>
+          <div class="bio-properties-panel-styles-field">
+            <span class="bio-properties-panel-label">Description</span>
+            <div class="bio-properties-panel-description">Configure this via the <a href="#">Documentation</a>.</div>
+          </div>
+        </section>
       </div>
     `;
   });
 
 
   // enforce WCAG AA text contrast so a regression (e.g. white-on-amber) fails CI
-  it('list badges meet WCAG AA text contrast', async function() {
+  it('badges and links meet WCAG AA text contrast', async function() {
 
     // given
     this.timeout(5000);
 
     container.innerHTML = `
       <span class="bio-properties-panel-list-badge" data-variant="neutral">3</span>
+      <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--accent" data-variant="accent">3</span>
       <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--warning" data-variant="warning">3</span>
       <span class="bio-properties-panel-list-badge bio-properties-panel-list-badge--error" data-variant="error">3</span>
 
+      <span data-variant="accent-hover" style="background: var(--accent-badge-hover-background-color); color: var(--accent-badge-color)">3</span>
       <span data-variant="warning-hover" style="background: var(--warning-badge-hover-background-color); color: var(--warning-badge-color)">3</span>
       <span data-variant="error-hover" style="background: var(--error-badge-hover-background-color); color: var(--error-badge-color)">3</span>
+
+      <div class="bio-properties-panel-description">Configure this via the <a href="#" data-variant="link">documentation</a>.</div>
     `;
 
     // when


### PR DESCRIPTION
### Proposed Changes

Introduce a WCAG AA compliant primary accent layer. The old accent `--color-blue-205-100-50` is **3.12:1** on white and fails WCAG AA [1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) — a problem for links and badges, which are text:

<img width="1627" height="809" alt="image" src="https://github.com/user-attachments/assets/727e6e5a-a8c3-4167-ab42-1fe86ebb44ad" />

- Add a semantic accent layer: `--accent-color` (`-40`, **4.66:1**) and `--accent-hover-color` (`-35`, 5.78:1).
- Add an `--accent-badge-*` set (`background-color`, `color`, `fill-color`, `hover-background-color`) mirroring the existing `--warning-badge-*` / `--error-badge-*`, so downstream consumers (e.g. element-templates' "Applied" badge) build on a shared, themeable token instead of raw palette values.
- Repoint `--link-color`, `--checkbox-checked-*`, `--input-focus-border-color`, `--toggle-switch-on-background-color`, `--add-entry-hover-background-color`, `--list-entry-add-entry-*` and `--feel-active-color` onto the accent tokens.
- Re-derive `--focus-ring-color` from `--color-blue-205-100-40-a35` (new primitive), keeping the ring == its state's border-at-0.35-alpha invariant already used by the error/warning rings.
- `-50` / `-50-a35` primitives retained for theme back-compat.
- Extend the styling visual playground (`test/spec/styling.spec.js`) with an `--accent` list-badge variant, accent badge swatches and links, and assert accent/link WCAG AA contrast via an axe `color-contrast` regression test.

Related to https://github.com/camunda/camunda-modeler/issues/6135

Part of a coordinated cross-repo rollout, released bottom-up: diagram-js → bpmn-js → properties-panel → element-templates.

### Steps to try out

```
npx @bpmn-io/sr bpmn-io/properties-panel#accessible-primary-accent
```

Description links, checked checkboxes, toggles, FEEL-active fields and focus rings now use the accessible accent. Or review every state at once in the visual playground:

```
npm run start:styles
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
