### PR TITLE
feat: source variables from @bpmn-io/theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.7",
         "@babel/plugin-transform-react-jsx": "^7.29.7",
+        "@bpmn-io/theme": "^0.1.0",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -578,6 +579,16 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.7.2"
+      }
+    },
+    "node_modules/@bpmn-io/theme": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/theme/-/theme-0.1.0.tgz",
+      "integrity": "sha512-QRvYAVRiJLTu1gyzKTBMHvcLb2wOjSpfS80c9VkEhnjX0HC+qoImd83kFUPQ0Jdzsen+b/OatY/ms7iWIHqCsw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bpmn-io-theme-validate": "bin/validate.js"
       }
     },
     "node_modules/@camunda/feel-builtins": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "preact"
   ],
   "scripts": {
-    "all": "run-s lint clean build test test:distro",
+    "all": "run-s lint lint:theme clean build test test:distro",
     "clean": "del-cli preact dist",
     "build": "rollup -c --bundleConfigAsCjs",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint .",
+    "lint:theme": "bpmn-io-theme-validate src/assets/properties-panel.css",
     "start": "cross-env SINGLE_START=example npm run dev",
     "start:styles": "cross-env SINGLE_START=styles npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
@@ -58,6 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@babel/plugin-transform-react-jsx": "^7.29.7",
+    "@bpmn-io/theme": "^0.0.0",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@babel/plugin-transform-react-jsx": "^7.29.7",
-    "@bpmn-io/theme": "^0.0.0",
+    "@bpmn-io/theme": "^0.1.0",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/src/PropertiesPanel.js
+++ b/src/PropertiesPanel.js
@@ -247,7 +247,7 @@ export default function PropertiesPanel(props) {
           <TooltipContext.Provider value={ tooltipContext }>
             <LayoutContext.Provider value={ layoutContext }>
               <EventContext.Provider value={ eventContext }>
-                <div class="bio-properties-panel">
+                <div class="bio-properties-panel bio-theme-parent">
                   { headerProvider ? (
                     <Header
                       element={ element }

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1,181 +1,185 @@
 /**
- * Theming
+ * Semantic tokens, copied from `@bpmn-io/theme` to style the components
+ * according to this theme.
+ *
+ * Names and values of the tokens should stay intact with the `@bpmn-io/theme`
+ * source of truth, to ensure matching styles and allow overrides with an
+ * alternative theme.
  */
- .bio-properties-panel,
- .djs-parent {
-  --color-grey-225-10-15: hsl(225, 10%, 15%);
-  --color-grey-225-10-35: hsl(225, 10%, 35%);
-  --color-grey-225-10-55: hsl(225, 10%, 55%);
-  --color-grey-225-10-75: hsl(225, 10%, 75%);
-  --color-grey-225-10-80: hsl(225, 10%, 80%);
-  --color-grey-225-10-85: hsl(225, 10%, 85%);
-  --color-grey-225-10-90: hsl(225, 10%, 90%);
-  --color-grey-225-10-95: hsl(225, 10%, 95%);
-  --color-grey-225-10-97: hsl(225, 10%, 97%);
-  --color-grey-0-0-22: hsl(0, 0%, 22%);
-
-  --color-blue-205-100-35: hsl(205, 100%, 35%);
-  --color-blue-205-100-40: hsl(205, 100%, 40%);
-  --color-green-150-86-44: hsl(150, 86%, 44%);
-  --color-blue-205-100-45: hsl(205, 100%, 45%);
-  --color-blue-205-100-50: hsl(205, 100%, 50%);
-  --color-blue-219-99-53: hsl(219, 99%, 53%);
-  --color-blue-218-100-74: hsl(218, 100%, 74%);
-  --color-blue-205-100-85: hsl(205, 100%, 85%);
-  --color-blue-205-100-95: hsl(205, 100%, 95%);
-  --color-blue-205-100-40-a35: hsla(205, 100%, 40%, 0.35);
-  --color-blue-205-100-50-a35: hsla(205, 100%, 50%, 0.35);
-
-  --color-red-360-100-40: hsl(360, 100%, 40%);
-  --color-red-360-100-45: hsl(360, 100%, 45%);
-  --color-red-360-100-92: hsl(360, 100%, 92%);
-  --color-red-360-100-97: hsl(360, 100%, 97%);
-  --color-red-360-100-45-a35: hsla(360, 100%, 45%, 0.35);
-
-  --color-amber-39-100-33: hsl(39, 100%, 33%);
-  --color-amber-35-84-62: hsl(35, 84%, 62%);
-  --color-amber-35-84-57: hsl(35, 84%, 57%);
-  --color-amber-38-100-96: hsl(38, 100%, 96%);
-  --color-amber-35-84-62-a35: hsla(35, 84%, 62%, 0.35);
-
-  --color-white: white;
-  --color-black: black;
-  --color-transparent: transparent;
-
+.bio-theme-parent {
+  --bio-surface: hsl(0, 0%, 100%);
+  --bio-surface-overlay: hsl(0, 0%, 100%);
+  --bio-surface-subtle: hsl(225, 10%, 97%);
+  --bio-surface-medium: hsl(225, 10%, 95%);
+  --bio-surface-strong: hsl(225, 10%, 90%);
+  --bio-surface-inverted: hsl(0, 0%, 22%);
+  --bio-text: hsl(225, 10%, 15%);
+  --bio-text-subtle: hsl(225, 10%, 35%);
+  --bio-text-subtlest: hsl(225, 10%, 55%);
+  --bio-text-on-primary: hsl(0, 0%, 100%);
+  --bio-text-on-inverted: hsl(0, 0%, 100%);
+  --bio-border: hsl(225, 10%, 75%);
+  --bio-border-subtle: hsl(225, 10%, 85%);
+  --bio-border-disabled: hsl(225, 10%, 90%);
+  --bio-border-input: hsl(225, 10%, 75%);
+  --bio-primary: hsl(205, 100%, 40%);
+  --bio-primary-hover: hsl(205, 100%, 35%);
+  --bio-primary-surface: hsl(205, 100%, 95%);
+  --bio-primary-surface-strong: hsl(205, 100%, 85%);
+  --bio-neutral: hsl(225, 10%, 35%);
+  --bio-danger: hsl(360, 100%, 45%);
+  --bio-danger-hover: hsl(360, 100%, 40%);
+  --bio-danger-surface: hsl(360, 100%, 92%);
+  --bio-danger-surface-subtle: hsl(360, 100%, 97%);
+  --bio-warning: hsl(35, 84%, 62%);
+  --bio-warning-hover: hsl(35, 84%, 57%);
+  --bio-warning-text: hsl(39, 100%, 33%);
+  --bio-warning-surface: hsl(38, 100%, 96%);
+  --bio-info: hsl(205, 100%, 40%);
+  --bio-info-on-inverted: hsl(218, 100%, 74%);
+  --bio-focus: hsl(205, 100%, 40%);
+  --bio-focus-ring: hsla(205, 100%, 40%, 0.35);
+  --bio-focus-ring-danger: hsla(360, 100%, 45%, 0.35);
+  --bio-focus-ring-warning: hsla(35, 84%, 62%, 0.35);
+  --bio-shadow: hsla(0, 0%, 0%, 30%);
+  --bio-shadow-subtle: hsla(0, 0%, 0%, 10%);
+  --bio-radius-sm: 2px;
+  --bio-radius-lg: 4px;
 }
 
 .bio-properties-panel {
-  --text-base-color: var(--color-grey-225-10-15);
-  --text-error-color: var(--color-red-360-100-45);
-  --text-warning-color: var(--color-amber-39-100-33);
+  --text-base-color: var(--bio-text);
+  --text-error-color: var(--bio-danger);
+  --text-warning-color: var(--bio-warning-text);
 
-  --accent-color: var(--color-blue-205-100-40);
-  --accent-hover-color: var(--color-blue-205-100-35);
+  --accent-color: var(--bio-primary);
+  --accent-hover-color: var(--bio-primary-hover);
 
-  --link-color: var(--accent-color);
+  --link-color: var(--bio-info);
 
-  --description-color: var(--color-grey-225-10-35);
-  --description-code-background-color: var(--color-grey-225-10-97);
-  --description-code-border-color: var(--color-grey-225-10-85);
-  --description-list-item-color: var(--color-grey-225-10-35);
+  --description-color: var(--bio-text-subtle);
+  --description-code-background-color: var(--bio-surface-subtle);
+  --description-code-border-color: var(--bio-border-subtle);
+  --description-list-item-color: var(--bio-text-subtle);
 
-  --tooltip-underline-color: var(--color-grey-225-10-55);
+  --tooltip-underline-color: var(--bio-text-subtlest);
 
-  --placeholder-color: var(--color-grey-225-10-35);
-  --placeholder-background-color: var(--color-grey-225-10-95);
+  --placeholder-color: var(--bio-text-subtle);
+  --placeholder-background-color: var(--bio-surface-medium);
 
-  --header-background-color: var(--color-grey-225-10-95);
-  --header-icon-fill-color: var(--color-grey-225-10-15);
-  --header-bottom-border-color: var(--color-grey-225-10-75);
+  --header-background-color: var(--bio-surface-medium);
+  --header-icon-fill-color: var(--bio-text);
+  --header-bottom-border-color: var(--bio-border);
 
-  --group-background-color: var(--color-white);
-  --group-bottom-border-color: var(--color-grey-225-10-75);
+  --group-background-color: var(--bio-surface);
+  --group-bottom-border-color: var(--bio-border);
 
-  --sticky-group-background-color: var(--color-grey-225-10-95);
-  --sticky-group-bottom-border-color: var(--color-grey-225-10-75);
+  --sticky-group-background-color: var(--bio-surface-medium);
+  --sticky-list-entry-background-color: var(--bio-surface);
+  --sticky-group-bottom-border-color: var(--bio-border);
 
-  --add-entry-fill-color: var(--color-grey-225-10-35);
-  --add-entry-hover-fill-color: var(--color-white);
-  --add-entry-hover-background-color: var(--accent-color);
-  --add-entry-label-color: var(--color-white);
+  --add-entry-fill-color: var(--bio-text-subtle);
+  --add-entry-hover-fill-color: var(--bio-text-on-primary);
+  --add-entry-hover-background-color: var(--bio-primary);
+  --add-entry-label-color: var(--bio-text-on-primary);
 
-  --remove-entry-fill-color: var(--color-red-360-100-45);
-  --remove-entry-hover-background-color: var(--color-red-360-100-92);
+  --remove-entry-fill-color: var(--bio-danger);
+  --remove-entry-hover-background-color: var(--bio-danger-surface);
 
-  --arrow-fill-color: var(--color-grey-225-10-35);
-  --arrow-hover-background-color: var(--color-grey-225-10-95);
+  --arrow-fill-color: var(--bio-text-subtle);
+  --arrow-hover-background-color: var(--bio-surface-medium);
 
-  --warning-badge-background-color: var(--color-amber-35-84-62);
-  --warning-badge-color: var(--color-grey-225-10-15);
-  --warning-badge-hover-background-color: var(--color-amber-35-84-57);
-  --error-badge-background-color: var(--color-red-360-100-45);
-  --error-badge-color: var(--color-white);
-  --error-badge-hover-background-color: var(--color-red-360-100-40);
+  --warning-badge-background-color: var(--bio-warning);
+  --warning-badge-color: var(--bio-text);
+  --warning-badge-hover-background-color: var(--bio-warning-hover);
+  --error-badge-background-color: var(--bio-danger);
+  --error-badge-color: var(--bio-text-on-primary);
+  --error-badge-hover-background-color: var(--bio-danger-hover);
 
   --accent-badge-background-color: var(--accent-color);
-  --accent-badge-color: var(--color-white);
-  --accent-badge-fill-color: var(--color-white);
+  --accent-badge-color: var(--bio-text-on-primary);
+  --accent-badge-fill-color: var(--bio-text-on-primary);
   --accent-badge-hover-background-color: var(--accent-hover-color);
 
-  --dot-color: var(--color-grey-225-10-35);
+  --dot-color: var(--bio-neutral);
   --dot-color-error: var(--error-badge-background-color);
   --dot-color-warning: var(--warning-badge-background-color);
 
-  --list-badge-color: var(--color-white);
-  --list-badge-background-color: var(--color-grey-225-10-35);
+  --list-badge-color: var(--bio-text-on-primary);
+  --list-badge-background-color: var(--bio-neutral);
 
-  --input-background-color: var(--color-grey-225-10-97);
-  --input-border-color: var(--color-grey-225-10-75);
-  --input-border-radius: 2px;
+  --input-background-color: var(--bio-surface-subtle);
+  --input-border-color: var(--bio-border-input);
+  --input-border-radius: var(--bio-radius-sm);
 
   --checkbox-size: 14px;
-  --checkbox-border-radius: 4px;
+  --checkbox-border-radius: var(--bio-radius-lg);
   --checkbox-border-color: var(--input-border-color);
   --checkbox-background-color: var(--input-background-color);
-  --checkbox-checked-background-color: var(--accent-color);
-  --checkbox-checked-border-color: var(--accent-color);
+  --checkbox-checked-background-color: var(--bio-primary);
+  --checkbox-checked-border-color: var(--bio-primary);
 
-  --input-focus-background-color: var(--color-blue-205-100-95);
-  --input-focus-border-color: var(--accent-color);
+  --input-focus-background-color: var(--bio-primary-surface);
+  --input-focus-border-color: var(--bio-primary);
 
-  --focus-outline-color: var(--color-blue-205-100-40);
+  --focus-outline-color: var(--bio-focus);
 
   /**
    * Focus ring — reusable, themeable primitive shared by inputs, checkboxes,
    * toggles and any control with the `bio-properties-panel-focus-ring` class.
    */
-  --focus-ring-color: var(--color-blue-205-100-40-a35);
-  --focus-ring-error-color: var(--color-red-360-100-45-a35);
-  --focus-ring-warning-color: var(--color-amber-35-84-62-a35);
+  --focus-ring-color: var(--bio-focus-ring);
+  --focus-ring-error-color: var(--bio-focus-ring-danger);
+  --focus-ring-warning-color: var(--bio-focus-ring-warning);
   --focus-ring-width: 2px;
   --focus-ring-offset: 0px;
   --focus-ring-offset-color: var(--group-background-color);
 
-  --input-error-background-color: var(--color-red-360-100-97);
-  --input-error-border-color: var(--color-red-360-100-45);
-  --input-error-focus-border-color: var(--color-red-360-100-45);
+  --input-error-background-color: var(--bio-danger-surface-subtle);
+  --input-error-border-color: var(--bio-danger);
+  --input-error-focus-border-color: var(--bio-danger);
 
-  --input-warning-background-color: var(--color-amber-38-100-96);
-  --input-warning-border-color: var(--color-amber-35-84-62);
-  --input-warning-focus-border-color: var(--color-amber-35-84-62);
+  --input-warning-background-color: var(--bio-warning-surface);
+  --input-warning-border-color: var(--bio-warning);
+  --input-warning-focus-border-color: var(--bio-warning);
 
-  --input-disabled-color: var(--color-grey-225-10-55);
-  --input-disabled-background-color: var(--color-grey-225-10-97);
-  --input-disabled-border-color: var(--color-grey-225-10-90);
+  --input-disabled-color: var(--bio-text-subtlest);
+  --input-disabled-background-color: var(--bio-surface-subtle);
+  --input-disabled-border-color: var(--bio-border-disabled);
 
-  --toggle-switch-on-background-color: var(--accent-color);
-  --toggle-switch-off-background-color: var(--color-grey-225-10-75);
-  --toggle-switch-switcher-background-color: var(--color-white);
+  --toggle-switch-on-background-color: var(--bio-primary);
+  --toggle-switch-off-background-color: var(--bio-border-input);
+  --toggle-switch-switcher-background-color: var(--bio-surface);
 
-  --side-line-background-color: var(--color-grey-225-10-35);
-  --side-line-extension-background-color: var(--color-grey-225-10-35);
+  --side-line-background-color: var(--bio-text-subtle);
+  --side-line-extension-background-color: var(--bio-text-subtle);
 
-  --list-entry-dot-background-color: var(--color-grey-225-10-35);
-  --list-entry-header-button-fill-color: var(--color-grey-225-10-35);
-  --list-entry-add-entry-empty-background-color: var(--accent-color);
-  --list-entry-add-entry-empty-hover-background-color: var(--accent-hover-color);
-  --list-entry-add-entry-label-color: var(--color-white);
-  --list-entry-add-entry-background-color: var(--accent-color);
-  --list-entry-add-entry-fill-color: var(--color-white);
+  --list-entry-dot-background-color: var(--bio-neutral);
+  --list-entry-header-button-fill-color: var(--bio-text-subtle);
+  --list-entry-add-entry-empty-background-color: var(--bio-primary);
+  --list-entry-add-entry-empty-hover-background-color: var(--bio-primary-hover);
+  --list-entry-add-entry-label-color: var(--bio-text-on-primary);
+  --list-entry-add-entry-background-color: var(--bio-primary);
+  --list-entry-add-entry-fill-color: var(--bio-text-on-primary);
 
-  --dropdown-item-background-color: var(--color-white);
-  --dropdown-item-hover-background-color: var(--color-grey-225-10-95);
-  --dropdown-separator-background-color: var(--color-grey-225-10-75);
+  --dropdown-item-background-color: var(--bio-surface-overlay);
+  --dropdown-item-hover-background-color: var(--bio-surface-medium);
+  --dropdown-separator-background-color: var(--bio-border);
 
   --feel-background-color: transparent;
   --feel-active-color: var(--accent-color);
-  --feel-inactive-color: var(--color-grey-225-10-35);
-  --feel-hover-color: var(--color-grey-225-10-15);
-  --feel-hover-background-color: var(--color-grey-225-10-97);
+  --feel-inactive-color: var(--bio-text-subtle);
+  --feel-hover-color: var(--bio-text);
+  --feel-hover-background-color: var(--bio-surface-subtle);
   --feel-active-background-color: transparent;
-  --feel-required-color: var(--color-grey-225-10-55);
-  --feel-open-popup-color: hsla(0, 0%, 32%, 1);
-  --feel-open-popup-background-color: var(--color-white);
-  --feel-open-popup-hover-color: hsla(219, 99%, 53%, 1);
+  --feel-required-color: var(--bio-text-subtlest);
+  --feel-open-popup-color: var(--bio-text-subtle);
+  --feel-open-popup-background-color: var(--bio-surface-overlay);
+  --feel-open-popup-hover-color: var(--bio-primary);
 
-  --feel-indicator-background-color: var(--color-grey-225-10-90);
+  --feel-indicator-background-color: var(--bio-surface-strong);
 
-  --feelers-select-color:  var(--color-blue-205-100-85);
+  --feelers-select-color: var(--bio-primary-surface-strong);
 
   --text-size-base: 14px;
   --text-size-small: 13px;
@@ -1048,7 +1052,7 @@ textarea.bio-properties-panel-input.auto-resize {
 }
 
 .bio-properties-panel-list-entry-header.sticky {
-  background-color: var(--color-white);
+  background-color: var(--sticky-list-entry-background-color);
   border-bottom: 1px solid var(--sticky-group-bottom-border-color);
   top: 32px;
   z-index: 9;
@@ -1202,7 +1206,7 @@ textarea.bio-properties-panel-input.auto-resize {
 
   padding: 8px 0;
 
-  box-shadow: 0 1px 4px 0 var(--color-grey-225-10-85), 0 2px 16px 0 var(--color-grey-225-10-75)
+  box-shadow: 0 1px 4px 0 var(--bio-shadow-subtle), 0 2px 16px 0 var(--bio-shadow)
 }
 
 .bio-properties-panel-dropdown-button__menu-item {
@@ -1427,13 +1431,14 @@ textarea.bio-properties-panel-input.auto-resize {
 }
 
 .bio-properties-panel-tooltip {
-  --tooltip-background-color: var(--color-grey-0-0-22);
-  --tooltip-link: var(--color-blue-218-100-74);
-  --tooltip-code-background-color: var(--color-grey-225-10-97);
-  --tooltip-code-border-color: var(--color-grey-225-10-85);
+  --tooltip-background-color: var(--bio-surface-inverted);
+  --tooltip-color: var(--bio-text-on-inverted);
+  --tooltip-link: var(--bio-info-on-inverted);
+  --tooltip-code-background-color: var(--bio-surface-subtle);
+  --tooltip-code-border-color: var(--bio-border-subtle);
 
   display: flex;
-  color: var(--color-white, white);
+  color: var(--tooltip-color);
   position: fixed;
   z-index: 1001;
   max-width: 300px;
@@ -1549,13 +1554,13 @@ textarea.bio-properties-panel-input.auto-resize {
 }
 
 .bio-properties-panel-popup {
-  --popup-background-color: hsla(0, 0%, 96%, 1);
-  --popup-header-background-color: white;
-  --popup-font-color: hsla(0, 0%, 0%, 1);
-  --popup-title-color: hsla(0, 0%, 0%, 1);
+  --popup-background-color: var(--bio-surface-subtle);
+  --popup-header-background-color: var(--bio-surface);
+  --popup-font-color: var(--bio-text);
+  --popup-title-color: var(--bio-text);
 
-  --feel-popup-close-background-color: hsla(219, 99%, 53%, 1);
-  --feel-popup-gutters-background-color: hsla(0, 0%, 90%, 1);
+  --feel-popup-close-background-color: var(--bio-primary);
+  --feel-popup-gutters-background-color: var(--bio-surface-strong);
 
   position: fixed;
   display: flex;

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1758,7 +1758,7 @@ textarea.bio-properties-panel-input.auto-resize {
   display: none;
   background: none;
   border: none;
-  color: var(--feel-open-popup-color);
+  fill: var(--feel-open-popup-color);
   cursor: pointer;
 }
 
@@ -1782,7 +1782,7 @@ textarea.bio-properties-panel-input.auto-resize {
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup:hover,
 .bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup:hover,
 .bio-properties-panel-textarea-container .bio-properties-panel-open-feel-popup:hover {
-  color: var(--feel-open-popup-hover-color);
+  fill: var(--feel-open-popup-hover-color);
 }
 
 .bio-properties-panel-feel-popup .bio-properties-panel-popup__footer .bio-properties-panel-feel-popup__close-btn {

--- a/src/components/entries/Tooltip.js
+++ b/src/components/entries/Tooltip.js
@@ -196,7 +196,7 @@ function Tooltip(props) {
 
     return (
       <div
-        class={ `bio-properties-panel-tooltip ${direction}` }
+        class={ `bio-properties-panel-tooltip bio-theme-parent ${direction}` }
         role="tooltip"
         id="bio-properties-panel-tooltip"
         aria-labelledby={ forId }

--- a/src/features/popup/components/Popup.js
+++ b/src/features/popup/components/Popup.js
@@ -130,7 +130,7 @@ function PopupComponent(props, globalRef) {
       ref={ popupRef }
       onKeyDown={ handleKeydown }
       role="dialog"
-      class={ classNames('bio-properties-panel-popup', className) }
+      class={ classNames('bio-properties-panel-popup', 'bio-theme-parent', className) }
       style={ style }
     >
       {props.children}

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -61,6 +61,7 @@ describe('styling (CSS)', function() {
   beforeEach(function() {
     container = document.createElement('div');
     container.classList.add('bio-properties-panel');
+    container.classList.add('bio-theme-parent');
     container.style.width = '100%';
     container.style.padding = '10px';
 

--- a/test/spec/styling.spec.js
+++ b/test/spec/styling.spec.js
@@ -92,6 +92,48 @@ describe('styling (CSS)', function() {
               <span class="bio-properties-panel-label">Checkbox</span>
             </label>
           </div>
+          <div class="bio-properties-panel-entry">
+            <div class="bio-properties-panel-feel-entry">
+              <label class="bio-properties-panel-label">
+                FEEL (optional)
+                <button type="button" class="bio-properties-panel-feel-icon optional" title="Click to set a dynamic value with FEEL expression">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M3.6168 11.9894C3.47957 12.6745 3.22473 13.1809 2.85227 13.5085C2.48961 13.8362 1.97012 14 1.29381 14H0L0.308751 12.4213H1.57316L3.08751 4.78085H2.17596L2.48471 3.20213H3.39626L3.6315 2.01064C3.76872 1.32553 4.01866 0.819149 4.38132 0.491489C4.75378 0.16383 5.27817 0 5.95448 0H7.2483L6.93954 1.57872H5.67514L5.35168 3.20213H6.61609L6.30734 4.78085H5.04293L3.6168 11.9894Z" fill="currentcolor" />
+                    <path d="M5.60492 11.0213L8.63361 6.86596L7.28099 3.20213H9.35403L10.0598 5.74894H10.2362L11.927 3.20213H14L10.986 7.25319L12.3239 11.0213H10.2509L9.54517 8.41489H9.36874L7.67796 11.0213H5.60492Z" fill="currentcolor" />
+                  </svg>
+                </button>
+              </label>
+              <div class="bio-properties-panel-feel-container">
+                <div class="bio-properties-panel-feel-input">
+                  <input class="bio-properties-panel-input" type="text" value="Optional text value" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="bio-properties-panel-entry">
+            <div class="bio-properties-panel-feel-entry feel-active">
+              <label class="bio-properties-panel-label">
+                FEEL (required)
+                <button type="button" class="bio-properties-panel-feel-icon required active" disabled title="FEEL expression is mandatory">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M3.6168 11.9894C3.47957 12.6745 3.22473 13.1809 2.85227 13.5085C2.48961 13.8362 1.97012 14 1.29381 14H0L0.308751 12.4213H1.57316L3.08751 4.78085H2.17596L2.48471 3.20213H3.39626L3.6315 2.01064C3.76872 1.32553 4.01866 0.819149 4.38132 0.491489C4.75378 0.16383 5.27817 0 5.95448 0H7.2483L6.93954 1.57872H5.67514L5.35168 3.20213H6.61609L6.30734 4.78085H5.04293L3.6168 11.9894Z" fill="currentcolor" />
+                    <path d="M5.60492 11.0213L8.63361 6.86596L7.28099 3.20213H9.35403L10.0598 5.74894H10.2362L11.927 3.20213H14L10.986 7.25319L12.3239 11.0213H10.2509L9.54517 8.41489H9.36874L7.67796 11.0213H5.60492Z" fill="currentcolor" />
+                  </svg>
+                </button>
+              </label>
+              <div class="bio-properties-panel-feel-container">
+                <span class="bio-properties-panel-feel-indicator">=</span>
+                <div class="bio-properties-panel-feel-editor-container">
+                  <div class="bio-properties-panel-input edited">= now()</div>
+                  <button type="button" class="bio-properties-panel-open-feel-popup" title="Open pop-up editor">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                      <path d="M6 15L6 14 2.7 14 7 9.7 6.3 9 2 13.3 2 10 1 10 1 15zM10 1L10 2 13.3 2 9 6.3 9.7 7 14 2.7 14 6 15 6 15 1z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section class="bio-properties-panel-styles-section">


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1364

### Proposed Changes

The properties panel declared its own copy of the bpmn.io palette and derived every component variable from it. A theme had no semantic name to override — it had to pin `--input-border-color` and forty others by hand, and again in every other bpmn.io library.

- The private palette is replaced by the 38 semantic tokens of [`@bpmn-io/theme`](https://github.com/bpmn-io/shadcn-theme/tree/main/packages/theme) the panel reads, copied verbatim into the top of `properties-panel.css` and declared on `.bio-theme-parent`. Nothing imports the theme at runtime — the copy *is* the shipped stylesheet.
- The panel root carries `bio-theme-parent`. The FEEL popup and the tooltip render outside the panel through portals, so they carry it too.
- `npm run lint:theme`, part of `npm run all`, fails if that copy drifts from the package.
- Two hard-coded literals become variables — `--sticky-list-entry-background-color` and `--tooltip-color` — keeping their exact value.
- The button that opens the FEEL popup is fixed to paint its icon with `fill`, so its colour variables take effect at all.

### Rendered output

Every `var()` chain was resolved in both revisions and the final colours compared. **122 of 129 component variables are identical**, and none are dropped.

**Five change, all in the FEEL editor popup.** None of those colours matched anything else in the panel: three pure greys and pure black, where every other neutral in the panel is in the `225, 10%` family, and `hsl(219, 99%, 53%)`, which is form-js's blue. Each now takes the value the panel already uses for that role.

| variable | was | now | why |
| --- | --- | --- | --- |
| `--popup-background-color` | `hsl(0, 0%, 96%)` | `hsl(225, 10%, 97%)` | a pure grey used nowhere else; now the grey behind the panel's inputs and code snippets |
| `--popup-font-color` | `black` | `hsl(225, 10%, 15%)` | pure black; now the panel's base text colour |
| `--popup-title-color` | `black` | `hsl(225, 10%, 15%)` | same |
| `--feel-popup-gutters-background-color` | `hsl(0, 0%, 90%)` | `hsl(225, 10%, 90%)` | a pure grey at the lightness already used behind the FEEL indicator, so the gutter now matches it |
| `--feel-popup-close-background-color` | `hsl(219, 99%, 53%)` | `hsl(205, 100%, 40%)` | form-js's blue; now the blue the panel already uses for links, checked checkboxes and the active FEEL indicator |

**One fix.** The button that opens the FEEL popup set `color` on itself, but its icon paints with `fill` — the property every other icon in the panel uses. The icon therefore rendered pure black, and its hover state had no effect at all. Both rules now set `fill`: the icon becomes `hsl(225, 10%, 35%)`, the grey shared with the panel's other icons, and hovering it turns `hsl(205, 100%, 40%)`, as it was meant to.

**One shadow.** The dropdown button menu was two *opaque* greys, `hsl(225, 10%, 85%)` over `hsl(225, 10%, 75%)`, which paint a grey box over whatever sits behind the menu. It is now `hsla(0, 0%, 0%, 10%)` over `hsla(0, 0%, 0%, 30%)` — the same two-layer depth, translucent, so it darkens the background instead of covering it.

### Steps to try out

```bash
npx @bpmn-io/sr bpmn-io/properties-panel#shared-base-theme
```

Siblings: https://github.com/bpmn-io/diagram-js/pull/1102, https://github.com/bpmn-io/bpmn-js/pull/2497

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)