### PR TITLE
chore(refactor): provide popup event bus via context

### DIFF
--- a/src/features/popup/PopupRenderer.js
+++ b/src/features/popup/PopupRenderer.js
@@ -2,6 +2,8 @@ import { render } from 'preact';
 import { query as domQuery } from 'min-dom';
 import { isString } from 'min-dash';
 
+import { EventContext } from '../../context';
+
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
 
@@ -30,16 +32,14 @@ export class PopupRenderer {
 
     container.appendChild(element);
 
-    // TODO(philippfromme): there is no useService in this context, so we need
-    // to pass the event bus as a prop or create a context provider, however,
-    // a custom renderer would have to use that context provider as well to have
-    // access to the event bus and other services
     this._emit('feelPopup.open');
 
     const Component = config.component;
 
     render(
-      <Component { ...config } eventBus={ this._eventBus } />,
+      <EventContext.Provider value={ { eventBus: this._eventBus } }>
+        <Component { ...config } eventBus={ this._eventBus } />
+      </EventContext.Provider>,
       element
     );
 

--- a/src/features/popup/components/FeelPopup.js
+++ b/src/features/popup/components/FeelPopup.js
@@ -20,7 +20,6 @@ import { Popup } from './Popup';
  * @property {boolean} [singleLine]
  * @property {HTMLElement} [sourceElement]
  * @property {HTMLElement|string} [tooltipContainer]
- * @property {Object} [eventBus]
  */
 
 export const FEEL_POPUP_WIDTH = 700;
@@ -44,7 +43,6 @@ export function FeelPopup(props) {
     singleLine,
     sourceElement,
     tooltipContainer,
-    eventBus,
     feelLanguageContext,
   } = props;
 
@@ -99,7 +97,6 @@ export function FeelPopup(props) {
     >
       <Popup.Title
         title={ title }
-        eventBus={ eventBus }
         showCloseButton={ true }
         closeButtonTooltip="Save and close"
         onClose={ onClose }

--- a/src/features/popup/components/Popup.js
+++ b/src/features/popup/components/Popup.js
@@ -1,6 +1,6 @@
 import { forwardRef } from 'preact/compat';
 
-import { useEffect, useRef } from 'preact/hooks';
+import { useContext, useEffect, useRef } from 'preact/hooks';
 
 import classNames from 'classnames';
 
@@ -9,6 +9,8 @@ import * as focusTrap from 'focus-trap';
 import { isDefined } from 'min-dash';
 
 import { DragIcon, CloseIcon } from '../../../components/icons';
+
+import { EventContext } from '../../../context';
 
 import { createDragger } from '../../../components/util/dragger';
 
@@ -149,11 +151,12 @@ export {
 };
 
 function Title(props) {
+  const { eventBus } = useContext(EventContext);
+
   const {
     children,
     className,
     draggable,
-    eventBus,
     title,
     showCloseButton = false,
     closeButtonTooltip = 'Close popup',

--- a/src/features/popup/components/TextPopup.js
+++ b/src/features/popup/components/TextPopup.js
@@ -11,7 +11,6 @@ import { Popup } from './Popup';
  * @property {string} title
  * @property {string} value
  * @property {HTMLElement} [sourceElement]
- * @property {Object} [eventBus]
  */
 
 export const TEXT_POPUP_WIDTH = 700;
@@ -32,8 +31,7 @@ export function TextPopup(props) {
     onClose,
     title,
     value,
-    sourceElement,
-    eventBus
+    sourceElement
   } = props;
 
   const editorRef = useRef();
@@ -66,7 +64,6 @@ export function TextPopup(props) {
     >
       <Popup.Title
         title={ title }
-        eventBus={ eventBus }
         showCloseButton={ true }
         closeButtonTooltip="Save and close"
         onClose={ onClose }

--- a/test/spec/features/popup/Popup.spec.js
+++ b/test/spec/features/popup/Popup.spec.js
@@ -383,7 +383,7 @@ describe('Popup', function() {
       function CustomPopup(props) {
         return (
           <Popup title={ props.title } onClose={ props.onClose }>
-            <PopupTitle title={ props.title } eventBus={ props.eventBus } showCloseButton onClose={ props.onClose } draggable />
+            <PopupTitle title={ props.title } showCloseButton onClose={ props.onClose } draggable />
             <PopupBody className="custom-popup-body">{ props.value }</PopupBody>
           </Popup>
         );
@@ -442,7 +442,7 @@ describe('Popup', function() {
       function CustomPopup(props) {
         return (
           <Popup title={ props.title } onClose={ props.onClose }>
-            <PopupTitle title={ props.title } eventBus={ props.eventBus } showCloseButton onClose={ props.onClose } />
+            <PopupTitle title={ props.title } showCloseButton onClose={ props.onClose } />
           </Popup>
         );
       }


### PR DESCRIPTION
### Proposed Changes

Provide the event bus to popup components through the existing `EventContext`.

This removes the need for popup providers to receive and forward `eventBus` as a prop. `PopupTitle` now consumes the event bus from context while preserving the existing `feelPopup.dragstart`, `feelPopup.dragover`, and `feelPopup.dragend` events.

The default popup renderer establishes the context. Custom popup renderers can establish the same context when rendering popup components.

Related to https://github.com/bpmn-io/internal-docs/issues/1342
Related to https://github.com/bpmn-io/properties-panel/pull/550

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
