### PR TITLE
fix: remove background from feel popup icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [`@bpmn-io/properties-panel`](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: remove background from FEEL popup icon ([#555](https://github.com/bpmn-io/properties-panel/pull/555))
+
 ## 3.54.0
 
 * `FEAT`: expose popup components ([#550](https://github.com/bpmn-io/properties-panel/pull/550))

--- a/src/assets/properties-panel.css
+++ b/src/assets/properties-panel.css
@@ -1751,23 +1751,10 @@ textarea.bio-properties-panel-input.auto-resize {
   padding: 2px 4px;
   margin: 0 3px;
   display: none;
-  background-color: var(--input-background-color);
+  background: none;
   border: none;
   color: var(--feel-open-popup-color);
   cursor: pointer;
-}
-
-/* fade the text out beneath the feel popup button */
-.bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup::before,
-.bio-properties-panel-feel-container .bio-properties-panel-open-feel-popup::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 100%;
-  width: 0.5em;
-  background: linear-gradient(to right, transparent, var(--input-background-color));
-  pointer-events: none;
 }
 
 .bio-properties-panel-feelers-editor-container .bio-properties-panel-open-feel-popup svg,


### PR DESCRIPTION
### Proposed Changes

Remove background from feel popup icon

<img width="377" height="175" alt="image" src="https://github.com/user-attachments/assets/bb8a51b9-8eab-4bd7-9157-d9ca83804d43" />

<img width="364" height="139" alt="image" src="https://github.com/user-attachments/assets/6053015e-3018-45e3-a125-0ad7e6710d34" />


### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
